### PR TITLE
[Bug-Fix :] QEFFAutoModelForCausalLM __repr__() Method Fixed

### DIFF
--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1325,7 +1325,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         return mname
 
     def __repr__(self) -> str:
-        return self.__class__.__name__ + "\n" + self.model.__repr__
+        return self.__class__.__name__ + "\n" + self.model.__repr__()
 
     @classmethod
     @with_replaced_quantizers


### PR DESCRIPTION
This is just small fixes done for printing the `QEFFAutoModelForCausalLM`'s instance by changing the `__repr__(self)` method.