### PR TITLE
Added support for creating model path hash when model card is not pro…

### DIFF
--- a/QEfficient/src/_transformers/auto.py
+++ b/QEfficient/src/_transformers/auto.py
@@ -19,7 +19,7 @@ from QEfficient.src._transformers.runtime_args import (
 )
 from QEfficient.src.base import QEFFBaseModel, Runtime
 from QEfficient.transformers.modeling_utils import TransformersToQEffModulesDict
-from QEfficient.utils import get_qpc_dir_name_infer, load_hf_tokenizer, qpc_exists
+from QEfficient.utils import generate_sha256_hash, get_qpc_dir_name_infer, load_hf_tokenizer, qpc_exists
 from QEfficient.utils.logging_utils import logger
 
 # Dictionary that defines the interface from transformers to be used underneath the QEFF interface
@@ -70,11 +70,7 @@ class QEFFTransformersBase(QEFFBaseModel):
     def get_model_card_name(self) -> str:
         # FIXME: use getter
         if self.model_card_name is None:
-            # Handle when pretrained_model_name_or_path is a path and we don't know the model_card_name
-            assert not os.path.isdir(
-                self.pretrained_model_name_or_path
-            ), f"Please provide `model_card_name` argument as valid string, got {self.model_card_name}"
-            self.model_card_name = self.pretrained_model_name_or_path
+            self.model_card_name = generate_sha256_hash(self.pretrained_model_name_or_path)
 
         return self.model_card_name
 
@@ -91,7 +87,7 @@ class QEFFTransformersBase(QEFFBaseModel):
         kwargs.update(
             {"use_cache": True}
         )  # Always pass use_cache = True, to get KV values as output during ONNX export
-        kwargs.update({"attn_implementation" : "eager"}) # Always use eager mode for attention implementation
+        kwargs.update({"attn_implementation": "eager"})  # Always use eager mode for attention implementation
         model_card_name = kwargs.pop("model_card_name", None)
         model = QEFFAutoModelToTransformersAutoModelMap[cls.__name__].from_pretrained(
             pretrained_model_name_or_path, *args, **kwargs

--- a/QEfficient/src/_transformers/auto.py
+++ b/QEfficient/src/_transformers/auto.py
@@ -70,7 +70,10 @@ class QEFFTransformersBase(QEFFBaseModel):
     def get_model_card_name(self) -> str:
         # FIXME: use getter
         if self.model_card_name is None:
-            self.model_card_name = generate_sha256_hash(self.pretrained_model_name_or_path)
+            if os.path.isdir(self.pretrained_model_name_or_path):
+                self.model_card_name = generate_sha256_hash(self.pretrained_model_name_or_path)
+            else:
+                self.model_card_name = self.pretrained_model_name_or_path
 
         return self.model_card_name
 

--- a/QEfficient/utils/__init__.py
+++ b/QEfficient/utils/__init__.py
@@ -7,6 +7,7 @@
 
 from QEfficient.utils._utils import (  # noqa: F401
     check_and_assign_cache_dir,
+    generate_sha256_hash,
     get_qpc_dir_name_infer,
     hf_download,
     load_hf_tokenizer,

--- a/QEfficient/utils/_utils.py
+++ b/QEfficient/utils/_utils.py
@@ -5,6 +5,7 @@
 #
 # -----------------------------------------------------------------------------
 
+import hashlib
 import os
 from typing import List, Optional, Tuple, Union
 
@@ -186,3 +187,17 @@ def padding_check_and_fix(tokenizer: Union[PreTrainedTokenizer, PreTrainedTokeni
             tokenizer.pad_token_id = tokenizer.eos_token_id
         else:
             tokenizer.pad_token_id = tokenizer.vocab_size - 1
+
+
+def generate_sha256_hash(data: str) -> str:
+    """
+    Generate a SHA-256 hash for the given data.
+
+    :param data: The input data to hash.
+    :return: The hexadecimal representation of the SHA-256 hash.
+    """
+    hash_object = hashlib.sha256()
+    hash_object.update(data.encode("utf-8"))
+    hash_hex = hash_object.hexdigest()
+
+    return hash_hex


### PR DESCRIPTION
Modified _transformers/auto.py to create a model card name as a hash of the local model path when the model path is given as input and the model card name is not specified.