### PR TITLE
Moving project metadata to pyproject.toml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,4 @@
 /QEfficient/customop @irajagop
 /QEfficient/generation @quic-mamta
 /QEfficient/utils @quic-mamta
-setup.py @carlstreeter-quic
+pyproject.toml @carlstreeter-quic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,16 +6,16 @@ Your help is essential for keeping this project great and for making it better.
 
 ## Branching Strategy
 
-In general, contributors should develop on branches based off of `master` and pull requests should be made against `master`.
+In general, contributors should develop on branches based off of `main` and pull requests should be made against `main`.
 
 ## Submitting a pull request
 
 1. Please read our [code of conduct](CODE-OF-CONDUCT.md) and [license](LICENSE).
 1. Fork and clone the repository.
-1. Create a new branch based on `master`: `git checkout -b <my-branch-name> master`.
+1. Create a new branch based on `main`: `git checkout -b <my-branch-name> main`.
 1. Make your changes, add tests, and make sure the tests still pass.
 1. Commit your changes using the [DCO](http://developercertificate.org/). You can attest to the DCO by commiting with the **-s** or **--signoff** options or manually adding the "Signed-off-by".
-1. Push to your fork and submit a pull request from your branch to `master`.
+1. Push to your fork and submit a pull request from your branch to `main`.
 1. Pat yourself on the back and wait for your pull request to be reviewed.
 
 Here are a few things you can do that will increase the likelihood of your pull request to be accepted:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-format:
-	isort --profile black -l 140 QEfficient/
-	black -l 140 QEfficient/

--- a/QEfficient/__init__.py
+++ b/QEfficient/__init__.py
@@ -13,3 +13,4 @@ from QEfficient.transformers.transform import transform  # noqa: F401
 
 # Users can use QEfficient.export for exporting models to ONNX
 export = qualcomm_efficient_converter
+__version__ = "0.0.1.dev0"

--- a/QEfficient/version.py
+++ b/QEfficient/version.py
@@ -1,8 +1,0 @@
-# -----------------------------------------------------------------------------
-#
-# Copyright (c)  2023-2024 Qualcomm Innovation Center, Inc. All rights reserved.
-# SPDX-License-Identifier: BSD-3-Clause
-#
-# -----------------------------------------------------------------------------
-
-__version__ = "0.0.1.dev0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,10 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering :: Artificial Intelligence for Inference Accelerator",
 ]
