### PR TITLE
Adding Low Level API Testing Scripts

### DIFF
--- a/tests/compiler/test_compiler_helper.py
+++ b/tests/compiler/test_compiler_helper.py
@@ -9,18 +9,17 @@ import shutil
 
 import pytest
 
-import QEfficient
 from QEfficient.cloud.export import get_onnx_model_path
 from QEfficient.compile.compile_helper import compile
 from QEfficient.utils import check_and_assign_cache_dir, get_qpc_dir_path
 
 
-@pytest.mark.parametrize("model_name",["lu-vae/llama-68m-fft"])
-class TestQEffCompileFunctions():
+@pytest.mark.parametrize("model_name", ["lu-vae/llama-68m-fft"])
+class TestQEffCompileFunctions:
     @classmethod
     def setup_method(cls):
         cls.num_cores: int = 16
-        cls.device_group = [0] #  FIXME: use num_devices instead
+        cls.device_group = [0]  #  FIXME: use num_devices instead
         cls.aic_enable_depth_first: bool = False
         cls.mos: int = -1
         cls.batch_size: int = 1
@@ -38,12 +37,12 @@ class TestQEffCompileFunctions():
         for model_name in ["lu-vae/llama-68m-fft"]:
             cache_dir = check_and_assign_cache_dir(cls.local_model_dir, cls.cache_dir)
             onnx_model_path = get_onnx_model_path(
-                                model_name=model_name,
-                                cache_dir=cache_dir,
-                                hf_token=cls.hf_token,
-                                local_model_dir=cls.local_model_dir,
-                                full_batch_size=cls.full_batch_size,
-                            )
+                model_name=model_name,
+                cache_dir=cache_dir,
+                hf_token=cls.hf_token,
+                local_model_dir=cls.local_model_dir,
+                full_batch_size=cls.full_batch_size,
+            )
             cls.models[model_name] = [str(onnx_model_path)]
 
     def teardown_class(cls):
@@ -52,58 +51,97 @@ class TestQEffCompileFunctions():
                 if os.path.exists(os.path.dirname(dir)):
                     shutil.rmtree(os.path.dirname(dir))
 
-    def test_compile_for_mxint8(self,model_name):
+    def test_compile_for_mxint8(self, model_name):
         self.mxint8 = True
-        qpc_dir_path = get_qpc_dir_path(model_name,self.num_cores,self.mos,self.batch_size,self.prompt_len,self.ctx_len,self.mxfp6,self.mxint8,self.device_group,self.full_batch_size)
-        result = compile(onnx_path = self.models[model_name][0],
-                            qpc_path = os.path.dirname(qpc_dir_path),
-                            num_cores = self.num_cores,
-                            device_group = self.device_group,  #  FIXME: use num_devices instead
-                            aic_enable_depth_first = self.aic_enable_depth_first,
-                            mos = self.mos,
-                            batch_size = self.batch_size,
-                            prompt_len = self.prompt_len,
-                            ctx_len = self.ctx_len,
-                            mxfp6 = self.mxfp6,
-                            mxint8 = self.mxint8,
-                            custom_io_file_path = self.custom_io_file_path,
-                            full_batch_size = self.full_batch_size)
+        qpc_dir_path = get_qpc_dir_path(
+            model_name,
+            self.num_cores,
+            self.mos,
+            self.batch_size,
+            self.prompt_len,
+            self.ctx_len,
+            self.mxfp6,
+            self.mxint8,
+            self.device_group,
+            self.full_batch_size,
+        )
+        result = compile(
+            onnx_path=self.models[model_name][0],
+            qpc_path=os.path.dirname(qpc_dir_path),
+            num_cores=self.num_cores,
+            device_group=self.device_group,  #  FIXME: use num_devices instead
+            aic_enable_depth_first=self.aic_enable_depth_first,
+            mos=self.mos,
+            batch_size=self.batch_size,
+            prompt_len=self.prompt_len,
+            ctx_len=self.ctx_len,
+            mxfp6=self.mxfp6,
+            mxint8=self.mxint8,
+            custom_io_file_path=self.custom_io_file_path,
+            full_batch_size=self.full_batch_size,
+        )
         assert result == qpc_dir_path
         self.models[model_name].append(qpc_dir_path)
 
-    def test_compile_for_fp16(self,model_name):
+    def test_compile_for_fp16(self, model_name):
         self.mxint8 = False
-        qpc_dir_path = get_qpc_dir_path(model_name,self.num_cores,self.mos,self.batch_size,self.prompt_len,self.ctx_len,self.mxfp6,self.mxint8,self.device_group,self.full_batch_size)
-        result = compile(onnx_path = self.models[model_name][0],
-                            qpc_path = os.path.dirname(qpc_dir_path),
-                            num_cores = self.num_cores,
-                            device_group = self.device_group,  #  FIXME: use num_devices instead
-                            aic_enable_depth_first = self.aic_enable_depth_first,
-                            mos = self.mos,
-                            batch_size = self.batch_size,
-                            prompt_len = self.prompt_len,
-                            ctx_len = self.ctx_len,
-                            mxfp6 = self.mxfp6,
-                            mxint8 = self.mxint8,
-                            custom_io_file_path = self.custom_io_file_path,
-                            full_batch_size = self.full_batch_size)
+        qpc_dir_path = get_qpc_dir_path(
+            model_name,
+            self.num_cores,
+            self.mos,
+            self.batch_size,
+            self.prompt_len,
+            self.ctx_len,
+            self.mxfp6,
+            self.mxint8,
+            self.device_group,
+            self.full_batch_size,
+        )
+        result = compile(
+            onnx_path=self.models[model_name][0],
+            qpc_path=os.path.dirname(qpc_dir_path),
+            num_cores=self.num_cores,
+            device_group=self.device_group,  #  FIXME: use num_devices instead
+            aic_enable_depth_first=self.aic_enable_depth_first,
+            mos=self.mos,
+            batch_size=self.batch_size,
+            prompt_len=self.prompt_len,
+            ctx_len=self.ctx_len,
+            mxfp6=self.mxfp6,
+            mxint8=self.mxint8,
+            custom_io_file_path=self.custom_io_file_path,
+            full_batch_size=self.full_batch_size,
+        )
         assert result == qpc_dir_path
         self.models[model_name].append(qpc_dir_path)
 
-    def test_compile_for_IO_notFound(self,model_name):
-        qpc_dir_path = get_qpc_dir_path(model_name,self.num_cores,self.mos,self.batch_size,self.prompt_len,self.ctx_len,self.mxfp6,self.mxint8,self.device_group,self.full_batch_size)
+    def test_compile_for_IO_notFound(self, model_name):
+        qpc_dir_path = get_qpc_dir_path(
+            model_name,
+            self.num_cores,
+            self.mos,
+            self.batch_size,
+            self.prompt_len,
+            self.ctx_len,
+            self.mxfp6,
+            self.mxint8,
+            self.device_group,
+            self.full_batch_size,
+        )
         with pytest.raises(FileNotFoundError):
