### PR TITLE
upgrading from yanked version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.8,<3.11"
 dependencies = [
-    "transformers==4.46.0",
+    "transformers==4.46.3",
     "huggingface-hub==0.27.0",
     "peft==0.13.2",
     "datasets==2.20.0",


### PR DESCRIPTION
https://pypi.org/project/transformers/#history 
Looking at above. Upgrading to `4.46.3` seems like a good choice.
Upgrading to 4.47 might break few things, as they are upgrading KV cache format in that version.