### PR TITLE
Remove SplitTensorsTransform while enabling qnn in Qeff

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional
 import onnx
 import torch
 
-from QEfficient.base.onnx_transforms import OnnxTransform
+from QEfficient.base.onnx_transforms import OnnxTransform, SplitTensorsTransform
 from QEfficient.base.pytorch_transforms import PytorchTransform
 from QEfficient.compile.qnn_compiler import compile as qnn_compile
 from QEfficient.generation.cloud_infer import QAICInferenceSession
@@ -191,7 +191,8 @@ class QEFFBaseModel(ABC):
                 transform_kwargs.update(onnx_transform_kwargs)
 
             for transform in self._onnx_transforms:
-                model, transformed = transform.apply(model, **transform_kwargs)
+                if not (self.enable_qnn and transform == SplitTensorsTransform):
+                    model, transformed = transform.apply(model, **transform_kwargs)
             model.metadata_props.append(
                 onnx.StringStringEntryProto(key="qeff_transforms", value=",".join(self._transform_names()))
             )

--- a/tests/qnn_tests/test_causal_lm_models_qnn.py
+++ b/tests/qnn_tests/test_causal_lm_models_qnn.py
@@ -82,7 +82,7 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
 
     pytorch_hf_tokens = api_runner.run_hf_model_on_pytorch(model_hf)
 
-    qeff_model = QEFFAutoModelForCausalLM(model_hf)
+    qeff_model = QEFFAutoModelForCausalLM(model_hf, enable_qnn=True)
 
     pytorch_kv_tokens = api_runner.run_kv_model_on_pytorch(qeff_model.model)
 
@@ -130,7 +130,7 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
     pytorch_hf_tokens = api_runner.run_hf_model_on_pytorch_CB(model_hf)
     pytorch_hf_tokens = np.vstack(pytorch_hf_tokens)
 
-    qeff_model = QEFFAutoModelForCausalLM(model_hf, continuous_batching=True)
+    qeff_model = QEFFAutoModelForCausalLM(model_hf, continuous_batching=True, enable_qnn=True)
     onnx_model_path = qeff_model.export()
 
     if not get_available_device_id():

--- a/tests/transformers/models/test_prefix_caching.py
+++ b/tests/transformers/models/test_prefix_caching.py
@@ -37,7 +37,7 @@ def test_simple_prefix_caching(model_name):
 @pytest.mark.qnn
 @pytest.mark.parametrize("model_name", test_models)
 def test_simple_prefix_caching_qnn(model_name):
-    qeff_model = QEFFAutoModelForCausalLM.from_pretrained(model_name, continuous_batching=True)
+    qeff_model = QEFFAutoModelForCausalLM.from_pretrained(model_name, continuous_batching=True, enable_qnn=True)
     qnn_config = {
         "convertor_args_extension": "",
         "context_binary_generator_args_extension": "--log_level debug",


### PR DESCRIPTION
Bypassing SplitTensorsTransform when enable_qnn is set for QEFFAutoModelForCausalLM.