### PR TITLE
Enabling FP8 models for `Cloud AI 100`

### DIFF
--- a/QEfficient/__init__.py
+++ b/QEfficient/__init__.py
@@ -5,6 +5,8 @@
 #
 # -----------------------------------------------------------------------------
 
+from QEfficient.utils.logging_utils import logger
+
 
 def check_qaic_sdk():
     """Check if QAIC SDK is installed"""
@@ -20,11 +22,10 @@ def check_qaic_sdk():
         return False
 
 
-QAIC_INSTALLED = check_qaic_sdk()
-
 # Conditionally import QAIC-related modules if the SDK is installed
 __version__ = "0.0.1.dev0"
-if QAIC_INSTALLED:
+
+if check_qaic_sdk():
     from QEfficient.base import (
         QEFFAutoModel,
         QEFFAutoModelForCausalLM,
@@ -52,6 +53,6 @@ if QAIC_INSTALLED:
         "QEFFCommonLoader",
     ]
 
-    print("QAIC SDK is installed.")
+    logger.warning("QAIC SDK is installed; eager mode features are enabled!")
 else:
-    print("QAIC SDK is not installed. Proceeding without it.")
+    logger.warning("QAIC SDK is not installed, eager mode features won't be available!")

--- a/QEfficient/__init__.py
+++ b/QEfficient/__init__.py
@@ -53,6 +53,5 @@ if check_qaic_sdk():
         "QEFFCommonLoader",
     ]
 
