### PR TITLE
Update text generation interface to remove slash from qpc path

### DIFF
--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -98,7 +98,10 @@ def latency_stats_bertstyle(
 
 
 def get_compilation_batch_size(qpc_path: str):
-    qpc_base_path = os.path.dirname(qpc_path.rstrip("/"))
+    if qpc_path.endswith("/"):
+        logger.warning("Removing the slash('/')from given qpc path and looking for specializations.json in parent folder")
+        qpc_path = qpc_path.rstrip("/")
+    qpc_base_path = os.path.dirname(qpc_path)
     specialization_file_path = os.path.join(qpc_base_path, "specializations.json")
     with open(specialization_file_path, "r") as file:
         data = json.load(file)

--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -98,11 +98,9 @@ def latency_stats_bertstyle(
 
 
 def get_compilation_batch_size(qpc_path: str):
-    if qpc_path.endswith("/"):
-        logger.warning("Removing the slash('/')from given qpc path and looking for specializations.json in parent folder")
-        qpc_path = qpc_path.rstrip("/")
-    qpc_base_path = os.path.dirname(qpc_path)
+    qpc_base_path = os.path.dirname(os.path.normpath(qpc_path))
     specialization_file_path = os.path.join(qpc_base_path, "specializations.json")
+    logger.info(f"specialization_file_path : {specialization_file_path}")
     with open(specialization_file_path, "r") as file:
         data = json.load(file)
     compilation_batch_size = int(data["specializations"][0]["batch_size"])

--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -98,7 +98,7 @@ def latency_stats_bertstyle(
 
 
 def get_compilation_batch_size(qpc_path: str):
-    qpc_base_path = os.path.dirname(qpc_path)
+    qpc_base_path = os.path.dirname(qpc_path.rstrip("/"))
     specialization_file_path = os.path.join(qpc_base_path, "specializations.json")
     with open(specialization_file_path, "r") as file:
         data = json.load(file)


### PR DESCRIPTION
Update text generation interface to remove slash("/') from qpc path

'/' in the end after qpcs makes execute API look for specializations.json in wrong folder.
 
This works:

python -m QEfficient.cloud.execute --model_name gpt2 --qpc_path qeff_models/gpt2/qpc_16cores_1BS_32PL_128CL_1devices_mxfp6/qpcs --prompt "Once upon a time in" --device_group [0]  
 
This fails:

python -m QEfficient.cloud.execute --model_name gpt2 --qpc_path qeff_models/gpt2/qpc_16cores_1BS_32PL_128CL_1devices_mxfp6/qpcs/ --prompt "Once upon a time in" --device_group [0]  