### PR TITLE
onnx_defer_loading parameter addition in QNN Convertor Command

### DIFF
--- a/QEfficient/utils/constants.py
+++ b/QEfficient/utils/constants.py
@@ -83,7 +83,7 @@ class QnnConstants:
     # Convertor Arguments
     FLOAT_BITWIDTH = 16
     FLOAT_BIAS_BITWIDTH = 32
-    CONVERTOR_DEFAULT_ARGS = "--keep_int64_inputs --onnx_no_simplification "
+    CONVERTOR_DEFAULT_ARGS = "--keep_int64_inputs --onnx_no_simplification --onnx_defer_loading "
 
     # Context-Binary-Generator Arguments
     LOG_LEVEL = "error"


### PR DESCRIPTION
A new parameter is introduced by the convertor team for optimization. Adding the same under CONVERTOR_DEFAULT_ARGS