### PR TITLE
HOTFIX/compiler arguments fix for VLM

### DIFF
--- a/QEfficient/transformers/models/internvl/modeling_internvl.py
+++ b/QEfficient/transformers/models/internvl/modeling_internvl.py
@@ -34,7 +34,7 @@ class QEffInternVLModel(nn.Module):
             img_size = 448
             logger.warning("Setting img_size to be 448, as it was neither passed nor found in vision_config")
 
-        return [
+        specializations = [
             {
                 "batch_size": batch_size,
                 "seq_len": prefill_seq_len,
@@ -49,7 +49,8 @@ class QEffInternVLModel(nn.Module):
                 "num_patches": num_patches,
                 "img_size": img_size,
             },
-        ], compiler_options
+        ]
+        return specializations, compiler_options
 
     def get_onnx_dynamic_axes(
         self,

--- a/QEfficient/transformers/models/internvl/modeling_internvl.py
+++ b/QEfficient/transformers/models/internvl/modeling_internvl.py
@@ -49,7 +49,7 @@ class QEffInternVLModel(nn.Module):
                 "num_patches": num_patches,
                 "img_size": img_size,
             },
-        ]
+        ], compiler_options
 
     def get_onnx_dynamic_axes(
         self,

--- a/QEfficient/transformers/models/llava/modeling_llava.py
+++ b/QEfficient/transformers/models/llava/modeling_llava.py
@@ -87,7 +87,7 @@ class QEffLlavaForConditionalGeneration(LlavaForConditionalGeneration):
             img_size = 336
             logger.warning("Setting img_size to be 336, as it was neither passed nor found in vision_config")
 
-        return [
+        specializations = [
             {
                 "batch_size": batch_size,
                 "seq_len": prefill_seq_len,
@@ -102,7 +102,8 @@ class QEffLlavaForConditionalGeneration(LlavaForConditionalGeneration):
                 "max_num_images": max_num_images,
                 "img_size": img_size,
             },
-        ], compiler_options
+        ]
+        return specializations, compiler_options
 
     def get_onnx_dynamic_axes(
         self,

--- a/QEfficient/transformers/models/llava/modeling_llava.py
+++ b/QEfficient/transformers/models/llava/modeling_llava.py
@@ -102,7 +102,7 @@ class QEffLlavaForConditionalGeneration(LlavaForConditionalGeneration):
                 "max_num_images": max_num_images,
                 "img_size": img_size,
             },
-        ]
+        ], compiler_options
 
     def get_onnx_dynamic_axes(
         self,

--- a/QEfficient/transformers/models/mllama/modeling_mllama.py
+++ b/QEfficient/transformers/models/mllama/modeling_mllama.py
@@ -1228,9 +1228,9 @@ class QEffMllamaForConditionalGeneration(MllamaForConditionalGeneration):
         if kv_offload:
             specializations["vision"] = vision
             specializations["lang"] = lang
-            return specializations
+            return specializations, compiler_options
         else:
-            return lang
+            return lang, compiler_options
 
     def get_onnx_dynamic_axes(self, kv_offload: bool = False):
         txt_cfg = self.config.get_text_config()

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -420,7 +420,6 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
 
     def __init__(self, model):
         super().__init__(model)
-        # self.model.config.text_config.use_cache=True
 
     def export(self, inputs, output_names, dynamic_axes, export_dir=None):
         return self._export(inputs, output_names, dynamic_axes, export_dir)
@@ -567,7 +566,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
 
         output_names = self.model.get_output_names(kv_offload=True)
 
-        specializations = self.model.get_specializations(
+        specializations, compiler_options = self.model.get_specializations(
             batch_size=batch_size,
             prefill_seq_len=prefill_seq_len,
             ctx_len=ctx_len,

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -532,7 +532,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
 
     def compile(
         self,
-        img_size: int,
+        img_size: Optional[int] = None,
         vision_onnx_path: Optional[str] = None,
         lang_onnx_path: Optional[str] = None,
         compile_dir: Optional[str] = None,
@@ -891,7 +891,7 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase):
 
         # Get specializations from modelling file
         # TODO: expose this via the auto class as well
-        specializations = self.model.get_specializations(
+        specializations, compiler_options = self.model.get_specializations(
             batch_size=batch_size,
             prefill_seq_len=prefill_seq_len,
             ctx_len=ctx_len,


### PR DESCRIPTION
Hotfix - compiler arguments fix for VLM

As we are popping few arguments of the compiler option inside function `get_specializations` and by default `**compiler_options` is passed by value not reference, so to handle this we are returning the updated `compiler_options` from the `get_specializations`.