-    logger.warning("QAIC SDK is installed; eager mode features are enabled!")
 else:
     logger.warning("QAIC SDK is not installed, eager mode features won't be available!")

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -39,7 +39,7 @@ from QEfficient.transformers.models.pytorch_transforms import (
 from QEfficient.transformers.quantizers.auto import QEFF_AUTO_QUANTIZATION_CONFIG_MAPPING, with_replaced_quantizers
 from QEfficient.transformers.quantizers.quant_transforms import (
     AwqToMatmulNbitsTransform,
-    FP8CompressedToLinearTransform,
+    FP8DeQuantLinearToLinearTransform,
     GPTQToMatmulNbitsTransform,
 )
 from QEfficient.utils import constants, get_padding_shape_from_config

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1203,7 +1203,13 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
     """
 
     _hf_auto_class = AutoModelForCausalLM
-    _pytorch_transforms = [AwqToMatmulNbitsTransform, GPTQToMatmulNbitsTransform, CustomOpsTransform, KVCacheTransform]
+    _pytorch_transforms = [
+        AwqToMatmulNbitsTransform,
+        GPTQToMatmulNbitsTransform,
+        FP8DeQuantLinearToLinearTransform,
+        CustomOpsTransform,
+        KVCacheTransform,
+    ]
     _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform]
 
     def __init__(

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -37,7 +37,11 @@ from QEfficient.transformers.models.pytorch_transforms import (
     VlmNoKVOffloadTransform,
 )
 from QEfficient.transformers.quantizers.auto import QEFF_AUTO_QUANTIZATION_CONFIG_MAPPING, with_replaced_quantizers
-from QEfficient.transformers.quantizers.quant_transforms import AwqToMatmulNbitsTransform, GPTQToMatmulNbitsTransform
+from QEfficient.transformers.quantizers.quant_transforms import (
+    AwqToMatmulNbitsTransform,
+    FP8CompressedToLinearTransform,
+    GPTQToMatmulNbitsTransform,
+)
 from QEfficient.utils import constants, get_padding_shape_from_config
 from QEfficient.utils.cache import to_hashable
 from QEfficient.utils.logging_utils import logger

--- a/QEfficient/transformers/quantizers/auto.py
+++ b/QEfficient/transformers/quantizers/auto.py
@@ -7,16 +7,37 @@
 
 from transformers.quantizers.auto import AUTO_QUANTIZATION_CONFIG_MAPPING, AUTO_QUANTIZER_MAPPING
 from transformers.quantizers.quantizer_awq import AwqQuantizer
+from transformers.quantizers.quantizer_compressed_tensors import CompressedTensorsHfQuantizer
 from transformers.quantizers.quantizer_gptq import GptqHfQuantizer
-from transformers.utils.quantization_config import AwqConfig, GPTQConfig
+from transformers.utils.quantization_config import AwqConfig, CompressedTensorsConfig, GPTQConfig
 
 from QEfficient.transformers.quantizers.quantizer_awq import QEffAwqConfig, QEffAwqQuantizer
+from QEfficient.transformers.quantizers.quantizer_compressed_tensors import (
+    QEffCompressedTensorsConfig,
+    QEffFP8Quantizer,
+)
 from QEfficient.transformers.quantizers.quantizer_gptq import QEffGPTQConfig, QEffGPTQQuantizer
 
-QEFF_AUTO_QUANTIZER_MAPPING = {"awq": QEffAwqQuantizer, "gptq": QEffGPTQQuantizer}
-QEFF_AUTO_QUANTIZATION_CONFIG_MAPPING = {"awq": QEffAwqConfig, "gptq": QEffGPTQConfig}
-DUPLICATE_AUTO_QUANTIZER_MAPPING = {"awq": AwqQuantizer, "gptq": GptqHfQuantizer}
-DUPLICATE_AUTO_QUANTIZATION_CONFIG_MAPPING = {"awq": AwqConfig, "gptq": GPTQConfig}
+QEFF_AUTO_QUANTIZER_MAPPING = {
+    "awq": QEffAwqQuantizer,
+    "gptq": QEffGPTQQuantizer,
+    "compressed-tensors": QEffFP8Quantizer,
+}
+QEFF_AUTO_QUANTIZATION_CONFIG_MAPPING = {
+    "awq": QEffAwqConfig,
+    "gptq": QEffGPTQConfig,
+    "compressed-tensors": QEffCompressedTensorsConfig,
+}
+DUPLICATE_AUTO_QUANTIZER_MAPPING = {
+    "awq": AwqQuantizer,
+    "gptq": GptqHfQuantizer,
+    "compressed-tensors": CompressedTensorsHfQuantizer,
+}
+DUPLICATE_AUTO_QUANTIZATION_CONFIG_MAPPING = {
+    "awq": AwqConfig,
+    "gptq": GPTQConfig,
+    "compressed-tensors": CompressedTensorsConfig,
+}
 
 
 def with_replaced_quantizers(func):

--- a/QEfficient/transformers/quantizers/auto.py
+++ b/QEfficient/transformers/quantizers/auto.py
@@ -53,11 +53,11 @@ def with_replaced_quantizers(func):
 
         for k in QEFF_AUTO_QUANTIZATION_CONFIG_MAPPING.keys():
             # Replace quantization config
-            transformers_replaced_quantization_config_mapping[k] = AUTO_QUANTIZATION_CONFIG_MAPPING[k]
+            transformers_replaced_quantization_config_mapping[k] = AUTO_QUANTIZATION_CONFIG_MAPPING.get(k, None)
             AUTO_QUANTIZATION_CONFIG_MAPPING[k] = QEFF_AUTO_QUANTIZATION_CONFIG_MAPPING[k]
 
             # Replace quantizer
-            transformers_replaced_quantizer_mapping[k] = AUTO_QUANTIZER_MAPPING[k]
+            transformers_replaced_quantizer_mapping[k] = AUTO_QUANTIZER_MAPPING.get(k, None)
             AUTO_QUANTIZER_MAPPING[k] = QEFF_AUTO_QUANTIZER_MAPPING[k]
 
         # Call the function for loading quantized models here

--- a/QEfficient/transformers/quantizers/auto.py
+++ b/QEfficient/transformers/quantizers/auto.py
@@ -14,6 +14,8 @@ from transformers.utils.quantization_config import AwqConfig, CompressedTensorsC
 from QEfficient.transformers.quantizers.quantizer_awq import QEffAwqConfig, QEffAwqQuantizer
 from QEfficient.transformers.quantizers.quantizer_compressed_tensors import (
     QEffCompressedTensorsConfig,
+    QEffCompressedTensorsFP8Quantizer,
+    QEffFP8Config,
     QEffFP8Quantizer,
 )
 from QEfficient.transformers.quantizers.quantizer_gptq import QEffGPTQConfig, QEffGPTQQuantizer
@@ -21,22 +23,26 @@ from QEfficient.transformers.quantizers.quantizer_gptq import QEffGPTQConfig, QE
 QEFF_AUTO_QUANTIZER_MAPPING = {
     "awq": QEffAwqQuantizer,
     "gptq": QEffGPTQQuantizer,
-    "compressed-tensors": QEffFP8Quantizer,
+    "compressed-tensors": QEffCompressedTensorsFP8Quantizer,
+    "fp8": QEffFP8Quantizer,
 }
 QEFF_AUTO_QUANTIZATION_CONFIG_MAPPING = {
     "awq": QEffAwqConfig,
     "gptq": QEffGPTQConfig,
     "compressed-tensors": QEffCompressedTensorsConfig,
+    "fp8": QEffFP8Config,
 }
 DUPLICATE_AUTO_QUANTIZER_MAPPING = {
     "awq": AwqQuantizer,
     "gptq": GptqHfQuantizer,
     "compressed-tensors": CompressedTensorsHfQuantizer,
+    "fp8": None,
 }
 DUPLICATE_AUTO_QUANTIZATION_CONFIG_MAPPING = {
     "awq": AwqConfig,
     "gptq": GPTQConfig,
     "compressed-tensors": CompressedTensorsConfig,
+    "fp8": None,
 }
 
 

--- a/QEfficient/transformers/quantizers/quant_transforms.py
+++ b/QEfficient/transformers/quantizers/quant_transforms.py
@@ -101,7 +101,7 @@ class GPTQToMatmulNbitsTransform(ModuleMutatorTransform):
         return new_module
 
 
-class FP8CompressedToLinearTransform(ModuleMutatorTransform):
+class FP8DeQuantLinearToLinearTransform(ModuleMutatorTransform):
     _match_class = FP8DeQuantLinear
 
     @classmethod

--- a/QEfficient/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/QEfficient/transformers/quantizers/quantizer_compressed_tensors.py
@@ -1,0 +1,252 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from dataclasses import dataclass
+
+import torch
+from transformers.quantizers.quantizer_compressed_tensors import CompressedTensorsHfQuantizer
+from transformers.utils.quantization_config import CompressedTensorsConfig, QuantizationMethod
+
+from QEfficient.utils.logging_utils import logger
+
+FP8_DTYPE = torch.float8_e4m3fn
+
+
+@dataclass
+class FP8QuantizationScheme:
+    dynamic: bool
+    num_bits: int
+    strategy: str
+    symmetric: bool
+    type: str
+
+    def __post_init__(self):
+        if self.num_bits != 8 or self.type != "float" or self.strategy not in ["tensor", "channel", "token"]:
+            raise NotImplementedError(
+                f"Only FP8 compressed-tensors supported, got num_bits={self.num_bits}, type={self.type}, strategy={self.strategy}"
+            )
+
+
+class CompressedFP8Linear(torch.nn.Module):
+    def __init__(
+        self,
+        in_features: int,
+        out_features: int,
+        weights_quant_scheme: FP8QuantizationScheme,
+        input_activations_quant_scheme: FP8QuantizationScheme,
+        bias: bool = False,
+    ):
+        super().__init__()
+        self.weights_quantization_scheme = weights_quant_scheme
+        self.input_activations_quantization_scheme = input_activations_quant_scheme
+        self.in_features = in_features
+        self.out_features = out_features
+
+        self.register_buffer(
+            "weight",
+            torch.empty(
+                (out_features, in_features), dtype=FP8_DTYPE
+            ),  # This is fixed for now and only e4m3fn quantization is prominent
+        )
+
+        if self.weights_quantization_scheme.dynamic:
+            raise NotImplementedError(
+                f"Expected statically quantized weights but got weights quantization scheme dynamic = {self.weights_quantization_scheme.dynamic}"
+            )
+
+        if self.weights_quantization_scheme.strategy == "tensor":
+            self.register_buffer("weight_scale", torch.zeros((1), dtype=torch.float32))
+        elif self.weights_quantization_scheme.strategy == "channel":
+            self.register_buffer("weight_scale", torch.zeros((out_features, 1), dtype=torch.float32))
+        else:
+            raise NotImplementedError(
+                f"Unknown weights quantization strategy {self.weights_quantization_scheme.strategy}, ['channel' or 'tensor'] strategy supported."
+            )
+
+        if not self.input_activations_quantization_scheme.dynamic:
+            if self.input_activations_quantization_scheme.strategy == "tensor":
+                self.register_buffer("input_scale", torch.zeros((1), dtype=torch.float32))
+            elif self.input_activations_quant_scheme.strategy == "token":
+                self.register_buffer("input_scale", torch.zeros((1, in_features), dtype=torch.float32))
+            else:
+                raise NotImplementedError(
+                    f"Unknown input activations quantization strategy {self.input_activations_quantization_scheme.strategy}, ['token' or 'tensor'] strategy supported."
+                )
+
+        if bias:
+            self.register_buffer(
+                "bias",
+                torch.zeros(
+                    (out_features),
+                    dtype=torch.float16,
+                ),
+            )
+        else:
+            self.bias = None
+
+    def forward(self, x):
+        # Only inference supported
+        with torch.no_grad():
+            dequantized_weights = self.weight.to(torch.float32) * self.weight_scale
+            out = torch.matmul(x.float(), dequantized_weights.T)
+            out = out + self.bias if self.bias is not None else out
+
+        return out
+
+
+class QEffCompressedTensorsConfig(CompressedTensorsConfig):
+    def __init__(
+        self,
+        config_groups=None,
+        format="dense",
+        quantization_status="initialized",
+        kv_cache_scheme=None,
+        global_compression_ratio=None,
+        ignore=None,
+        sparsity_config=None,
+        quant_method="compressed-tensors",
+        **kwargs,
+    ):
+        self.config_groups = config_groups
+        self.quant_method = quant_method
+        self.kv_cache_scheme = kv_cache_scheme
+        self.format = format
+        self.quantization_status = quantization_status
+        self.global_compression_ratio = global_compression_ratio
+        self.ignore = ignore
+
+        # Validate configuration
+        if len(self.config_groups) != 1:
+            raise NotImplementedError(
+                "Currently only single quantization group is supported, please raise an issue with model details for support!"
+            )
+
+        if quantization_status != "frozen":
+            raise NotImplementedError(f"expected quantization_status=`frozen`, got {quantization_status}")
+
+        if kv_cache_scheme:
+            raise NotImplementedError(f"Expected kv_cache_scheme=None, got {kv_cache_scheme}")
+
+        if format != "naive-quantized":
+            raise NotImplementedError(f"Expected quantization format =`naive_quantized` got {format}")
+
+        if sparsity_config:
+            raise NotImplementedError(f"Expected sparsity_config to be None, got {sparsity_config}")
+
+        if quant_method != "compressed-tensors":
+            raise NotImplementedError("Only compressed-tensors quant_method is supported for now!")
+
+        group_0 = self.config_groups.get("group_0")
+        activations_quantization_config = group_0.get("input_activations")
+        weights_quantization_config = group_0.get("weights")
+        output_activation_quantization_config = group_0.get("output_activations")
+        self.targets = group_0.get("targets")
+
+        if self.targets != ["Linear"]:
+            raise NotImplementedError(f"Only linear targets are supported, got {self.targets}")
+
+        if output_activation_quantization_config:
+            raise NotImplementedError(
+                f"output_activations quantization is not supported got {output_activation_quantization_config}"
+            )
+
+        if (
+            activations_quantization_config.get("block_structure")
+            or activations_quantization_config.get("group_size")
+            or weights_quantization_config.get("block_structure")
+            or weights_quantization_config.get("group_size")
+        ):
+            raise NotImplementedError(f"group_size and block_structure not supported got {group_0}")
+
+        self.weights_quantization_scheme = FP8QuantizationScheme(
+            weights_quantization_config.get("dynamic"),
+            weights_quantization_config.get("num_bits"),
+            weights_quantization_config.get("strategy"),
+            weights_quantization_config.get("symmetric"),
+            weights_quantization_config.get("type"),
+        )
+        self.input_activations_quantization_scheme = FP8QuantizationScheme(
+            activations_quantization_config.get("dynamic"),
+            activations_quantization_config.get("num_bits"),
+            activations_quantization_config.get("strategy"),
+            activations_quantization_config.get("symmetric"),
+            activations_quantization_config.get("type"),
+        )
+
+        self.quant_method = QuantizationMethod.COMPRESSED_TENSORS
+
+    def to_dict(self):
+        return {
+            "quantization_config": {
+                "config_groups": self.config_groups,
+                "weights_quantization_scheme": self.weights_quantization_scheme.__dict__,
+                "activations_quantization_scheme": self.input_activations_quantization_scheme.__dict__,
+                "quant_method": self.quant_method,
+                "kv_cache_scheme": self.kv_cache_scheme,
+                "format": self.format,
+                "quantization_status": self.quantization_status,
+                "global_compression_ratio": self.global_compression_ratio,
+                "ignore": self.ignore,
+                "targets": self.targets,
+            },
+            "sparsity_config": None,
+        }
+
+
+class QEffFP8Quantizer(CompressedTensorsHfQuantizer):
+    requires_calibration = False
+
+    def __init__(self, quantization_config, **kwargs):
+        # TODO: check if more checks are required
+        if not isinstance(quantization_config, QEffCompressedTensorsConfig):
+            raise TypeError(
+                f"Only {QEffCompressedTensorsConfig} is supported for initialization got {type(quantization_config)}"
+            )
+
+        self.quantization_config = quantization_config
+
+        # -- Handle extra kwargs below --
+        self.modules_to_not_convert = kwargs.pop("modules_to_not_convert", [])
+        self.pre_quantized = kwargs.pop("pre_quantized", True)
+
+        if not self.pre_quantized and self.requires_calibration:
+            raise ValueError(
+                f"The quantization method {quantization_config.quant_method} does require the model to be pre-quantized."
+                f" You explicitly passed `pre_quantized=False` meaning your model weights are not quantized. Make sure to "
+                f"pass `pre_quantized=True` while knowing what you are doing."
+            )
+
+    def validate_environment(self, *args, **kwargs):
+        return True
+
+    def update_torch_dtype(self, torch_dtype):
+        if torch_dtype not in [None, torch.float32]:
+            logger.warning(f"Requested dtype {torch_dtype} is not supported, overriding to None")
+        return None
+
+    def _process_model_before_weight_loading(self, model, **kwargs):
+        if self.quantization_config.targets != ["Linear"]:
+            raise NotImplementedError(
+                f"Only Linear layer with FP8 quantization are supported got targets = {self.quantization_config.targets}"
+            )
+
+        # -- Defining local method as it uses lot of local variables --
+        def replace_linear_layer_with_compressed_fp8_layer(module):
+            for name, child_module in module.named_children():
+                if isinstance(child_module, torch.nn.Linear) and name not in self.quantization_config.ignore:
+                    compressed_fp8_layer = CompressedFP8Linear(
+                        child_module.in_features,
+                        child_module.out_features,
+                        self.quantization_config.weights_quantization_scheme,
+                        self.quantization_config.input_activations_quantization_scheme,
+                        child_module.bias,
+                    )
+                    setattr(module, name, compressed_fp8_layer)
+                else:
+                    replace_linear_layer_with_compressed_fp8_layer(child_module)
+
+        replace_linear_layer_with_compressed_fp8_layer(model)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ---
 
 *Latest news* :fire: <br>
-
+- [01/2025] [FP8 models support](https://huggingface.co/collections/neuralmagic/fp8-llms-for-vllm-666742ed2b78b7ac8df13127) Added support for inference of FP8 models.
 - [11/2024] [finite adapters support](https://github.com/quic/efficient-transformers/pull/153) allows mixed adapter usage for peft models.
 - [11/2024] [Speculative decoding TLM](https://github.com/quic/efficient-transformers/pull/119) QEFFAutoModelForCausalLM model can be compiled for returning more than 1 logits during decode for TLM.
 - [11/2024] Added support for [Meta-Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct), [Meta-Llama-3.2-1B](https://huggingface.co/meta-llama/Llama-3.2-1B) and [Meta-Llama-3.2-3B](https://huggingface.co/meta-llama/Llama-3.2-3B)

--- a/tests/transformers/models/test_causal_lm_models.py
+++ b/tests/transformers/models/test_causal_lm_models.py
@@ -38,6 +38,7 @@ test_models = [
     "TheBloke/TinyLlama-1.1B-Chat-v0.3-AWQ",  # AWQ model
     "TheBloke/Llama-2-7B-GPTQ",  # GPTQ model
     "ibm-granite/granite-20b-code-base",
+    "neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",  # FP8 model
 ]
 
 spd_test_models = [

--- a/tests/transformers/models/test_causal_lm_models.py
+++ b/tests/transformers/models/test_causal_lm_models.py
@@ -38,7 +38,9 @@ test_models = [
     "TheBloke/TinyLlama-1.1B-Chat-v0.3-AWQ",  # AWQ model
     "TheBloke/Llama-2-7B-GPTQ",  # GPTQ model
     "ibm-granite/granite-20b-code-base",
-    "neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",  # FP8 model
+    # "neuralmagic/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",  # naive-quantized compressed-tensor FP8 model per-channel weight, per-token activations
+    "neuralmagic/Llama-3.2-3B-Instruct-FP8",  # float quantized compressed-tensor per tensor both weight and activations
+    "neuralmagic/Qwen2-0.5B-Instruct-FP8",  # fp8 quant method, static, with lm head ignored
 ]
 
 spd_test_models = [


### PR DESCRIPTION
This PR enables support for FP8 models by dequantizing the `FP8` values to `float32` and later these can be compressed to `mxfp6` with `Cloud AI 100 Apps SDK`.

* Added Quantizer for loading FP8 weights from transformers
* Added CompressedTensorsFP8Linear method for executing fp8 linear layer
* Added Compressed layer to linear layer transform