### PR TITLE
track RAM & save measurements during compile and run

### DIFF
--- a/QEfficient/utils/logging_utils.py
+++ b/QEfficient/utils/logging_utils.py
@@ -5,7 +5,9 @@
 #
 # -----------------------------------------------------------------------------
 
+import csv
 import logging
+import os
 
 
 class QEffFormatter(logging.Formatter):
@@ -56,3 +58,13 @@ def create_logger() -> logging.Logger:
 
 # Define the logger object that can be used for logging purposes throughout the module.
 logger = create_logger()
+
+
+def tabulate_measurements(fields, file):
+    if not os.path.exists(file):
+        with open(file, "w") as csvfile:
+            csvwriter = csv.writer(csvfile)
+            csvwriter.writerow(list(fields.keys()))
+    with open(file, "a", newline="") as csvfile:
+        csvwriter = csv.writer(csvfile)
+        csvwriter.writerow(list(fields.values()))


### PR DESCRIPTION
For the user to keep track of their measurements, code is added to log the necessary arguments and the measurements in addition to memory (RAM) usage during compile/runtime into a csv file. E.g. running the following command two times:

python -m QEfficient.cloud.infer --model_name gpt2 --batch_size 4 --prompt_len 64 --ctx_len 1024 --generation_len 512 --mxfp6 --num_cores 16 --device_group [0] --prompt "My name is|My name is|My name is|My name is" --benchmark

gpt2_benchmarking.csv is generated in the working directory that stores
![image](https://github.com/user-attachments/assets/a94ab10f-57c5-49b4-8f57-c6e693d2ad3b)