+requires-python = "==3.8.*"
 dependencies = [
     "transformers==4.41.2",
-    "torch@https://download.pytorch.org/whl/cpu/torch-2.0.0%2Bcpu-cp38-cp38-linux_x86_64.whl#sha256=354f281351cddb590990089eced60f866726415f7b287db5105514aa3c5f71ca",
+    "torch==2.0.1",
     "datasets==2.7.0",
     "fsspec==2023.6.0",
     "multidict==6.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ description = """
     QEfficient is the library interface for the Hugging Face Transformer \
     models for efficient inference on Qualcomm Cloud AI 100"""
 readme = "README.md"
-license = "BSD-3-Clause"
-authors = "Qualcomm Cloud AI ML Team"
+license = { file = "LICENSE" }
+authors = [{ name = "Qualcomm Cloud AI ML Team" }]
 keywords = ["transformers", "Cloud AI 100", "Inference"]
 classifiers = [
     "Programming Language :: Python :: 3", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,24 @@
 [project]
-name = "Efficient Transformers"
+name = "QEfficient"
 dynamic = ["version"]
 description = """
-	QEfficient is the library interface for the Hugging Face Transformer \
-	models for efficient inference on Qualcomm Cloud AI 100"""
+    QEfficient is the library interface for the Hugging Face Transformer \
+    models for efficient inference on Qualcomm Cloud AI 100"""
 readme = "README.md"
 license = "BSD-3-Clause"
 authors = "Qualcomm Cloud AI ML Team"
 keywords = ["transformers", "Cloud AI 100", "Inference"]
 classifiers = [
-	"Programming Language :: Python :: 3", 
-	"Development Status :: 5 - Development/Unstable",
-	"Intended Audience :: Developers",
-	"Intended Audience :: Education",
-	"Operating System :: Linux",
-	"Programming Language :: Python :: 3.8",
-	"Topic :: Scientific/Engineering :: Artificial Intelligence for Inference Accelerator",
+    "Programming Language :: Python :: 3", 
+    "Development Status :: 5 - Development/Unstable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
+    "Operating System :: Linux",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence for Inference Accelerator",
 ]
 dependencies = [
-	"transformers==4.41.2",
+    "transformers==4.41.2",
     "torch@https://download.pytorch.org/whl/cpu/torch-2.0.0%2Bcpu-cp38-cp38-linux_x86_64.whl#sha256=354f281351cddb590990089eced60f866726415f7b287db5105514aa3c5f71ca",
     "datasets==2.7.0",
     "fsspec==2023.6.0",
@@ -30,7 +30,7 @@ dependencies = [
     "numpy==1.23.0",
     "protobuf==3.20.2",
     "onnxscript==0.1.0.dev20240327",
-	"sympy",
+    "sympy",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = "==3.8.*"
 dependencies = [
     "transformers==4.41.2",
-    "torch==2.0.1",
+    "torch@https://download.pytorch.org/whl/cpu/torch-2.0.1%2Bcpu-cp38-cp38-linux_x86_64.whl#sha256=8046f49deae5a3d219b9f6059a1f478ae321f232e660249355a8bf6dcaa810c1",
     "datasets==2.7.0",
     "fsspec==2023.6.0",
     "multidict==6.0.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,53 @@
+[project]
+name = "Efficient Transformers"
+dynamic = ["version"]
+description = """
+	QEfficient is the library interface for the Hugging Face Transformer \
+	models for efficient inference on Qualcomm Cloud AI 100"""
+readme = "README.md"
+license = "BSD-3-Clause"
+authors = "Qualcomm Cloud AI ML Team"
+keywords = ["transformers", "Cloud AI 100", "Inference"]
+classifiers = [
+	"Programming Language :: Python :: 3", 
+	"Development Status :: 5 - Development/Unstable",
+	"Intended Audience :: Developers",
+	"Intended Audience :: Education",
+	"Operating System :: Linux",
+	"Programming Language :: Python :: 3.8",
+	"Topic :: Scientific/Engineering :: Artificial Intelligence for Inference Accelerator",
+]
+dependencies = [
+	"transformers==4.41.2",
+    "torch@https://download.pytorch.org/whl/cpu/torch-2.0.0%2Bcpu-cp38-cp38-linux_x86_64.whl#sha256=354f281351cddb590990089eced60f866726415f7b287db5105514aa3c5f71ca",
+    "datasets==2.7.0",
+    "fsspec==2023.6.0",
+    "multidict==6.0.4",
+    "urllib3<2",
+    "sentencepiece==0.1.98",
+    "onnx==1.16.0",
+    "onnxruntime==1.16.3",
+    "numpy==1.23.0",
+    "protobuf==3.20.2",
+    "onnxscript==0.1.0.dev20240327",
+	"sympy",
+]
+
+[project.optional-dependencies]
+test = ["pytest"]
+quality = ["black", "ruff", "hf_doc_builder@git+https://github.com/huggingface/doc-builder.git"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["QEfficient"]
+ 
 [tool.ruff]
 line-length = 120
 # Enable the isort rules.
 lint.extend-select = ["I"]
+
+[tool.pytest.ini_options]
+doctest_optionflags = "NUMBER NORMALIZE_WHITESPACE ELLIPSIS"

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -35,11 +35,9 @@ pipeline
             {
                 sh '''
                     . preflight_qeff/bin/activate
-                    python3 -m pip install multidict==6.0.4
                     pip install --upgrade pip setuptools
-                    pip install torch==2.0.0+cpu --extra-index-url https://download.pytorch.org/whl/cpu --no-deps
                     pip install /opt/qti-aic/dev/lib/x86_64/qaic-0.0.1-py3-none-any.whl
-                    pip install -e .
+                    pip install -e .[test]
                 '''
             }
         }
@@ -54,8 +52,6 @@ pipeline
                     sh '''
                     . preflight_qeff/bin/activate
                     export TOKENIZERS_PARALLELISM=false
-                    find . | grep -E "(/__pycache__$)" | xargs rm -rf
-                    export PYTHONPATH="."
                     pytest -W ignore -s -v tests
                     deactivate
                     exit

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[tool:pytest]
-doctest_optionflags=NUMBER NORMALIZE_WHITESPACE ELLIPSIS

--- a/setup.py
+++ b/setup.py
@@ -7,71 +7,11 @@
 
 import re
 
-from setuptools import find_namespace_packages, setup
+from setuptools import setup
 
-# Ensure we match the version set in QEfficient//version.py
-try:
-    filepath = "QEfficient/version.py"
-    with open(filepath) as version_file:
-        (__version__,) = re.findall('__version__ = "(.*)"', version_file.read())
-except Exception as error:
-    assert False, "Error: Could not open '%s' due %s\n" % (filepath, error)
+# Ensure we match the version set in QEfficient/__init__.py
+filepath = "QEfficient/__init__.py"
+with open(filepath) as version_file:
+    (version,) = re.findall('__version__ = "(.*)"', version_file.read())
 
-INSTALL_REQUIRES = [
-    "transformers==4.41.2",
-    "torch@https://download.pytorch.org/whl/cpu/torch-2.0.0%2Bcpu-cp38-cp38-linux_x86_64.whl#sha256=354f281351cddb590990089eced60f866726415f7b287db5105514aa3c5f71ca",
-    "datasets==2.7.0",
-    "fsspec==2023.6.0",
-    "multidict==6.0.4",
-    "urllib3<2",
-    "sentencepiece==0.1.98",
-    "onnx==1.16.0",
-    "onnxruntime==1.16.3",
-    "numpy==1.23.0",
-    "protobuf==3.20.2",
-    "onnxscript==0.1.0.dev20240327",
-    "pytest",
-    "sympy",
-]
-
-QUALITY_REQUIRES = [
-    "black",
-    "ruff",
-    "hf_doc_builder @ git+https://github.com/huggingface/doc-builder.git",
-]
-
-EXTRAS_REQUIRE = {
-    "quality": QUALITY_REQUIRES,
-}
-
-setup(
-    name="QEfficient Library",
-    version=__version__,
-    description=(
-        "QEfficient is the library interface for the Hugging Face Transformer"
-        "models for efficient inference on Qualcomm Cloud AI 100"
-    ),
-    long_description=open("README.md", "r", encoding="utf-8").read(),
-    long_description_content_type="text/markdown",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Development Status :: 5 - Development/Unstable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Operating System :: Linux",
-        "Programming Language :: Python :: 3.8",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence for Inference Accelerator",
-    ],
-    keywords="transformers, Cloud AI 100, Inference",
-    author="Qualcomm Cloud AI ML Team",
-    license="BSD-3-Clause",
-    packages=find_namespace_packages(include=["QEfficient*"]),
-    install_requires=INSTALL_REQUIRES,
-    extras_require=EXTRAS_REQUIRE,
-    include_package_data=True,
-    zip_safe=False,
-    dependency_links=[
-        "https://download.pytorch.org/whl/torch_stable.html",
-        "https://download.pytorch.org/whl/cpu",
-    ],
-)
+setup(version=version)


### PR DESCRIPTION
Modernizing by moving the setup.py metadata to pyproject.toml, according to [setuptools guide](https://packaging.python.org/en/latest/guides/modernize-setup-py-project/)

Minimal setup.py is still retained to read version dynamically and to run `python setup.py` based installs.

- Use `__init__.py` instead of `version.py`, so `QEfficient.__version__` can be read after `import QEfficient`, as per [PEP 8](https://peps.python.org/pep-0008/#module-level-dunder-names)
- Move config from setup.cfg to pyproject.toml
- Cleanup unused Makefile, which used isort and black. Already using ruff for formatting in pre-commit hooks.
- Fixed contributing guide to use `main` branch instead of `master`.