-            compile(onnx_path = "",
-                            qpc_path = os.path.dirname(qpc_dir_path),
-                            num_cores = self.num_cores,
-                            device_group = self.device_group,  #  FIXME: use num_devices instead
-                            aic_enable_depth_first = self.aic_enable_depth_first,
-                            mos = self.mos,
-                            batch_size = self.batch_size,
-                            prompt_len = self.prompt_len,
-                            ctx_len = self.ctx_len,
-                            mxfp6 = self.mxfp6,
-                            mxint8 = self.mxint8,
-                            custom_io_file_path = self.custom_io_file_path,
-                            full_batch_size = self.full_batch_size)
+            compile(
+                onnx_path="",
+                qpc_path=os.path.dirname(qpc_dir_path),
+                num_cores=self.num_cores,
+                device_group=self.device_group,  #  FIXME: use num_devices instead
+                aic_enable_depth_first=self.aic_enable_depth_first,
+                mos=self.mos,
+                batch_size=self.batch_size,
+                prompt_len=self.prompt_len,
+                ctx_len=self.ctx_len,
+                mxfp6=self.mxfp6,
+                mxint8=self.mxint8,
+                custom_io_file_path=self.custom_io_file_path,
+                full_batch_size=self.full_batch_size,
+            )
         self.models[model_name].append(qpc_dir_path)

--- a/tests/compiler/test_compiler_helper.py
+++ b/tests/compiler/test_compiler_helper.py
@@ -1,0 +1,109 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+import os
+import shutil
+
+import pytest
+
+import QEfficient
+from QEfficient.cloud.export import get_onnx_model_path
+from QEfficient.compile.compile_helper import compile
+from QEfficient.utils import check_and_assign_cache_dir, get_qpc_dir_path
+
+
+@pytest.mark.parametrize("model_name",["lu-vae/llama-68m-fft"])
+class TestQEffCompileFunctions():
+    @classmethod
+    def setup_method(cls):
+        cls.num_cores: int = 16
+        cls.device_group = [0] #  FIXME: use num_devices instead
+        cls.aic_enable_depth_first: bool = False
+        cls.mos: int = -1
+        cls.batch_size: int = 1
+        cls.prompt_len: int = 3
+        cls.ctx_len: int = 128
+        cls.mxfp6: bool = True
+        cls.mxint8: bool = False
+        cls.seq_len = 128
+        cls.hf_token = None
+        cls.local_model_dir = None
+        cls.cache_dir = None
+        cls.custom_io_file_path = None
+        cls.full_batch_size = None
+        cls.models = {}
+        for model_name in ["lu-vae/llama-68m-fft"]:
+            cache_dir = check_and_assign_cache_dir(cls.local_model_dir, cls.cache_dir)
+            onnx_model_path = get_onnx_model_path(
+                                model_name=model_name,
+                                cache_dir=cache_dir,
+                                hf_token=cls.hf_token,
+                                local_model_dir=cls.local_model_dir,
+                                full_batch_size=cls.full_batch_size,
+                            )
+            cls.models[model_name] = [str(onnx_model_path)]
+
+    def teardown_class(cls):
+        for model_dirs in cls.models.values():
+            for dir in model_dirs:
+                if os.path.exists(os.path.dirname(dir)):
+                    shutil.rmtree(os.path.dirname(dir))
+
+    def test_compile_for_mxint8(self,model_name):
+        self.mxint8 = True
+        qpc_dir_path = get_qpc_dir_path(model_name,self.num_cores,self.mos,self.batch_size,self.prompt_len,self.ctx_len,self.mxfp6,self.mxint8,self.device_group,self.full_batch_size)
+        result = compile(onnx_path = self.models[model_name][0],
+                            qpc_path = os.path.dirname(qpc_dir_path),
+                            num_cores = self.num_cores,
+                            device_group = self.device_group,  #  FIXME: use num_devices instead
+                            aic_enable_depth_first = self.aic_enable_depth_first,
+                            mos = self.mos,
+                            batch_size = self.batch_size,
+                            prompt_len = self.prompt_len,
+                            ctx_len = self.ctx_len,
+                            mxfp6 = self.mxfp6,
+                            mxint8 = self.mxint8,
+                            custom_io_file_path = self.custom_io_file_path,
+                            full_batch_size = self.full_batch_size)
+        assert result == qpc_dir_path
+        self.models[model_name].append(qpc_dir_path)
+
+    def test_compile_for_fp16(self,model_name):
+        self.mxint8 = False
+        qpc_dir_path = get_qpc_dir_path(model_name,self.num_cores,self.mos,self.batch_size,self.prompt_len,self.ctx_len,self.mxfp6,self.mxint8,self.device_group,self.full_batch_size)
+        result = compile(onnx_path = self.models[model_name][0],
+                            qpc_path = os.path.dirname(qpc_dir_path),
+                            num_cores = self.num_cores,
+                            device_group = self.device_group,  #  FIXME: use num_devices instead
+                            aic_enable_depth_first = self.aic_enable_depth_first,
+                            mos = self.mos,
+                            batch_size = self.batch_size,
+                            prompt_len = self.prompt_len,
+                            ctx_len = self.ctx_len,
+                            mxfp6 = self.mxfp6,
+                            mxint8 = self.mxint8,
+                            custom_io_file_path = self.custom_io_file_path,
+                            full_batch_size = self.full_batch_size)
+        assert result == qpc_dir_path
+        self.models[model_name].append(qpc_dir_path)
+
+    def test_compile_for_IO_notFound(self,model_name):
+        qpc_dir_path = get_qpc_dir_path(model_name,self.num_cores,self.mos,self.batch_size,self.prompt_len,self.ctx_len,self.mxfp6,self.mxint8,self.device_group,self.full_batch_size)
+        with pytest.raises(FileNotFoundError):
+            compile(onnx_path = "",
+                            qpc_path = os.path.dirname(qpc_dir_path),
+                            num_cores = self.num_cores,
+                            device_group = self.device_group,  #  FIXME: use num_devices instead
+                            aic_enable_depth_first = self.aic_enable_depth_first,
+                            mos = self.mos,
+                            batch_size = self.batch_size,
+                            prompt_len = self.prompt_len,
+                            ctx_len = self.ctx_len,
+                            mxfp6 = self.mxfp6,
+                            mxint8 = self.mxint8,
+                            custom_io_file_path = self.custom_io_file_path,
+                            full_batch_size = self.full_batch_size)
+        self.models[model_name].append(qpc_dir_path)

