### PR TITLE
[QEff. Finetune] Stop fine tuning when loss has converged

### DIFF
--- a/QEfficient/finetune/configs/training.py
+++ b/QEfficient/finetune/configs/training.py
@@ -39,6 +39,10 @@ class train_config:
     intermediate_step_save: int = 1000
     batching_strategy: str = "packing"
     enable_sorting_for_ddp: bool = True
+    convergence_counter: int = 5  # its value should be >= 1, stop fine tuning when loss <= convergence_loss (defined below) for #convergence_counter steps
+    convergence_loss: float = (
+        1e-4  # if loss value is <= convergence_loss for #convergence_counter consecutive steps, fine tuning stops
+    )
 
     # TODO: vbaddi: Uncomment post adding qaic to Pytorch Profiler
     # flop_counter: bool = False # Enable flop counter to measure model throughput, can not be used with pytorch profiler at the same time.

--- a/QEfficient/finetune/utils/train_utils.py
+++ b/QEfficient/finetune/utils/train_utils.py
@@ -94,8 +94,24 @@ def train(
     if train_config.grad_scaler:
         scaler = GradScaler()
 
+    loss_0_counter = torch.tensor([0]).to(device)
+
+    if train_config.enable_ddp:
+        dist.broadcast(loss_0_counter, src=0)
+
     # Start the training loop
     for epoch in range(train_config.num_epochs):
+        if loss_0_counter.item() == train_config.convergence_counter:
+            if train_config.enable_ddp:
+                print(
+                    f"Not proceeding with epoch {epoch + 1} on device {local_rank} since loss value has been <= {train_config.convergence_loss} for last {loss_0_counter.item()} steps."
+                )
+                break
+            else:
+                print(
+                    f"Not proceeding with epoch {epoch + 1} since loss value has been <= {train_config.convergence_loss}  for last {loss_0_counter.item()} steps."
+                )
+                break
         print(f"Starting epoch {epoch + 1}/{train_config.num_epochs}")
         print(f"train_config.max_train_step: {train_config.max_train_step}")
         # stop when the maximum number of training steps is reached
@@ -148,6 +164,18 @@ def train(
             total_loss += loss.detach().float()
             # Accumalate graidents
             loss = loss / train_config.gradient_accumulation_steps
+            if train_config.enable_ddp:
+                if local_rank == 0:
+                    if loss <= train_config.convergence_loss:
+                        loss_0_counter += 1
+                    else:
+                        loss_0_counter = torch.tensor([0]).to(device)
+                dist.broadcast(loss_0_counter, src=0)
+            else:
+                if loss <= train_config.convergence_loss:
+                    loss_0_counter += 1
+                else:
+                    loss_0_counter = torch.tensor([0]).to(device)
 
             if train_config.enable_ddp:
                 if local_rank == 0:
@@ -197,12 +225,27 @@ def train(
                     val_step_perplexity,
                     val_prep,
                 )
+            if train_config.enable_ddp:
+                if loss_0_counter.item() == train_config.convergence_counter:
+                    print(
+                        f"Loss value has been <= {train_config.convergence_loss} for last {loss_0_counter.item()} steps. Hence, stopping the fine tuning on device {local_rank}."
+                    )
+                    break
+            else:
+                if loss_0_counter.item() == train_config.convergence_counter:
+                    print(
+                        f"Loss value has been  <= {train_config.convergence_loss}  for last {loss_0_counter.item()} steps. Hence, stopping the fine tuning."
+                    )
+                    break
 
         pbar.close()
         epoch_end_time = time.perf_counter() - epoch_start_time
         epoch_times.append(epoch_end_time)
 
-        train_epoch_loss = total_loss / len(train_dataloader)
+        if loss_0_counter.item() == train_config.convergence_counter:
+            train_epoch_loss = total_loss / step
+        else:
+            train_epoch_loss = total_loss / len(train_dataloader)
         train_perplexity = torch.exp(train_epoch_loss)
 
         train_prep.append(float(train_perplexity))

--- a/docs/source/finetune.md
+++ b/docs/source/finetune.md
@@ -34,7 +34,7 @@ To download the Alpaca dataset, visit this [link](https://raw.githubusercontent.
 wget -c https://raw.githubusercontent.com/tatsu-lab/stanford_alpaca/refs/heads/main/alpaca_data.json -P dataset/
 ```
 
-To download the grammar dataset, visit this [link](https://github.com/meta-llama/llama-recipes/blob/main/src/llama_recipes/datasets/grammar_dataset/grammar_dataset_process.ipynb). Download the dataset and place it under the **datasets_grammar** directory. Make sure to update the training configuration accordingly.
+To download the grammar dataset, visit this [link](https://github.com/meta-llama/llama-cookbook/blob/main/src/llama_cookbook/datasets/grammar_dataset/grammar_dataset_process.ipynb). Download the dataset and place it under the **datasets_grammar** directory. Make sure to update the training configuration accordingly.
 
 
 ## Usage


### PR DESCRIPTION
Fine tuning will stop once the loss becomes close to convergence_loss (whose default value is <=1e-4) for few consecutive iterations, i.e., convergence_counter (by default 5).
Corrected the url of grammar dataset in finetune.md. 