### PR TITLE
Adding support for torch==2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = "==3.8.*"
 dependencies = [
     "transformers==4.41.2",
-    "torch@https://download.pytorch.org/whl/cpu/torch-2.0.0%2Bcpu-cp38-cp38-linux_x86_64.whl#sha256=354f281351cddb590990089eced60f866726415f7b287db5105514aa3c5f71ca",
+    "torch==2.0.0",
     "datasets==2.7.0",
     "fsspec==2023.6.0",
     "multidict==6.0.4",


### PR DESCRIPTION
In this PR, I have just changed the torch version to `torch==2.0.0` in `pyproject.toml` file.

I have also tested the library after changing the torch version to 2.0.0 on two machines: x86_64 and aarch64.

## Test Report
NA