--- a/tests/exporter/test_export_hf_to_cloud_ai_100.py
+++ b/tests/exporter/test_export_hf_to_cloud_ai_100.py
@@ -1,0 +1,112 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+import os
+import shutil
+
+import pytest
+
+import QEfficient
+from QEfficient.base.common import QEFFCommonLoader
+from QEfficient.exporter.export_hf_to_cloud_ai_100 import (
+    convert_to_cloud_bertstyle,
+    convert_to_cloud_kvstyle,
+    qualcomm_efficient_converter,
+)
+from QEfficient.utils import load_hf_tokenizer, onnx_exists
+
+
+def create_onnx_dir(model_name):
+    _,onnx_dir_path,_ = onnx_exists(model_name=model_name,full_batch_size=None)
+    return onnx_dir_path
+
+@pytest.mark.parametrize("model_name",["lu-vae/llama-68m-fft"])
+class TestQEffExportFunctions():
+    @classmethod
+    def setup_class(cls):
+        cls.seq_len = 128
+        cls.hf_token = None
+        cls.cache_dir = None
+        cls.models = {}
+        for model_name in ["lu-vae/llama-68m-fft"]:
+            onnx_dir_path = create_onnx_dir(model_name)
+            tokenizer = load_hf_tokenizer(pretrained_model_name_or_path=model_name,hf_token=cls.hf_token,cache_dir=cls.cache_dir)
+            model_kv = QEFFCommonLoader.from_pretrained(pretrained_model_name_or_path=model_name,token=cls.hf_token,cache_dir=cls.cache_dir)
+            qeff_model = QEfficient.transform(model_kv)
+            cls.models[model_name] = [onnx_dir_path,tokenizer,model_kv,qeff_model]
+    
+    def teardown_class(cls):
+        for models in cls.models.values():
+            onnx_dir_path = models[0]
+            if os.path.exists(onnx_dir_path):
+                shutil.rmtree(onnx_dir_path)
+    
+    def test_convert_to_cloud_bertstyle(self,model_name):
+        _=model_name
+        assert True
+
+    def test_convert_to_cloud_kvstyle_success(self,model_name):
+        """
+        Test method for convert_to_cloud_kvstyle function in the case of general code flow that qeff_model is transformed
+        """
+        onnx_dir_path,tokenizer,_,qeff_model = self.models[model_name]
+        result = convert_to_cloud_kvstyle(
+            model_name=model_name,
+            qeff_model=qeff_model,
+            tokenizer=tokenizer,
+            onnx_dir_path=onnx_dir_path,
+            seq_len=self.seq_len
+        )
+        assert os.path.isfile(result)
+        assert os.path.exists(result)
+    
+    def test_convert_to_cloud_kvstyle_warning(self,model_name):
+        """
+        Test method for convert_to_cloud_kvstyle function in the case of Depcreation Warning in the function
+        """
+        onnx_dir_path,tokenizer,_,qeff_model = self.models[model_name]
+        with pytest.warns(DeprecationWarning):
+            convert_to_cloud_kvstyle(
+                model_name=model_name,
+                qeff_model=qeff_model,
+                tokenizer=tokenizer,
+                onnx_dir_path=onnx_dir_path,
+                seq_len=self.seq_len
+            )
+    
+    def test_qualcomm_efficient_converter_success(self,model_name):
+        """
+        Test method for qualcomm_efficient_converter function in the case of general code flow 
+        """
+        result = qualcomm_efficient_converter(
+            model_name=model_name,
+            model_kv=None,
+            tokenizer=None,
+            onnx_dir_path=None,
+            seq_length=self.seq_len,
+            kv=True,
+            form_factor="cloud"
+        )
+        assert os.path.exists(result[0])
+        assert os.path.exists(result[1])
+
+    def test_qualcomm_efficient_converter_transformed_model(self,model_name):
+        """
+        Test method for qualcomm_efficient_converter function in the case of qeff_model is already transformed 
+        """
+        onnx_dir_path,tokenizer,_,qeff_model = self.models[model_name]
+        result = qualcomm_efficient_converter(
+            model_name=model_name,
+            model_kv=qeff_model,
+            tokenizer=tokenizer,
+            onnx_dir_path=onnx_dir_path,
+            seq_length=self.seq_len,
+            kv=True,
+            form_factor="cloud"
+        )
+        assert os.path.exists(result[0])
+        assert os.path.exists(result[1])

--- a/tests/exporter/test_export_hf_to_cloud_ai_100.py
+++ b/tests/exporter/test_export_hf_to_cloud_ai_100.py
@@ -13,7 +13,6 @@ import pytest
 import QEfficient
 from QEfficient.base.common import QEFFCommonLoader
 from QEfficient.exporter.export_hf_to_cloud_ai_100 import (
-    convert_to_cloud_bertstyle,
     convert_to_cloud_kvstyle,
     qualcomm_efficient_converter,
 )
@@ -21,11 +20,12 @@ from QEfficient.utils import load_hf_tokenizer, onnx_exists
 
 
 def create_onnx_dir(model_name):
-    _,onnx_dir_path,_ = onnx_exists(model_name=model_name,full_batch_size=None)
+    _, onnx_dir_path, _ = onnx_exists(model_name=model_name, full_batch_size=None)
     return onnx_dir_path
 
-@pytest.mark.parametrize("model_name",["lu-vae/llama-68m-fft"])
-class TestQEffExportFunctions():
+
+@pytest.mark.parametrize("model_name", ["lu-vae/llama-68m-fft"])
+class TestQEffExportFunctions:
     @classmethod
     def setup_class(cls):
         cls.seq_len = 128
@@ -34,53 +34,57 @@ class TestQEffExportFunctions():
         cls.models = {}
         for model_name in ["lu-vae/llama-68m-fft"]:
             onnx_dir_path = create_onnx_dir(model_name)
-            tokenizer = load_hf_tokenizer(pretrained_model_name_or_path=model_name,hf_token=cls.hf_token,cache_dir=cls.cache_dir)
-            model_kv = QEFFCommonLoader.from_pretrained(pretrained_model_name_or_path=model_name,token=cls.hf_token,cache_dir=cls.cache_dir)
+            tokenizer = load_hf_tokenizer(
+                pretrained_model_name_or_path=model_name, hf_token=cls.hf_token, cache_dir=cls.cache_dir
+            )
+            model_kv = QEFFCommonLoader.from_pretrained(
+                pretrained_model_name_or_path=model_name, token=cls.hf_token, cache_dir=cls.cache_dir
+            )
             qeff_model = QEfficient.transform(model_kv)
-            cls.models[model_name] = [onnx_dir_path,tokenizer,model_kv,qeff_model]
-    
+            cls.models[model_name] = [onnx_dir_path, tokenizer, model_kv, qeff_model]
+
     def teardown_class(cls):
         for models in cls.models.values():
             onnx_dir_path = models[0]
             if os.path.exists(onnx_dir_path):
                 shutil.rmtree(onnx_dir_path)
