### PR TITLE
Add Optional CustomIO Config for MXINT8 Precision (Branch 1.16)

### DIFF
--- a/QEfficient/cloud/compile.py
+++ b/QEfficient/cloud/compile.py
@@ -115,7 +115,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--mxint8",
-        action="store_false",
+        action="store_true",
         help="Compress Present/Past KV to MXINT8 using CustomIO config, default is False",
     )
     parser.add_argument(

--- a/QEfficient/cloud/compile.py
+++ b/QEfficient/cloud/compile.py
@@ -72,7 +72,9 @@ def main(
     custom_io_file_path = os.path.join(os.path.dirname(onnx_path), custom_io_file_name)
 
     if not os.path.isfile(custom_io_file_path):
-        raise FileNotFoundError(f"file {custom_io_file_path} needs to exist in the same directory as onnx model files.")
+        raise FileNotFoundError(
+            f"file {custom_io_file_path} needs to exist in the same directory as onnx model files. Please rerun infer/export Api"
+        )
 
     _, qpc_path = compile_kv_model_on_cloud_ai_100(
         onnx_path=onnx_path,

--- a/QEfficient/cloud/compile.py
+++ b/QEfficient/cloud/compile.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--qpc-path",
         "--qpc_path",
-        required=True,
+        required=False,
         help="Compiled qpc binaries will be stored under this folder",
     )
     parser.add_argument("--batch_size", "--batch-size", type=int, default=1, help="Batch size for text generation")

--- a/QEfficient/cloud/compile.py
+++ b/QEfficient/cloud/compile.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--qpc-path",
         "--qpc_path",
-        required=False,
+        required=True,
         help="Compiled qpc binaries will be stored under this folder",
     )
     parser.add_argument("--batch_size", "--batch-size", type=int, default=1, help="Batch size for text generation")

--- a/QEfficient/cloud/compile.py
+++ b/QEfficient/cloud/compile.py
@@ -65,9 +65,9 @@ def main(
 
     # Select the customIO config based on the mx flag.
     if mxint8:
-        custom_io_file_name = "custom_io_fp16.yaml"
-    else:
         custom_io_file_name = "custom_io_int8.yaml"
+    else:
+        custom_io_file_name = "custom_io_fp16.yaml"
 
     custom_io_file_path = os.path.join(os.path.dirname(onnx_path), custom_io_file_name)
 

--- a/QEfficient/cloud/execute.py
+++ b/QEfficient/cloud/execute.py
@@ -36,7 +36,9 @@ def main(
         login(hf_token)
     # Download tokenizer along with model if it doesn't exist
     model_hf_path = hf_download(repo_id=model_name, cache_dir=cache_dir, allow_patterns=["*.json"])
-    tokenizer = AutoTokenizer.from_pretrained(model_hf_path, use_cache=True, padding_side="left")
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_hf_path, use_cache=True, padding_side="left", trust_remote_code=True
+    )
 
     cloud_ai_100_exec_kv(tokenizer=tokenizer, qpc=qpc_path, device_id=devices, prompt=prompt)
 

--- a/QEfficient/cloud/export.py
+++ b/QEfficient/cloud/export.py
@@ -11,9 +11,11 @@ import os
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import QEfficient
+from QEfficient.cloud.infer import onnx_exists
 from QEfficient.exporter.export_hf_to_cloud_ai_100 import qualcomm_efficient_converter
 from QEfficient.utils import hf_download
-from QEfficient.utils.constants import Constants
+from QEfficient.utils.constants import QEFF_MODELS_DIR, Constants
+from QEfficient.utils.logging_utils import logger
 
 # Specifically for Docker images.
 ROOT_DIR = os.path.dirname(os.path.abspath(""))
@@ -26,6 +28,16 @@ def main(model_name: str, cache_dir: str) -> None:
     :param model_name: str. Hugging Face Model Card name, Example: gpt2
     :cache_dir: str. Cache dir to store the downloaded huggingface files.
     """
+    model_card_dir = os.path.join(QEFF_MODELS_DIR, str(model_name))
+    os.makedirs(model_card_dir, exist_ok=True)
+
+    onnx_dir_path = os.path.join(model_card_dir, "onnx")
+    onnx_model_path = os.path.join(onnx_dir_path, model_name.replace("/", "_") + "_kv_clipped_fp16.onnx")
+
+    if onnx_exists(onnx_model_path):
+        logger.warning(f"Generated Onnx files found {onnx_model_path}! Please use Infer/Compile Apis()")
+        return
+
     model_hf_path = hf_download(repo_id=model_name, hf_token=None, cache_dir=cache_dir)
     tokenizer = AutoTokenizer.from_pretrained(
         model_hf_path, use_cache=True, padding_side="left", trust_remote_code=True

--- a/QEfficient/cloud/export.py
+++ b/QEfficient/cloud/export.py
@@ -12,12 +12,11 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import QEfficient
 from QEfficient.exporter.export_hf_to_cloud_ai_100 import qualcomm_efficient_converter
-from QEfficient.utils.constants import Constants, QEFF_MODELS_DIR
 from QEfficient.utils import hf_download
+from QEfficient.utils.constants import Constants
 
 # Specifically for Docker images.
 ROOT_DIR = os.path.dirname(os.path.abspath(""))
-
 
 
 def main(model_name: str, cache_dir: str) -> None:
@@ -28,7 +27,9 @@ def main(model_name: str, cache_dir: str) -> None:
     :cache_dir: str. Cache dir to store the downloaded huggingface files.
     """
     model_hf_path = hf_download(repo_id=model_name, hf_token=None, cache_dir=cache_dir)
-    tokenizer = AutoTokenizer.from_pretrained(model_hf_path, use_cache=True, padding_side="left")
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_hf_path, use_cache=True, padding_side="left", trust_remote_code=True
+    )
     model = AutoModelForCausalLM.from_pretrained(model_hf_path, use_cache=True)
 
     # Easy and minimal api to update the model to QEff.
@@ -52,7 +53,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Export script.")
     parser.add_argument("--model_name", "--model-name", required=True, help="HF Model card name/id")
     parser.add_argument(
-        "--cache_dir", "--cache-dir",
+        "--cache_dir",
+        "--cache-dir",
         required=False,
         default=Constants.CACHE_DIR,
         help="Cache_dir to store the HF files",

--- a/QEfficient/cloud/infer.py
+++ b/QEfficient/cloud/infer.py
@@ -84,7 +84,9 @@ def main(
         cache_dir=cache_dir,
         ignore_patterns=["*.txt", "*.onnx", "*.ot", "*.md", "*.tflite", "*.pdf"],
     )
-    tokenizer = AutoTokenizer.from_pretrained(model_hf_path, use_cache=True, padding_side="left")
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_hf_path, use_cache=True, padding_side="left", trust_remote_code=True
+    )
 
     if qpc_exists(qpc_dir_path):
         # execute

--- a/QEfficient/cloud/infer.py
+++ b/QEfficient/cloud/infer.py
@@ -41,7 +41,7 @@ def qpc_exists(qpc_dir_path: str) -> bool:
 def onnx_exists(onnx_file_path: str) -> bool:
     # todo(ochougul): add check for other files like raw input files, input_list.txt
     return os.path.isfile(onnx_file_path) and os.path.isfile(
-        os.path.join(os.path.dirname(onnx_file_path), "custom_io.yaml")
+        os.path.join(os.path.dirname(onnx_file_path), "custom_io_fp16.yaml")
     )
 
 
@@ -57,6 +57,7 @@ def main(
     prompt_len: int = 32,
     ctx_len: int = 128,
     mxfp6: bool = False,
+    mxint8: bool = False,
     device_group: List[int] = [
         0,
     ],
@@ -82,7 +83,7 @@ def main(
     model_hf_path = hf_download(
         repo_id=model_name,
         cache_dir=cache_dir,
-        ignore_patterns=["*.txt", "*.onnx", "*.ot", "*.md", "*.tflite", "*.pdf"],
+        ignore_patterns=["*.txt", "*.onnx", "*.ot", "*.md", "*.tflite", "*.pdf", "*.msgpack", "*.h5"],
     )
     tokenizer = AutoTokenizer.from_pretrained(
         model_hf_path, use_cache=True, padding_side="left", trust_remote_code=True
@@ -149,6 +150,7 @@ def main(
         prompt_len=prompt_len,
         ctx_len=ctx_len,
         mxfp6=mxfp6,
+        mxint8=mxint8,
         aic_enable_depth_first=aic_enable_depth_first,
         mos=mos,
         device_group=device_group,
@@ -180,6 +182,11 @@ if __name__ == "__main__":
     parser.add_argument("--ctx-len", "--ctx_len", default=128, type=int, help="Context length for text generation.")
     parser.add_argument(
         "--mxfp6", action="store_true", help="Compress constant MatMul weights to MXFP6 E2M3, default is no compression"
+    )
+    parser.add_argument(
+        "--mxint8",
+        action="store_false",
+        help="Compress Present/Past KV to MXINT8 using CustomIO config, default is False",
     )
     parser.add_argument(
         "--num_cores", "--num-cores", type=int, required=True, help="Number of cores to compile on Cloud AI 100"

--- a/QEfficient/cloud/infer.py
+++ b/QEfficient/cloud/infer.py
@@ -70,7 +70,7 @@ def main(
         f"qpc_{num_cores}cores_{batch_size}BS_{prompt_len}PL_{ctx_len}CL_"
         + f"{len(device_group)}"
         + "devices"
-        + ("_mxfp6" if mxfp6 else "_fp16")
+        + ("_mxfp6_mxint8" if mxfp6 and mxint8 else "_mxfp6" if mxfp6 else "_fp16")
     )
     qpc_dir_path = os.path.join(model_card_dir, qpc_base_dir_name, "qpcs")
 
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--mxint8",
-        action="store_false",
+        action="store_true",
         help="Compress Present/Past KV to MXINT8 using CustomIO config, default is False",
     )
     parser.add_argument(

--- a/QEfficient/exporter/export_hf_to_cloud_ai_100.py
+++ b/QEfficient/exporter/export_hf_to_cloud_ai_100.py
@@ -372,8 +372,8 @@ def convert_to_cloud_kvstyle(
             save_fp32_onnx=save_fp32_onnx,
         )
 
-    # Generate custom-IO files
-    with open(os.path.join(onnx_dir_path, "custom_io.yaml"), "w") as fp:
+    # Generate custom-IO files for fp16 and int8 kv
+    with open(os.path.join(onnx_dir_path, "custom_io_fp16.yaml"), "w") as fp:
         fp.write("# Model Inputs\n\n")
         for input_name in key_value_names:
             fp.write(f" - IOName: {input_name}\n   Precision: float16\n\n")
@@ -381,6 +381,14 @@ def convert_to_cloud_kvstyle(
         fp.write("# Model Outputs\n\n")
         for output_name in key_value_names:
             fp.write(f" - IOName: {output_name}_RetainedState\n   Precision: float16\n\n")
+
+    with open(os.path.join(onnx_dir_path, "custom_io_int8.yaml"), "w") as fp:
+        fp.write("# Model Inputs\n\n")
+        for input_name in key_value_names:
+            fp.write(f" - IOName: {input_name}\n   Precision: mxint8\n\n")
+        fp.write("# Model Outputs\n\n")
+        for output_name in key_value_names:
+            fp.write(f" - IOName: {output_name}_RetainedState\n   Precision: mxint8\n\n")
 
     # Generate inputFiles
     input_list_file = os.path.join(onnx_dir_path, "input_list.txt")

--- a/QEfficient/exporter/export_hf_to_cloud_ai_100.py
+++ b/QEfficient/exporter/export_hf_to_cloud_ai_100.py
@@ -69,10 +69,10 @@ def convert_to_cloud_bertstyle(
 
     # Load tokenizer
     if tokenizer is None:
-        tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left")
+        tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left", trust_remote_code=True)
     else:
         if tokenizer.padding_side != "left":
-            logger.warning(f"Please use padding_side='left' while initializing the tokenizer")
+            logger.warning("Please use padding_side='left' while initializing the tokenizer")
             tokenizer.padding_side = "left"
 
     if tokenizer.pad_token_id is None:
@@ -263,7 +263,7 @@ def convert_to_cloud_kvstyle(
         tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left")
     else:
         if tokenizer.padding_side != "left":
-            logger.warning(f"Please use padding_side='left' while initializing the tokenizer")
+            logger.warning("Please use padding_side='left' while initializing the tokenizer")
             tokenizer.padding_side = "left"
 
     if tokenizer.pad_token_id is None:

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ from QEfficient.exporter.export_hf_to_cloud_ai_100 import qualcomm_efficient_con
 # Bertstyle models do not have any optimization w.r.t KV cache changes and are unoptimized version.
 # It is recommended to use kv=True for better performance.
 
+# For custom models defined on the Hub in their own modeling files. We need `trust_remote_code` option
+# Should be set to `True` in `AutoTokenizer` for repositories you trust.
 tokenizer = AutoTokenizer.from_pretrained(model_hf_path, use_cache=True, padding_side="left")
 base_path, onnx_path = qualcomm_efficient_converter(
     model_kv=model_transformed,

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ In summary:
 
 | High Level APIs | Sample use | Arguments         |
 |-----------------|------------|-------------------|
-| QEfficient.cloud.infer           |   [click here](#1-use-qefficientcloudinfer)         |  <li>model_name : $\color{green} {Mandatory}$</li> <li>num_cores : $\color{green} {Mandatory}$</li> <li>device_group : $\color{green} {Mandatory}$</li><li>batch_size : Optional [Default-1]</li> <li>prompt_len : Optional [Default-32]</li> <li>ctx_len : Optional [Default-128]</li><li>mxfp6 : Optional </li> <li>hf_token : Optional </li><li>cache_dir : Optional ["cache_dir" in current working directory]</li><li>prompt : Optinoal [Default-"My name is"]</li> |
+| QEfficient.cloud.infer           |   [click here](#1-use-qefficientcloudinfer)         |  <li>model_name : $\color{green} {Mandatory}$</li> <li>num_cores : $\color{green} {Mandatory}$</li> <li>device_group : $\color{green} {Mandatory}$</li><li>batch_size : Optional [Default-1]</li> <li>prompt_len : Optional [Default-32]</li> <li>ctx_len : Optional [Default-128]</li><li>mxfp6 : Optional </li> <li>mxint8 : Optional </li><li>hf_token : Optional </li><li>cache_dir : Optional ["cache_dir" in current working directory]</li><li>prompt : Optinoal [Default-"My name is"]</li> |
 | QEfficient.cloud.execute  |     [click here](#2-use-of-qefficientcloudexcute)       |   <li>model_name : $\color{green} {Mandatory}$</li> <li>device_group : $\color{green} {Mandatory}$</li><li>qpc_path : $\color{green} {Mandatory}$</li><li>prompt : Optional [Default-"My name is"]</li> <li>cache_dir : Optional ["cache_dir" in current working directory]</li><li>hf_token : Optional </li>             |
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -173,7 +173,7 @@ def get_cloud_ai_100_tokens(setup_info):
             num_cores=14,
             base_path=tests_qpc_dir,
             mxfp6=False,
-            custom_io_path=os.path.join(setup_info["base_path"], "custom_io.yaml"),
+            custom_io_path=os.path.join(setup_info["base_path"], "custom_io_fp16.yaml"),
             aic_enable_depth_first=False,
             device_group=[0],
         )


### PR DESCRIPTION
- Enable compilation with mxint8 precision via `custom_io` config file.
- Fix the export api() to check if `onnx_exist()` already.
- Additional argument `--mxint8` in `infer` and `compile` api, when enabled, `custom-io_int8` yaml will be used for compilation with mxint8 precision for $KVs. Default to False.
- Sample command: `python -m QEfficient.cloud.infer --model-name gpt2  --batch-size 1 --prompt-len 32 --ctx-len 128 --mxfp6 --num-cores 14 --device-group "[0]" --prompt "Top 5 must do things in Bengaluru" --aic_enable_depth_first --mos 1 --mxint8`
- Add additional ignore patterns to `hf_download()`