### PR TITLE
saving measurements during compile and run time

### DIFF
--- a/QEfficient/cloud/infer.py
+++ b/QEfficient/cloud/infer.py
@@ -141,7 +141,7 @@ def main(
     #########
 
     if benchmark:
-        file_name = tabulate_measurements(
+        _ = tabulate_measurements(
             model_name=model_name,
             tokenizer=tokenizer,
             prompt=prompt,

--- a/QEfficient/utils/__init__.py
+++ b/QEfficient/utils/__init__.py
@@ -17,4 +17,5 @@ from QEfficient.utils._utils import (  # noqa: F401
     onnx_exists,
     padding_check_and_fix,
     qpc_exists,
+    tabulate_measurements,
 )

--- a/QEfficient/utils/_utils.py
+++ b/QEfficient/utils/_utils.py
@@ -318,16 +318,19 @@ def tabulate_measurements(
     }
 
     model_card_dir = os.path.join(QEFF_MODELS_DIR, str(model_name))
-    os.makedirs(model_card_dir, exist_ok=True)
     model_name = model_name.replace("/", "-")
     file_name = f"{model_card_dir}/{model_name}_benchmarking.csv"
 
-    if not os.path.exists(file_name):
-        with open(file_name, "w") as csvfile:
+    try:
+        os.makedirs(model_card_dir, exist_ok=True)
+        if not os.path.exists(file_name):
+            with open(file_name, "w") as csvfile:
+                csvwriter = csv.writer(csvfile)
+                csvwriter.writerow(list(fields.keys()))
+        with open(file_name, "a", newline="") as csvfile:
             csvwriter = csv.writer(csvfile)
-            csvwriter.writerow(list(fields.keys()))
-    with open(file_name, "a", newline="") as csvfile:
-        csvwriter = csv.writer(csvfile)
-        csvwriter.writerow(list(fields.values()))
+            csvwriter.writerow(list(fields.values()))
+    except OSError as e:
+        print(f"An error occurred while handling file {file_name}: {e}")
 
     return file_name

--- a/QEfficient/utils/logging_utils.py
+++ b/QEfficient/utils/logging_utils.py
@@ -5,7 +5,9 @@
 #
 # -----------------------------------------------------------------------------
 
+import csv
 import logging
+import os
 
 
 class QEffFormatter(logging.Formatter):
@@ -56,3 +58,13 @@ def create_logger() -> logging.Logger:
 
 # Define the logger object that can be used for logging purposes throughout the module.
 logger = create_logger()
+
+
+def tabulate_measurements(fields, file):
+    if not os.path.exists(file):
+        with open(file, "w") as csvfile:
+            csvwriter = csv.writer(csvfile)
+            csvwriter.writerow(list(fields.keys()))
+    with open(file, "a", newline="") as csvfile:
+        csvwriter = csv.writer(csvfile)
+        csvwriter.writerow(list(fields.values()))

--- a/QEfficient/utils/logging_utils.py
+++ b/QEfficient/utils/logging_utils.py
@@ -5,9 +5,7 @@
 #
 # -----------------------------------------------------------------------------
 
-import csv
 import logging
-import os
 
 
 class QEffFormatter(logging.Formatter):
@@ -58,13 +56,3 @@ def create_logger() -> logging.Logger:
 
 # Define the logger object that can be used for logging purposes throughout the module.
 logger = create_logger()
-
-
-def tabulate_measurements(fields, file):
-    if not os.path.exists(file):
-        with open(file, "w") as csvfile:
-            csvwriter = csv.writer(csvfile)
-            csvwriter.writerow(list(fields.keys()))
-    with open(file, "a", newline="") as csvfile:
-        csvwriter = csv.writer(csvfile)
-        csvwriter.writerow(list(fields.values()))


### PR DESCRIPTION
For the user to keep track of their measurements, code is added to log the necessary arguments and the measurements into a csv file. E.g. running the following command two times:

python -m QEfficient.cloud.infer --model_name gpt2 --batch_size 4 --prompt_len 64 --ctx_len 1024 --generation_len 512 --mxfp6 --num_cores 16 --device_group [0] --prompt "My name is|My name is|My name is|My name is" --benchmark

generates gpt2_benchmarking.csv
![image](https://github.com/user-attachments/assets/74033b2b-981f-4e7e-b6c8-4f65a4e249d2)



































































