### PR TITLE
[QEff. Finetune] Adding the support to resume the fine tuning using pre computed 

### DIFF
--- a/QEfficient/finetune/configs/training.py
+++ b/QEfficient/finetune/configs/training.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 @dataclass
 class train_config:
     model_name: str = "meta-llama/Llama-3.2-1B"
-    tokenizer_name: str = "meta-llama/Llama-3.2-1B"
+    tokenizer_name: str = None  # if not passed as an argument, it uses the value of model_name
     run_validation: bool = True
     batch_size_training: int = 1
     context_length: int = None

--- a/QEfficient/finetune/utils/train_utils.py
+++ b/QEfficient/finetune/utils/train_utils.py
@@ -116,6 +116,10 @@ def train(
         # enable profile for qaic
         qaic_profile.start_profiling(device, 1) if train_config.use_profiler else None
         for step, batch in enumerate(train_dataloader):
+            if train_config.use_peft and train_config.from_peft_checkpoint:
+                intermediate_step = int(train_config.from_peft_checkpoint.split("/")[-1].split("_")[-1])
+                if step < intermediate_step:
+                    continue
             total_train_steps += 1
             #  stop when the maximum number of training steps is reached
             if train_config.max_train_step > 0 and total_train_steps > train_config.max_train_step:


### PR DESCRIPTION
Adding the support to resume the fine tuning using checkpoints from a prev run which would have stopped in between. 
There's no necessity to pass tokenizer_name if a model_name is passed. It will take the same name as model_name by default. 
If a different tokenizer_name is required than the model_name, then it can be passed separately as an argument in the command. 