### PR TITLE
Add prompt_to_lora_id_mapping adjustment in fix_prompts() (for release/v1.19)

### DIFF
--- a/QEfficient/cloud/finetune.py
+++ b/QEfficient/cloud/finetune.py
@@ -30,6 +30,7 @@ from QEfficient.finetune.utils.dataset_utils import (
     get_preprocessed_dataset,
 )
 from QEfficient.finetune.utils.train_utils import get_longest_seq_length, print_model_size, train
+from QEfficient.utils._utils import login_and_download_hf_lm
 
 try:
     import torch_qaic  # noqa: F401
@@ -76,8 +77,9 @@ def main(**kwargs):
 
     # Load the pre-trained model and setup its configuration
     # config = AutoConfig.from_pretrained(train_config.model_name)
+    pretrained_model_path = login_and_download_hf_lm(train_config.model_name)
     model = AutoModelForCausalLM.from_pretrained(
-        train_config.model_name,
+        pretrained_model_path,
         use_cache=False,
         attn_implementation="sdpa",
         torch_dtype=torch.float16,

--- a/docs/source/validate.md
+++ b/docs/source/validate.md
@@ -17,6 +17,8 @@
 | [Gemma-2-2b](https://huggingface.co/google/gemma-2-2b) |✔️ |
 | [Gemma-2-9b](https://huggingface.co/google/gemma-2-9b) |✔️ |
 | [Gemma-2-27b](https://huggingface.co/google/gemma-2-27b) |✔️ |
+| [Granite-20b-code-base](https://huggingface.co/ibm-granite/granite-20b-code-base-8k) | ✔️ |
+| [Granite-20b-code-instruct-8k](https://huggingface.co/ibm-granite/granite-20b-code-instruct-8k) | ✔️ |
 | [Jais-adapted-7b](https://huggingface.co/inceptionai/jais-adapted-7b) |✔️ |
 | [Jais-adapted-13b-chat](https://huggingface.co/inceptionai/jais-adapted-13b-chat) |✔️ |
 | [Jais-adapted-70b](https://huggingface.co/inceptionai/jais-adapted-70b) |✔️ |

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -90,6 +90,7 @@ pipeline {
                     cd /efficient-transformers &&
                     . preflight_qeff/bin/activate &&
                     mkdir -p $PWD/Qnn_cli &&
+                    pip install rich &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_cli &&
                     pytest tests -m '(cli and qnn)' --junitxml=tests/tests_log4.xml &&
@@ -107,6 +108,7 @@ pipeline {
                     source /qnn_sdk/bin/envcheck -c &&
                     cd /efficient-transformers &&
                     . preflight_qeff/bin/activate &&
+                    pip install rich &&
                     mkdir -p $PWD/Qnn_non_cli &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_non_cli &&


### PR DESCRIPTION
Same as PR#242 but for release/v1.19

Regarding issue raised in JIRA: https://jira-dc.qualcomm.com/jira/browse/QRANIUMSW-52111

The finite lorax feature failed to execute when the number of prompts provided is less than the full batch size. The solution involves applying the same adjustment strategy for `prompt_to_lora_id_mapping` as used for `prompt` in the `fix_prompts()` function located in `QEfficient/generation/text_generation_inference.py`.