-    
-    def test_convert_to_cloud_bertstyle(self,model_name):
-        _=model_name
+
+    def test_convert_to_cloud_bertstyle(self, model_name):
+        _ = model_name
         assert True
 
-    def test_convert_to_cloud_kvstyle_success(self,model_name):
+    def test_convert_to_cloud_kvstyle_success(self, model_name):
         """
         Test method for convert_to_cloud_kvstyle function in the case of general code flow that qeff_model is transformed
         """
-        onnx_dir_path,tokenizer,_,qeff_model = self.models[model_name]
+        onnx_dir_path, tokenizer, _, qeff_model = self.models[model_name]
         result = convert_to_cloud_kvstyle(
             model_name=model_name,
             qeff_model=qeff_model,
             tokenizer=tokenizer,
             onnx_dir_path=onnx_dir_path,
-            seq_len=self.seq_len
+            seq_len=self.seq_len,
         )
         assert os.path.isfile(result)
         assert os.path.exists(result)
-    
-    def test_convert_to_cloud_kvstyle_warning(self,model_name):
+
+    def test_convert_to_cloud_kvstyle_warning(self, model_name):
         """
         Test method for convert_to_cloud_kvstyle function in the case of Depcreation Warning in the function
         """
-        onnx_dir_path,tokenizer,_,qeff_model = self.models[model_name]
+        onnx_dir_path, tokenizer, _, qeff_model = self.models[model_name]
         with pytest.warns(DeprecationWarning):
             convert_to_cloud_kvstyle(
                 model_name=model_name,
                 qeff_model=qeff_model,
                 tokenizer=tokenizer,
                 onnx_dir_path=onnx_dir_path,
-                seq_len=self.seq_len
+                seq_len=self.seq_len,
             )
-    
-    def test_qualcomm_efficient_converter_success(self,model_name):
+
+    def test_qualcomm_efficient_converter_success(self, model_name):
         """
-        Test method for qualcomm_efficient_converter function in the case of general code flow 
+        Test method for qualcomm_efficient_converter function in the case of general code flow
         """
         result = qualcomm_efficient_converter(
             model_name=model_name,
@@ -89,16 +93,16 @@ class TestQEffExportFunctions():
             onnx_dir_path=None,
             seq_length=self.seq_len,
             kv=True,
-            form_factor="cloud"
+            form_factor="cloud",
         )
         assert os.path.exists(result[0])
         assert os.path.exists(result[1])
 
-    def test_qualcomm_efficient_converter_transformed_model(self,model_name):
+    def test_qualcomm_efficient_converter_transformed_model(self, model_name):
         """
-        Test method for qualcomm_efficient_converter function in the case of qeff_model is already transformed 
+        Test method for qualcomm_efficient_converter function in the case of qeff_model is already transformed
         """
-        onnx_dir_path,tokenizer,_,qeff_model = self.models[model_name]
+        onnx_dir_path, tokenizer, _, qeff_model = self.models[model_name]
         result = qualcomm_efficient_converter(
             model_name=model_name,
             model_kv=qeff_model,
@@ -106,7 +110,7 @@ class TestQEffExportFunctions():
             onnx_dir_path=onnx_dir_path,
             seq_length=self.seq_len,
             kv=True,
-            form_factor="cloud"
+            form_factor="cloud",
         )
         assert os.path.exists(result[0])
         assert os.path.exists(result[1])

--- a/tests/generation/test_text_generation_inference.py
+++ b/tests/generation/test_text_generation_inference.py
@@ -7,7 +7,7 @@
 
 import os
 import shutil
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 import pytest
 
@@ -17,7 +17,22 @@ from QEfficient.generation.text_generation_inference import CloudAI100ExecInfo, 
 from QEfficient.utils import check_and_assign_cache_dir, get_qpc_dir_path, load_hf_tokenizer
 
 
-def get_qpc(model_name, num_cores, aic_enable_depth_first,mos, batch_size,full_batch_size, prompt_len, ctx_len, mxfp6, mxint8, device_group,local_model_dir, cache_dir,hf_token):
+def get_qpc(
+    model_name,
+    num_cores,
+    aic_enable_depth_first,
+    mos,
+    batch_size,
+    full_batch_size,
+    prompt_len,
+    ctx_len,
+    mxfp6,
+    mxint8,
+    device_group,
+    local_model_dir,
+    cache_dir,
+    hf_token,
+):
     cache_dir = check_and_assign_cache_dir(local_model_dir, cache_dir)
     tokenizer = load_hf_tokenizer(
         pretrained_model_name_or_path=(local_model_dir if local_model_dir else model_name),
@@ -30,9 +45,9 @@ def get_qpc(model_name, num_cores, aic_enable_depth_first,mos, batch_size,full_b
     )
 
     onnx_model_path = get_onnx_model_path(
-            model_name, cache_dir, tokenizer, hf_token, local_model_dir, full_batch_size
-        )  # , base_dir_name)
-    
+        model_name, cache_dir, tokenizer, hf_token, local_model_dir, full_batch_size
+    )  # , base_dir_name)
+
     _ = QEfficient.compile(
         onnx_path=onnx_model_path,
         qpc_path=os.path.dirname(
@@ -49,10 +64,11 @@ def get_qpc(model_name, num_cores, aic_enable_depth_first,mos, batch_size,full_b
         device_group=device_group,
         full_batch_size=full_batch_size,
     )
-    return tokenizer,onnx_model_path,qpc_dir_path
+    return tokenizer, onnx_model_path, qpc_dir_path
 
-@pytest.mark.parametrize("model_name",["lu-vae/llama-68m-fft"])
-class TestQEffInferenceFunctions():
+
+@pytest.mark.parametrize("model_name", ["lu-vae/llama-68m-fft"])
+class TestQEffInferenceFunctions:
     @classmethod
     def setup_method(cls):
         cls.num_cores: int = 14
@@ -72,42 +88,72 @@ class TestQEffInferenceFunctions():
         cls.cache_dir: Optional[str] = None
         cls.hf_token: Optional[str] = None
         cls.models = []
-    
+
     def teardown_class(cls):
         for dir in cls.models:
             if os.path.exists(os.path.dirname(dir)):
                 shutil.rmtree(os.path.dirname(dir))
-    
-    def test_cloud_ai_100_exec_kv_batch_size_1(self,model_name):
-        tokenizer,onnx_model_path,qpc_dir_path = get_qpc(model_name, self.num_cores, self.aic_enable_depth_first,self.mos, self.batch_size,self.full_batch_size, self.prompt_len, self.ctx_len, self.mxfp6, self.mxint8, self.device_group,self.local_model_dir, self.cache_dir,self.hf_token)
+
+    def test_cloud_ai_100_exec_kv_batch_size_1(self, model_name):
+        tokenizer, onnx_model_path, qpc_dir_path = get_qpc(
+            model_name,
+            self.num_cores,
+            self.aic_enable_depth_first,
+            self.mos,
+            self.batch_size,
+            self.full_batch_size,
+            self.prompt_len,
+            self.ctx_len,
+            self.mxfp6,
+            self.mxint8,
+            self.device_group,
+            self.local_model_dir,
+            self.cache_dir,
+            self.hf_token,
+        )
         result = cloud_ai_100_exec_kv(
-                    tokenizer=tokenizer,
-                    qpc_path=qpc_dir_path,
-                    device_id=self.device_group,
-                    prompt=self.prompt,
-                    prompts_txt_file_path=self.prompts_txt_file_path,
-                    generation_len=self.generation_len,
-                    full_batch_size=self.full_batch_size,
-                )
-        self.models.extend([onnx_model_path,qpc_dir_path])
+            tokenizer=tokenizer,
+            qpc_path=qpc_dir_path,
+            device_id=self.device_group,
+            prompt=self.prompt,
+            prompts_txt_file_path=self.prompts_txt_file_path,
+            generation_len=self.generation_len,
+            full_batch_size=self.full_batch_size,
+        )
+        self.models.extend([onnx_model_path, qpc_dir_path])
         assert isinstance(result, CloudAI100ExecInfo)
 
-    def test_cloud_ai_100_exec_kv_full_batch_size(self,model_name):
+    def test_cloud_ai_100_exec_kv_full_batch_size(self, model_name):
         self.full_batch_size = 3
-        tokenizer,onnx_model_path,qpc_dir_path = get_qpc(model_name, self.num_cores, self.aic_enable_depth_first,self.mos, self.batch_size,self.full_batch_size, self.prompt_len, self.ctx_len, self.mxfp6, self.mxint8, self.device_group,self.local_model_dir, self.cache_dir,self.hf_token)
+        tokenizer, onnx_model_path, qpc_dir_path = get_qpc(
+            model_name,
+            self.num_cores,
+            self.aic_enable_depth_first,
+            self.mos,
+            self.batch_size,
+            self.full_batch_size,
+            self.prompt_len,
+            self.ctx_len,
+            self.mxfp6,
+            self.mxint8,
+            self.device_group,
+            self.local_model_dir,
+            self.cache_dir,
+            self.hf_token,
+        )
         result = cloud_ai_100_exec_kv(
-                    tokenizer=tokenizer,
-                    qpc_path=qpc_dir_path,
-                    device_id=self.device_group,
-                    prompt=self.prompt,
-                    prompts_txt_file_path=self.prompts_txt_file_path,
-                    generation_len=self.generation_len,
-                    full_batch_size=self.full_batch_size,
-                )
-        self.models.extend([onnx_model_path,qpc_dir_path])
+            tokenizer=tokenizer,
+            qpc_path=qpc_dir_path,
+            device_id=self.device_group,
+            prompt=self.prompt,
+            prompts_txt_file_path=self.prompts_txt_file_path,
+            generation_len=self.generation_len,
+            full_batch_size=self.full_batch_size,
+        )
+        self.models.extend([onnx_model_path, qpc_dir_path])
         assert isinstance(result, CloudAI100ExecInfo)
 
