### PR TITLE
Clean and Optimize Infer Api() code

### DIFF
--- a/QEfficient/cloud/infer.py
+++ b/QEfficient/cloud/infer.py
@@ -5,6 +5,13 @@
 #
 # -----------------------------------------------------------------------------
 
+"""
+1. Check if compiled qpc for given config already exists, if it does jump to execute, else
+2. Check if exported ONNX file already exists, if true, jump to compilation -> execution, else
+3. Check if HF model exists in cache, if true, start transform -> export -> compilation -> execution, else,
+4. Download HF model -> transform -> export -> compile -> execute
+"""
+
 import argparse
 import os
 from typing import List
@@ -21,14 +28,6 @@ from QEfficient.generation.text_generation_inference import (
 )
 from QEfficient.utils import hf_download, onnx_exists, qpc_exists
 from QEfficient.utils.constants import Constants
-from QEfficient.utils.logging_utils import logger
-
-"""
-1. Check if compiled qpc for given config already exists, if it does jump to execute, else
-2. Check if exported ONNX file already exists, if true, jump to compilation -> execution, else
-3. Check if HF model exists in cache, if true, start transform -> export -> compilation -> execution, else,
-4. Download HF model -> transform -> export -> compile -> execute
-"""
 
 
 def main(
@@ -45,102 +44,166 @@ def main(
     ctx_len: int = 128,
     mxfp6: bool = False,
     mxint8: bool = False,
-    device_group: List[int] = [
-        0,
-    ],
+    device_group: List[int] = [0],
 ) -> None:
-    qpc_base_dir_name = (
-        f"qpc_{num_cores}cores_{batch_size}BS_{prompt_len}PL_{ctx_len}CL_{mos}MOS_"
-        + f"{len(device_group)}"
-        + "devices"
-        + ("_mxfp6_mxint8" if (mxfp6 and mxint8) else "_mxfp6" if mxfp6 else "_fp16_mxint8" if mxint8 else "_fp16")
+    """
+    Main function to download, optimize, compile, and execute a model on Cloud AI 100.
+
+    Parameters:
+    - model_name: The name or ID of the Hugging Face model.
+    - num_cores: Number of cores to compile on Cloud AI 100.
+    - prompt: Input prompt for text generation.
+    - prompts_txt_file_path: File path for input prompts from a text file.
+    - aic_enable_depth_first: Enable depth-first search during compilation.
+    - mos: Effort level to reduce on-chip memory.
+    - cache_dir: Directory to store Hugging Face downloads.
+    - hf_token: Hugging Face token for accessing private models.
+    - batch_size: Batch size for text generation.
+    - prompt_len: Sequence length for text generation.
+    - ctx_len: Context length for text generation.
+    - mxfp6: Compress constant MatMul weights to MXFP6 E2M3.
+    - mxint8: Compress Present/Past KV to MXINT8 using CustomIO config.
+    - device_group: Cloud AI 100 device IDs (comma-separated).
+    """
+
+    qpc_base_dir_name = create_qpc_base_dir_name(
+        num_cores, batch_size, prompt_len, ctx_len, mos, len(device_group), mxfp6, mxint8
     )
 
-    prompt = check_batch_size_and_num_prompts(prompt, prompts_txt_file_path, batch_size)
+    prompt = process_prompt(prompt, prompts_txt_file_path, batch_size)
 
-    # Get tokenizer
-    if hf_token is not None:
+    # Login to Hugging Face Hub if hf_token is provided
+    if hf_token:
         login(hf_token)
-    model_hf_path = hf_download(
-        repo_id=model_name,
-        cache_dir=cache_dir,
-        ignore_patterns=["*.txt", "*.onnx", "*.ot", "*.md", "*.tflite", "*.pdf", "*.msgpack", "*.h5"],
-    )
-    tokenizer = AutoTokenizer.from_pretrained(
-        model_hf_path, use_cache=True, padding_side="left", trust_remote_code=True
-    )
 
+    # Check if pre-compiled QPC/Onnx exists and execute if so
     qpc_path_exists, qpc_dir_path = qpc_exists(model_name, qpc_base_dir_name)
-    if qpc_path_exists:
-        # execute
-        logger.info("Pre-compiled qpc found! Trying to execute with given prompt")
-        cloud_ai_100_exec_kv(
-            batch_size,
-            tokenizer=tokenizer,
-            qpc_path=qpc_dir_path,
-            device_id=device_group,
-            prompt=prompt,
-        )
-        return
-
     onnx_path_exists, onnx_dir_path, onnx_model_path = onnx_exists(model_name)
-    if onnx_path_exists:
-        # Compile -> execute
-        # We need to pass parent directory of qpc_dir_path, as the compile function handles the qpcs directory creation
-        generated_qpc_path = compile(
-            onnx_path=onnx_model_path,
-            qpc_path=os.path.dirname(qpc_dir_path),
-            num_cores=num_cores,
-            batch_size=batch_size,
-            prompt_len=prompt_len,
-            ctx_len=ctx_len,
-            mxfp6=mxfp6,
-            mxint8=mxint8,
-            aic_enable_depth_first=aic_enable_depth_first,
-            mos=mos,
-            device_group=device_group,
+
+    if qpc_path_exists:
+        # Load the tokenizer
+        tokenizer = load_tokenizer(model_name)
+    else:
+        # Download the model from Hugging Face Hub
+        model_hf_path = hf_download(
+            model_name,
+            cache_dir,
+            ignore_patterns=["*.txt", "*.onnx", "*.ot", "*.md", "*.tflite", "*.pdf", "*.msgpack", "*.h5"],
         )
-        assert (
-            generated_qpc_path == qpc_dir_path
-        ), f"QPC files were generated at an unusual location, expected {qpc_dir_path}; got {generated_qpc_path}"
-        cloud_ai_100_exec_kv(
+        tokenizer = load_tokenizer(model_hf_path)
+
+    if qpc_path_exists:
+        execute_with_qpc(tokenizer, batch_size, qpc_dir_path, device_group, prompt)
+        return
+
+    # Check if ONNX file exists and compile and execute if so
+    if onnx_path_exists:
+        compile_and_execute_onnx(
+            onnx_model_path,
+            tokenizer,
             batch_size,
-            tokenizer=tokenizer,
-            qpc_path=qpc_dir_path,
-            device_id=device_group,
-            prompt=prompt,
+            qpc_dir_path,
+            num_cores,
+            prompt_len,
+            ctx_len,
+            mxfp6,
+            mxint8,
+            aic_enable_depth_first,
+            mos,
+            device_group,
+            prompt,
         )
         return
 
-    #############################################
-    # hf model -> export -> compile -> execute
-    #############################################
+    # If none of the above conditions met, proceed with downloading, transforming, exporting, compiling, and executing
     model_hf = AutoModelForCausalLM.from_pretrained(model_hf_path, use_cache=True)
-    # Easy and minimal api to update the model to QEff.
     model_transformed = QEfficient.transform(model_hf, type="Transformers", form_factor="cloud")
-    logger.info(f"Model after Optimized transformations {model_transformed}")
-
-    # Export to the Onnx
-    logger.info(f"Exporting to Pytorch {model_name} to ONNX...")
-    base_path, generated_onnx_path = qualcomm_efficient_converter(
-        model_kv=model_transformed,
-        onnx_dir_path=onnx_dir_path,
-        model_name=model_name,
-        kv=True,
-        form_factor="cloud",
-        return_path=True,
-        tokenizer=tokenizer,
+    onnx_model_path = export_to_onnx(model_transformed, model_name, tokenizer, onnx_dir_path, onnx_model_path)
+    compile_and_execute_onnx(
+        onnx_model_path,
+        tokenizer,
+        batch_size,
+        qpc_dir_path,
+        num_cores,
+        prompt_len,
+        ctx_len,
+        mxfp6,
+        mxint8,
+        aic_enable_depth_first,
+        mos,
+        device_group,
+        prompt,
     )
-    print(
-        f"Generated Onnx_path {generated_onnx_path} and Onnx_model_path {onnx_model_path} and Onnx_dir_path is {onnx_dir_path}"
-    )
-    assert (
-        generated_onnx_path == onnx_model_path
-    ), f"ONNX files were generated at an unusual location, expected {onnx_model_path}, got {generated_onnx_path}"
-    logger.info(f"Base Path is {base_path} and Onnx Model Path is : {generated_onnx_path}")
 
-    # Compile
-    # We need to pass parent directory of qpc_dir_path, as the compile function handles the qpcs directory creation
+
+def create_qpc_base_dir_name(
+    num_cores: int,
+    batch_size: int,
+    prompt_len: int,
+    ctx_len: int,
+    mos: int,
+    device_count: int,
+    mxfp6: bool,
+    mxint8: bool,
+) -> str:
+    """
+    Create the base directory name for the QPC based on the parameters.
+
+    Returns:
+    - A string representing the base directory name.
+    """
+    return f"qpc_{num_cores}cores_{batch_size}BS_{prompt_len}PL_{ctx_len}CL_{mos}MOS_{device_count}devices{'_mxfp6_mxint8' if mxfp6 and mxint8 else '_mxfp6' if mxfp6 else '_fp16_mxint8' if mxint8 else '_fp16'}"
+
+
+def process_prompt(prompt: str, prompts_txt_file_path: str, batch_size: int) -> str:
+    """
+    Process the prompt for text generation.
+
+    Returns:
+    - The processed prompt.
+    """
+    return check_batch_size_and_num_prompts(prompt, prompts_txt_file_path, batch_size)
+
+
+def load_tokenizer(model_hf_path: str) -> AutoTokenizer:
+    """
+    Load the tokenizer from the downloaded model.
+
+    Returns:
+    - An instance of the tokenizer.
+    """
+    return AutoTokenizer.from_pretrained(model_hf_path, use_cache=True, padding_side="left", trust_remote_code=True)
+
+
+def execute_with_qpc(
+    tokenizer: AutoTokenizer, batch_size: int, qpc_dir_path: str, device_group: List[int], prompt: str
+) -> None:
+    """
+    Execute the model with the pre-compiled QPC.
+    """
+    cloud_ai_100_exec_kv(
+        batch_size=batch_size, tokenizer=tokenizer, qpc_path=qpc_dir_path, device_id=device_group, prompt=prompt
+    )
+
+
+def compile_and_execute_onnx(
+    onnx_model_path: str,
+    tokenizer: AutoTokenizer,
+    batch_size: int,
+    qpc_dir_path: str,
+    num_cores: int,
+    prompt_len: int,
+    ctx_len: int,
+    mxfp6: bool,
+    mxint8: bool,
+    aic_enable_depth_first: bool,
+    mos: int,
+    device_group: List[int],
+    prompt,
+) -> None:
+    """
+    Compile and execute the model using the ONNX file.
+    """
     generated_qpc_path = compile(
         onnx_path=onnx_model_path,
         qpc_path=os.path.dirname(qpc_dir_path),
@@ -155,24 +218,43 @@ def main(
         device_group=device_group,
     )
     assert (
-        qpc_dir_path == generated_qpc_path
+        generated_qpc_path == qpc_dir_path
     ), f"QPC files were generated at an unusual location, expected {qpc_dir_path}; got {generated_qpc_path}"
-    logger.info(f"Compiled qpc files can be found at : {generated_qpc_path}")
+    execute_with_qpc(tokenizer, batch_size, qpc_dir_path, device_group, prompt)
 
-    # Execute
-    cloud_ai_100_exec_kv(
-        batch_size,
+
+def export_to_onnx(
+    transformed_model: AutoModelForCausalLM,
+    model_name: str,
+    tokenizer: AutoTokenizer,
+    onnx_dir_path: str,
+    onnx_model_path: str,
+) -> str:
+    """
+    Export the transformed model to ONNX format.
+
+    Returns:
+    - The path to the generated ONNX file.
+    """
+    base_path, generated_onnx_path = qualcomm_efficient_converter(
+        model_kv=transformed_model,
+        onnx_dir_path=onnx_dir_path,
+        model_name=model_name,
+        kv=True,
+        form_factor="cloud",
+        return_path=True,
         tokenizer=tokenizer,
-        qpc_path=qpc_dir_path,
-        device_id=device_group,
-        prompt=prompt,
     )
+    assert (
+        generated_onnx_path == onnx_model_path
+    ), f"ONNX files were generated at an unusual location, expected {onnx_model_path}, got {generated_onnx_path}"
+    return generated_onnx_path
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Inference command, the model will be downloaded from HF, optmized, compiled, executed on Cloud AI 100"
-    )
+def add_arguments(parser):
+    """
+    Add arguments to the argument parser.
+    """
     parser.add_argument("--model-name", "--model_name", required=True, help="HF Model card name/id")
     parser.add_argument(
         "--cache-dir",
@@ -198,19 +280,19 @@ if __name__ == "__main__":
         help="Compress Present/Past KV to MXINT8 using CustomIO config, default is False",
     )
     parser.add_argument(
-        "--num_cores", "--num-cores", type=int, required=True, help="Number of cores to compile on Cloud AI 100"
+        "--num-cores", "--num_cores", type=int, required=True, help="Number of cores to compile on Cloud AI 100"
     )
     parser.add_argument(
-        "--device_group",
         "--device-group",
-        required=True,
+        "--device_group",
+        required=False,
         type=lambda device_ids: [int(x) for x in device_ids.strip("[]").split(",")],
-        help="Cloud AI 100 device ids (comma-separated) e.g. [0,1]  ",
+        help="Cloud AI 100 device ids (comma-separated) e.g. [0,1]",
     )
     parser.add_argument(
         "--prompt",
         type=lambda prompt: prompt.split("|"),
-        help="Input prompt, if executing for batch size>1, pass input prompts in single string but seperate with pipe (|) symbol",
+        help="Input prompt, if executing for batch size>1, pass input prompts in single string but separate with pipe (|) symbol",
     )
     parser.add_argument(
         "--prompts_txt_file_path",
@@ -224,12 +306,13 @@ if __name__ == "__main__":
         action="store_true",
         help="If passed, this option will be enabled during compilation, disabled by default",
     )
-    parser.add_argument(
-        "--mos",
-        type=int,
-        default=-1,
-        help="Effort level to reduce the on-chip memory",
-    )
+    parser.add_argument("--mos", type=int, default=-1, help="Effort level to reduce the on-chip memory")
 
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Inference command, the model will be downloaded from HF, optimized, compiled, executed on Cloud AI 100"
+    )
+    add_arguments(parser)
     args = parser.parse_args()
     main(**args.__dict__)


### PR DESCRIPTION
- Add individual methods to keep the code base neat
- Also easy for `Api(`) documentation creation.
- Add comments and missing docstring.
- If user intends to just `execute` from `infer`, without `cache-dir`, now he can do it, he will just need tokenizer to be downloaded and doesn't require entire `cache-dir` to be present and can be deleted once downloaded and exporting work is done.
- `[TODO]: Customers should be able to use single infer api to do --export-only, --compile-only`