### PR TITLE
fix mdp config at compilation

### DIFF
--- a/QEfficient/exporter/export_utils.py
+++ b/QEfficient/exporter/export_utils.py
@@ -403,11 +403,11 @@ def compile_kv_model_on_cloud_ai_100(
         command.append("-aic-enable-depth-first")
     if len(device_group) > 1:
         mdp_ts_config = {
-            "connections": [{"devices": device_group, "type": "p2p"}],
+            "connections": [{"devices": list(range(len(device_group))), "type": "p2p"}],
             "partitions": [
                 {
                     "name": "Partition0",
-                    "devices": [{"deviceId": device, "numCores": num_cores} for device in device_group],
+                    "devices": [{"deviceId": device, "numCores": num_cores} for device in range(len(device_group))],
                 }
             ],
         }


### PR DESCRIPTION
This PR fixes the issue with mdp config while compilation.
Tested: `python -m QEfficient.cloud.infer --model_name openai-community/gpt2 --batch_size 1 --prompt_len 32 --ctx_len 128 --mxfp6 --num_cores 16 --device_group [2,3] --prompt "My name is" --mos 1 --aic_enable_depth_first`