-    def test_latency_stats_bertstyle(self,model_name):
+    def test_latency_stats_bertstyle(self, model_name):
         # Will Implement
         _ = model_name
         assert True

--- a/tests/generation/test_text_generation_inference.py
+++ b/tests/generation/test_text_generation_inference.py
@@ -1,0 +1,113 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+import os
+import shutil
+from typing import Dict, List, Optional
+
+import pytest
+
+import QEfficient
+from QEfficient.cloud.export import get_onnx_model_path
+from QEfficient.generation.text_generation_inference import CloudAI100ExecInfo, cloud_ai_100_exec_kv
+from QEfficient.utils import check_and_assign_cache_dir, get_qpc_dir_path, load_hf_tokenizer
+
+
+def get_qpc(model_name, num_cores, aic_enable_depth_first,mos, batch_size,full_batch_size, prompt_len, ctx_len, mxfp6, mxint8, device_group,local_model_dir, cache_dir,hf_token):
+    cache_dir = check_and_assign_cache_dir(local_model_dir, cache_dir)
+    tokenizer = load_hf_tokenizer(
+        pretrained_model_name_or_path=(local_model_dir if local_model_dir else model_name),
+        cache_dir=cache_dir,
+        hf_token=hf_token,
+    )
+
+    qpc_dir_path = get_qpc_dir_path(
+        model_name, num_cores, mos, batch_size, prompt_len, ctx_len, mxfp6, mxint8, device_group, full_batch_size
+    )
+
+    onnx_model_path = get_onnx_model_path(
+            model_name, cache_dir, tokenizer, hf_token, local_model_dir, full_batch_size
+        )  # , base_dir_name)
+    
+    _ = QEfficient.compile(
+        onnx_path=onnx_model_path,
+        qpc_path=os.path.dirname(
+            qpc_dir_path
+        ),  # We need to pass parent directory of qpc_dir_path, as the compile function handles the qpcs directory creation
+        num_cores=num_cores,
+        batch_size=batch_size,
+        prompt_len=prompt_len,
+        ctx_len=ctx_len,
+        mxfp6=mxfp6,
+        mxint8=mxint8,
+        aic_enable_depth_first=aic_enable_depth_first,
+        mos=mos,
+        device_group=device_group,
+        full_batch_size=full_batch_size,
+    )
+    return tokenizer,onnx_model_path,qpc_dir_path
+
+@pytest.mark.parametrize("model_name",["lu-vae/llama-68m-fft"])
+class TestQEffInferenceFunctions():
+    @classmethod
+    def setup_method(cls):
+        cls.num_cores: int = 14
+        cls.device_group: Optional[List[int]] = None
+        cls.prompt: Optional[str] = None  # type: ignore
+        cls.prompts_txt_file_path: Optional[str] = "examples/prompts.txt"
+        cls.aic_enable_depth_first: bool = False
+        cls.mos: int = -1
+        cls.batch_size: int = 1
+        cls.full_batch_size: Optional[int] = None
+        cls.prompt_len: int = 32
+        cls.ctx_len: int = 128
+        cls.generation_len: Optional[int] = None
+        cls.mxfp6: bool = False
+        cls.mxint8: bool = False
+        cls.local_model_dir: Optional[str] = None
+        cls.cache_dir: Optional[str] = None
+        cls.hf_token: Optional[str] = None
+        cls.models = []
+    
+    def teardown_class(cls):
+        for dir in cls.models:
+            if os.path.exists(os.path.dirname(dir)):
+                shutil.rmtree(os.path.dirname(dir))
+    
+    def test_cloud_ai_100_exec_kv_batch_size_1(self,model_name):
+        tokenizer,onnx_model_path,qpc_dir_path = get_qpc(model_name, self.num_cores, self.aic_enable_depth_first,self.mos, self.batch_size,self.full_batch_size, self.prompt_len, self.ctx_len, self.mxfp6, self.mxint8, self.device_group,self.local_model_dir, self.cache_dir,self.hf_token)
+        result = cloud_ai_100_exec_kv(
+                    tokenizer=tokenizer,
+                    qpc_path=qpc_dir_path,
+                    device_id=self.device_group,
+                    prompt=self.prompt,
+                    prompts_txt_file_path=self.prompts_txt_file_path,
+                    generation_len=self.generation_len,
+                    full_batch_size=self.full_batch_size,
+                )
+        self.models.extend([onnx_model_path,qpc_dir_path])
+        assert isinstance(result, CloudAI100ExecInfo)
+
+    def test_cloud_ai_100_exec_kv_full_batch_size(self,model_name):
+        self.full_batch_size = 3
+        tokenizer,onnx_model_path,qpc_dir_path = get_qpc(model_name, self.num_cores, self.aic_enable_depth_first,self.mos, self.batch_size,self.full_batch_size, self.prompt_len, self.ctx_len, self.mxfp6, self.mxint8, self.device_group,self.local_model_dir, self.cache_dir,self.hf_token)
+        result = cloud_ai_100_exec_kv(
+                    tokenizer=tokenizer,
+                    qpc_path=qpc_dir_path,
+                    device_id=self.device_group,
+                    prompt=self.prompt,
+                    prompts_txt_file_path=self.prompts_txt_file_path,
+                    generation_len=self.generation_len,
+                    full_batch_size=self.full_batch_size,
+                )
+        self.models.extend([onnx_model_path,qpc_dir_path])
+        assert isinstance(result, CloudAI100ExecInfo)
+
+    def test_latency_stats_bertstyle(self,model_name):
+        # Will Implement
+        _ = model_name
+        assert True

