### PR TITLE
Removed onnx_defer_loading flag

### DIFF
--- a/QEfficient/utils/constants.py
+++ b/QEfficient/utils/constants.py
@@ -136,7 +136,6 @@ class QnnConstants:
         "--float_bitwidth ",
         "--preserve_io_datatype",
         "--onnx_skip_simplification",
-        "--onnx_defer_loading",
     ]
 
     IMMUTABLE_CONTEXT_BIN_GEN_ARGS = [


### PR DESCRIPTION
Removing onnx_defer_loading flag which was originally removed in _[Removed onnx_defer_loading from Immutable Convertor Args. PR: 230]_ but got added back later in _[Mllama(single + dual) + InternVL(single) + Llava (single) PR: 267]_ maybe becausing of rebasing.