--- a/tests/transformers/test_cache_utils.py
+++ b/tests/transformers/test_cache_utils.py
@@ -1,0 +1,120 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+import pytest
+import torch
+
+from QEfficient.transformers.cache_utils import QEffDynamicCache  # Adjust the import based on your module's structure
+
+
+@pytest.fixture
+def setup_cache():
+    return QEffDynamicCache()
+
+def test_update_new_layer(setup_cache):
+    cache = setup_cache
+    key_states = torch.tensor([[[[1.0]]]])
+    value_states = torch.tensor([[[[2.0]]]])
+    layer_idx = 0
+
+    k_out,v_out = cache.update(key_states, value_states, layer_idx)
+
+    assert torch.equal(k_out, key_states)
+    assert torch.equal(v_out, value_states)
+    assert len(cache.key_cache) == 1
+    assert len(cache.value_cache) == 1
+
+def test_update_existing_layer(setup_cache):
+    cache = setup_cache
+    key_states = torch.tensor([[[[1.0]]]])
+    value_states = torch.tensor([[[[2.0]]]])
+    layer_idx = 0
+    cache_kwargs = {
+        'position_ids': torch.tensor([[0]]),
+        'batch_index': torch.tensor([0])
+    }
+    cache.update(key_states, value_states, layer_idx,cache_kwargs)
+
+    key_states2 = torch.tensor([[[[3.0]]]])
+    value_states2 = torch.tensor([[[[4.0]]]])
+    k_out,v_out = cache.update(key_states2, value_states2, layer_idx,cache_kwargs)
+
+    assert torch.equal(k_out, key_states2)
+    assert torch.equal(v_out, value_states2)
+    assert len(cache.key_cache) == 1
+    assert len(cache.value_cache) == 1
+
+def test_update_with_batch_index(setup_cache):
+    cache = setup_cache
+    key_states = torch.tensor([[[[1.0]]]])
+    value_states = torch.tensor([[[[2.0]]]])
+    layer_idx = 0
+    cache_kwargs = {
+        'position_ids': torch.tensor([[0]])
+    }
+    cache.update(key_states, value_states, layer_idx,cache_kwargs)
+
+    key_states2 = torch.tensor([[[[3.0]]]])
+    value_states2 = torch.tensor([[[[4.0]]]])
+    k_out,v_out = cache.update(key_states2, value_states2, layer_idx,cache_kwargs)
+
+    assert torch.equal(k_out, key_states2)
+    assert torch.equal(v_out, value_states2)
+    assert len(cache.key_cache) == 1
+    assert len(cache.value_cache) == 1
+
+def test_update3D_new_layer(setup_cache):
+    cache = setup_cache
+    key_states = torch.tensor([[[[1.0]]]])
+    value_states = torch.tensor([[[[2.0]]]])
+    layer_idx = 0
+
+    k_out,v_out = cache.update3D(key_states, value_states, layer_idx)
+
+    assert torch.equal(k_out, key_states)
+    assert torch.equal(v_out, value_states)
+    assert len(cache.key_cache) == 1
+    assert len(cache.value_cache) == 1
+
+def test_update3D_existing_layer(setup_cache):
+    cache = setup_cache
+    key_states = torch.tensor([[[[1.0]]]])
+    value_states = torch.tensor([[[[2.0]]]])
+    layer_idx = 0
+    cache_kwargs = {
+        'position_ids': torch.tensor([[0]]),
+        'batch_index': torch.tensor([0])
+    }
+    cache.update3D(key_states, value_states, layer_idx,cache_kwargs)
+
+    key_states2 = torch.tensor([[[[3.0]]]])
+    value_states2 = torch.tensor([[[[4.0]]]])
+    k_out,v_out = cache.update3D(key_states2, value_states2, layer_idx,cache_kwargs)
+
+    assert torch.equal(k_out, key_states2)
+    assert torch.equal(v_out, value_states2)
+    assert len(cache.key_cache) == 1
+    assert len(cache.value_cache) == 1
+
+def test_update3D_with_batch_index(setup_cache):
+    cache = setup_cache
+    key_states = torch.tensor([[[[1.0]]]])
+    value_states = torch.tensor([[[[2.0]]]])
+    layer_idx = 0
+    cache_kwargs = {
+        'position_ids': torch.tensor([[0]])
+    }
+    cache.update3D(key_states, value_states, layer_idx,cache_kwargs)
+
+    key_states2 = torch.tensor([[[[3.0]]]])
+    value_states2 = torch.tensor([[[[4.0]]]])
+    k_out,v_out = cache.update3D(key_states2, value_states2, layer_idx,cache_kwargs)
+
+    assert torch.equal(k_out, key_states2)
+    assert torch.equal(v_out, value_states2)
+    assert len(cache.key_cache) == 1
+    assert len(cache.value_cache) == 1

--- a/tests/transformers/test_cache_utils.py
+++ b/tests/transformers/test_cache_utils.py
@@ -15,57 +15,56 @@ from QEfficient.transformers.cache_utils import QEffDynamicCache  # Adjust the i
 def setup_cache():
     return QEffDynamicCache()
 
+
 def test_update_new_layer(setup_cache):
     cache = setup_cache
     key_states = torch.tensor([[[[1.0]]]])
     value_states = torch.tensor([[[[2.0]]]])
     layer_idx = 0
 
-    k_out,v_out = cache.update(key_states, value_states, layer_idx)
+    k_out, v_out = cache.update(key_states, value_states, layer_idx)
 
     assert torch.equal(k_out, key_states)
     assert torch.equal(v_out, value_states)
     assert len(cache.key_cache) == 1
     assert len(cache.value_cache) == 1
 
+
 def test_update_existing_layer(setup_cache):
     cache = setup_cache
     key_states = torch.tensor([[[[1.0]]]])
     value_states = torch.tensor([[[[2.0]]]])
     layer_idx = 0
-    cache_kwargs = {
-        'position_ids': torch.tensor([[0]]),
-        'batch_index': torch.tensor([0])
-    }
-    cache.update(key_states, value_states, layer_idx,cache_kwargs)
+    cache_kwargs = {"position_ids": torch.tensor([[0]]), "batch_index": torch.tensor([0])}
+    cache.update(key_states, value_states, layer_idx, cache_kwargs)
 
     key_states2 = torch.tensor([[[[3.0]]]])
     value_states2 = torch.tensor([[[[4.0]]]])
-    k_out,v_out = cache.update(key_states2, value_states2, layer_idx,cache_kwargs)
+    k_out, v_out = cache.update(key_states2, value_states2, layer_idx, cache_kwargs)
 
     assert torch.equal(k_out, key_states2)
     assert torch.equal(v_out, value_states2)
     assert len(cache.key_cache) == 1
     assert len(cache.value_cache) == 1
+
 
 def test_update_with_batch_index(setup_cache):
     cache = setup_cache
     key_states = torch.tensor([[[[1.0]]]])
     value_states = torch.tensor([[[[2.0]]]])
     layer_idx = 0
-    cache_kwargs = {
-        'position_ids': torch.tensor([[0]])
-    }
-    cache.update(key_states, value_states, layer_idx,cache_kwargs)
+    cache_kwargs = {"position_ids": torch.tensor([[0]])}
+    cache.update(key_states, value_states, layer_idx, cache_kwargs)
 
     key_states2 = torch.tensor([[[[3.0]]]])
     value_states2 = torch.tensor([[[[4.0]]]])
-    k_out,v_out = cache.update(key_states2, value_states2, layer_idx,cache_kwargs)
+    k_out, v_out = cache.update(key_states2, value_states2, layer_idx, cache_kwargs)
 
     assert torch.equal(k_out, key_states2)
     assert torch.equal(v_out, value_states2)
     assert len(cache.key_cache) == 1
     assert len(cache.value_cache) == 1
+
 
 def test_update3D_new_layer(setup_cache):
     cache = setup_cache
@@ -73,46 +72,43 @@ def test_update3D_new_layer(setup_cache):
     value_states = torch.tensor([[[[2.0]]]])
     layer_idx = 0
 
-    k_out,v_out = cache.update3D(key_states, value_states, layer_idx)
+    k_out, v_out = cache.update3D(key_states, value_states, layer_idx)
 
     assert torch.equal(k_out, key_states)
     assert torch.equal(v_out, value_states)
     assert len(cache.key_cache) == 1
     assert len(cache.value_cache) == 1
 
+
 def test_update3D_existing_layer(setup_cache):
     cache = setup_cache
     key_states = torch.tensor([[[[1.0]]]])
     value_states = torch.tensor([[[[2.0]]]])
     layer_idx = 0
-    cache_kwargs = {
-        'position_ids': torch.tensor([[0]]),
-        'batch_index': torch.tensor([0])
-    }
-    cache.update3D(key_states, value_states, layer_idx,cache_kwargs)
+    cache_kwargs = {"position_ids": torch.tensor([[0]]), "batch_index": torch.tensor([0])}
+    cache.update3D(key_states, value_states, layer_idx, cache_kwargs)
 
     key_states2 = torch.tensor([[[[3.0]]]])
     value_states2 = torch.tensor([[[[4.0]]]])
-    k_out,v_out = cache.update3D(key_states2, value_states2, layer_idx,cache_kwargs)
+    k_out, v_out = cache.update3D(key_states2, value_states2, layer_idx, cache_kwargs)
 
     assert torch.equal(k_out, key_states2)
     assert torch.equal(v_out, value_states2)
     assert len(cache.key_cache) == 1
     assert len(cache.value_cache) == 1
 
+
 def test_update3D_with_batch_index(setup_cache):
     cache = setup_cache
     key_states = torch.tensor([[[[1.0]]]])
     value_states = torch.tensor([[[[2.0]]]])
     layer_idx = 0
-    cache_kwargs = {
-        'position_ids': torch.tensor([[0]])
-    }
-    cache.update3D(key_states, value_states, layer_idx,cache_kwargs)
+    cache_kwargs = {"position_ids": torch.tensor([[0]])}
+    cache.update3D(key_states, value_states, layer_idx, cache_kwargs)
 
     key_states2 = torch.tensor([[[[3.0]]]])
     value_states2 = torch.tensor([[[[4.0]]]])
-    k_out,v_out = cache.update3D(key_states2, value_states2, layer_idx,cache_kwargs)
+    k_out, v_out = cache.update3D(key_states2, value_states2, layer_idx, cache_kwargs)
 
     assert torch.equal(k_out, key_states2)
     assert torch.equal(v_out, value_states2)

--- a/tests/transformers/test_transform.py
+++ b/tests/transformers/test_transform.py
@@ -9,20 +9,19 @@ import shutil
 
 import pytest
 
-import QEfficient
-from QEfficient.base.common import AUTO_MODEL_MAP_TO_MODEL_TYPE_MAP, QEFF_MODEL_TYPE, QEFFCommonLoader
+from QEfficient.base.common import QEFFCommonLoader
 from QEfficient.base.modeling_qeff import QEFFBaseModel
 from QEfficient.transformers.transform import transform, transform_lm
 from QEfficient.utils import load_hf_tokenizer, onnx_exists
 
 
 def create_onnx_dir(model_name):
-    _,onnx_dir_path,_ = onnx_exists(model_name=model_name,full_batch_size=None)
+    _, onnx_dir_path, _ = onnx_exists(model_name=model_name, full_batch_size=None)
     return onnx_dir_path
 
-@pytest.mark.parametrize("model_name",["lu-vae/llama-68m-fft"])
-class TestTransformFunctions():
 
+@pytest.mark.parametrize("model_name", ["lu-vae/llama-68m-fft"])
+class TestTransformFunctions:
     @classmethod
     def setup_method(cls):
         cls.seq_len = 128
@@ -31,32 +30,36 @@ class TestTransformFunctions():
         cls.models = {}
         for model_name in ["lu-vae/llama-68m-fft"]:
             onnx_dir_path = create_onnx_dir(model_name)
-            tokenizer = load_hf_tokenizer(pretrained_model_name_or_path=model_name,hf_token=cls.hf_token,cache_dir=cls.cache_dir)
-            model_kv = QEFFCommonLoader.from_pretrained(pretrained_model_name_or_path=model_name,token=cls.hf_token,cache_dir=cls.cache_dir)
-            cls.models[model_name] = [onnx_dir_path,tokenizer,model_kv]
-    
+            tokenizer = load_hf_tokenizer(
+                pretrained_model_name_or_path=model_name, hf_token=cls.hf_token, cache_dir=cls.cache_dir
+            )
+            model_kv = QEFFCommonLoader.from_pretrained(
+                pretrained_model_name_or_path=model_name, token=cls.hf_token, cache_dir=cls.cache_dir
+            )
+            cls.models[model_name] = [onnx_dir_path, tokenizer, model_kv]
+
     def teardown_class(cls):
         for models in cls.models.values():
             onnx_dir_path = models[0]
             if os.path.exists(onnx_dir_path):
                 shutil.rmtree(onnx_dir_path)
 
-    def test_transform_success(self,model_name):
-        _,_,model = self.models[model_name]
+    def test_transform_success(self, model_name):
+        _, _, model = self.models[model_name]
         result = transform(model)
-        assert isinstance(result,QEFFBaseModel)
+        assert isinstance(result, QEFFBaseModel)
 
-    def test_transform_invalid_form_factor(self,model_name):
-        _,_,model = self.models[model_name]
+    def test_transform_invalid_form_factor(self, model_name):
+        _, _, model = self.models[model_name]
         with pytest.raises(AssertionError):
-            transform(model,"edge")
-        
-    def test_transform_not_implemented(self,model_name):
-        _,_,model = self.models[model_name]
+            transform(model, "edge")
+
+    def test_transform_not_implemented(self, model_name):
+        _, _, model = self.models[model_name]
         with pytest.raises(NotImplementedError):
             transform("not_edge")
 
-    def test_transform_lm(self,model_name):
-        _,_,model = self.models[model_name]
+    def test_transform_lm(self, model_name):
+        _, _, model = self.models[model_name]
         result = transform_lm(model.model)
         assert getattr(result, "qeff_transformed", False)

--- a/tests/transformers/test_transform.py
+++ b/tests/transformers/test_transform.py
@@ -1,0 +1,62 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+import os
+import shutil
+
+import pytest
+
+import QEfficient
+from QEfficient.base.common import AUTO_MODEL_MAP_TO_MODEL_TYPE_MAP, QEFF_MODEL_TYPE, QEFFCommonLoader
+from QEfficient.base.modeling_qeff import QEFFBaseModel
+from QEfficient.transformers.transform import transform, transform_lm
+from QEfficient.utils import load_hf_tokenizer, onnx_exists
+
+
+def create_onnx_dir(model_name):
+    _,onnx_dir_path,_ = onnx_exists(model_name=model_name,full_batch_size=None)
+    return onnx_dir_path
+
+@pytest.mark.parametrize("model_name",["lu-vae/llama-68m-fft"])
+class TestTransformFunctions():
+
+    @classmethod
+    def setup_method(cls):
+        cls.seq_len = 128
+        cls.hf_token = None
+        cls.cache_dir = None
+        cls.models = {}
+        for model_name in ["lu-vae/llama-68m-fft"]:
+            onnx_dir_path = create_onnx_dir(model_name)
+            tokenizer = load_hf_tokenizer(pretrained_model_name_or_path=model_name,hf_token=cls.hf_token,cache_dir=cls.cache_dir)
+            model_kv = QEFFCommonLoader.from_pretrained(pretrained_model_name_or_path=model_name,token=cls.hf_token,cache_dir=cls.cache_dir)
+            cls.models[model_name] = [onnx_dir_path,tokenizer,model_kv]
+    
+    def teardown_class(cls):
+        for models in cls.models.values():
+            onnx_dir_path = models[0]
+            if os.path.exists(onnx_dir_path):
+                shutil.rmtree(onnx_dir_path)
+
+    def test_transform_success(self,model_name):
+        _,_,model = self.models[model_name]
+        result = transform(model)
+        assert isinstance(result,QEFFBaseModel)
+
+    def test_transform_invalid_form_factor(self,model_name):
+        _,_,model = self.models[model_name]
+        with pytest.raises(AssertionError):
+            transform(model,"edge")
+        
+    def test_transform_not_implemented(self,model_name):
+        _,_,model = self.models[model_name]
+        with pytest.raises(NotImplementedError):
+            transform("not_edge")
+
+    def test_transform_lm(self,model_name):
+        _,_,model = self.models[model_name]
+        result = transform_lm(model.model)
+        assert getattr(result, "qeff_transformed", False)

--- a/tests/utils/test_device_utils.py
+++ b/tests/utils/test_device_utils.py
@@ -10,14 +10,16 @@ from QEfficient.utils.device_utils import is_multi_qranium_setup_available, is_q
 
 def test_is_qpc_size_gt_32gb_mxfp6():
     params = 2**40
-    result = is_qpc_size_gt_32gb(params=params,mxfp6=True)
+    result = is_qpc_size_gt_32gb(params=params, mxfp6=True)
     assert result
+
 
 def test_is_qpc_size_gt_32gb_other():
     params = 2**30
-    result = is_qpc_size_gt_32gb(params=params,mxfp6=False)
+    result = is_qpc_size_gt_32gb(params=params, mxfp6=False)
     assert result is not True
-    
+
+
 def test_is_multi_qranium_setup_available():
     _ = is_multi_qranium_setup_available()
     assert True

--- a/tests/utils/test_device_utils.py
+++ b/tests/utils/test_device_utils.py
@@ -1,0 +1,23 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from QEfficient.utils.device_utils import is_multi_qranium_setup_available, is_qpc_size_gt_32gb
+
+
+def test_is_qpc_size_gt_32gb_mxfp6():
+    params = 2**40
+    result = is_qpc_size_gt_32gb(params=params,mxfp6=True)
+    assert result
+
+def test_is_qpc_size_gt_32gb_other():
+    params = 2**30
+    result = is_qpc_size_gt_32gb(params=params,mxfp6=False)
+    assert result is not True
+    
+def test_is_multi_qranium_setup_available():
+    _ = is_multi_qranium_setup_available()
+    assert True


### PR DESCRIPTION
In this PR I am adding testing scripts for all the possible low level apis in order to increase the overall code coverage.

Below is mentioned all the testing modules:

1. tests/compiler/
3. tests/exporter/ 
4. tests/generation/
5. tests/transformers/test_cache_utils.py
6. tests/transformers/test_transform.py
7. tests/utils/test_device_utils.py


Note: will be adding more 