### PR TITLE
Enabling VLLM test 

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                 steps
                 {
                     build job: 'qefficient_vllm_upstream', 
-                    parameters: [string(name: 'qeff_container', value: "${BUILD_TAG}")],
+                    parameters: [string(name: 'NAME', value: "${BUILD_TAG}")],
                     propagate: true
                 }
         }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -83,43 +83,43 @@ pipeline {
                        }
                    }
         }
-        stage('QNN CLI Tests') {
-            steps {
-                timeout(time: 30, unit: 'MINUTES') {
-                    sh '''
-                    sudo docker exec ${BUILD_TAG} bash -c "
-                    source /qnn_sdk/bin/envsetup.sh &&
-                    source /qnn_sdk/bin/envcheck -c &&
-                    cd /efficient-transformers &&
-                    . preflight_qeff/bin/activate &&
-                    mkdir -p $PWD/Qnn_cli &&
-                    export TOKENIZERS_PARALLELISM=false &&
-                    export QEFF_HOME=$PWD/Qnn_cli &&
-                    pytest tests -m '(cli and qnn)' --ignore tests/vllm --junitxml=tests/tests_log4.xml &&
-                    deactivate"
-                    '''
-                }
-            }
-        }
-        stage('QNN Non-CLI Tests') {
-            steps {
-                timeout(time: 60, unit: 'MINUTES') {
-                    sh '''
-                    sudo docker exec ${BUILD_TAG} bash -c "
-                    source /qnn_sdk/bin/envsetup.sh &&
-                    source /qnn_sdk/bin/envcheck -c &&
-                    cd /efficient-transformers &&
-                    . preflight_qeff/bin/activate &&
-                    mkdir -p $PWD/Qnn_non_cli &&
-                    export TOKENIZERS_PARALLELISM=false &&
-                    export QEFF_HOME=$PWD/Qnn_non_cli &&
-                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --ignore tests/vllm --junitxml=tests/tests_log5.xml &&
-                    junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
-                    deactivate"
-                    '''
-                }
-            }
-        }
+        // stage('QNN CLI Tests') {
+        //     steps {
+        //         timeout(time: 30, unit: 'MINUTES') {
+        //             sh '''
+        //             sudo docker exec ${BUILD_TAG} bash -c "
+        //             source /qnn_sdk/bin/envsetup.sh &&
+        //             source /qnn_sdk/bin/envcheck -c &&
+        //             cd /efficient-transformers &&
+        //             . preflight_qeff/bin/activate &&
+        //             mkdir -p $PWD/Qnn_cli &&
+        //             export TOKENIZERS_PARALLELISM=false &&
+        //             export QEFF_HOME=$PWD/Qnn_cli &&
+        //             pytest tests -m '(cli and qnn)' --ignore tests/vllm --junitxml=tests/tests_log4.xml &&
+        //             deactivate"
+        //             '''
+        //         }
+        //     }
+        // }
+        // stage('QNN Non-CLI Tests') {
+        //     steps {
+        //         timeout(time: 60, unit: 'MINUTES') {
+        //             sh '''
+        //             sudo docker exec ${BUILD_TAG} bash -c "
+        //             source /qnn_sdk/bin/envsetup.sh &&
+        //             source /qnn_sdk/bin/envcheck -c &&
+        //             cd /efficient-transformers &&
+        //             . preflight_qeff/bin/activate &&
+        //             mkdir -p $PWD/Qnn_non_cli &&
+        //             export TOKENIZERS_PARALLELISM=false &&
+        //             export QEFF_HOME=$PWD/Qnn_non_cli &&
+        //             pytest tests -m '(not cli) and (qnn) and (on_qaic)' --ignore tests/vllm --junitxml=tests/tests_log5.xml &&
+        //             junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
+        //             deactivate"
+        //             '''
+        //         }
+        //     }
+        // }
       stage('vLLM Test')
             {
 

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
                            mkdir -p $PWD/Non_qaic &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/Non_qaic &&
-                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' --ignore tests/vllm -n 5 --junitxml=tests/tests_log2.xml &&
+                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' --ignore tests/vllm -n 4 --junitxml=tests/tests_log2.xml &&
                            deactivate"
                            '''
                        }
@@ -77,7 +77,7 @@ pipeline {
                            mkdir -p $PWD/cli &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/cli &&
-                           pytest tests -m '(cli and not qnn)' --ignore tests/vllm -n 5 --junitxml=tests/tests_log3.xml &&
+                           pytest tests -m '(cli and not qnn)' --ignore tests/vllm --junitxml=tests/tests_log3.xml &&
                            deactivate"
                            '''
                        }
@@ -105,7 +105,7 @@ pipeline {
                     mkdir -p $PWD/Qnn_cli &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_cli &&
-                    pytest tests -m '(cli and qnn)' --ignore tests/vllm -n 5 --junitxml=tests/tests_log4.xml &&
+                    pytest tests -m '(cli and qnn)' --ignore tests/vllm --junitxml=tests/tests_log4.xml &&
                     deactivate"
                     '''
                 }
@@ -123,14 +123,13 @@ pipeline {
                     mkdir -p $PWD/Qnn_non_cli &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_non_cli &&
-                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --ignore tests/vllm -n 5 --junitxml=tests/tests_log5.xml &&
+                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --ignore tests/vllm --junitxml=tests/tests_log5.xml &&
                     junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
                     deactivate"
                     '''
                 }
             }
         }
-      
     }
 
    post {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                            mkdir -p $PWD/Non_cli_qaic &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/Non_cli_qaic &&
-                           pytest tests -m '(not cli) and (not on_qaic) and (not vllm)' -n auto --junitxml=tests/tests_log1.xml &&
+                           pytest tests -m '(not cli) and (not on_qaic)' --ignore tests/vllm -n auto --junitxml=tests/tests_log1.xml &&
                            junitparser merge tests/tests_log1.xml tests/tests_log.xml &&
                            deactivate"
                            '''
@@ -58,7 +58,7 @@ pipeline {
                            mkdir -p $PWD/Non_qaic &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/Non_qaic &&
-                           pytest tests -m '(not cli) and (on_qaic) and (not qnn) and (not vllm)' -n 4 --junitxml=tests/tests_log2.xml &&
+                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' --ignore tests/vllm -n 4 --junitxml=tests/tests_log2.xml &&
                            junitparser merge tests/tests_log2.xml tests/tests_log.xml &&
                            deactivate"
                            '''
@@ -79,7 +79,7 @@ pipeline {
                            mkdir -p $PWD/cli &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/cli &&
-                           pytest tests -m '(cli) and (not qnn) and (not vllm)' --junitxml=tests/tests_log3.xml &&
+                           pytest tests -m '(cli and not qnn)' --ignore tests/vllm --junitxml=tests/tests_log3.xml &&
                            junitparser merge tests/tests_log3.xml tests/tests_log.xml &&
                            deactivate"
                            '''
@@ -108,7 +108,7 @@ pipeline {
                     mkdir -p $PWD/Qnn_cli &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_cli &&
-                    pytest tests -m '(cli and qnn)' and (not vllm) --junitxml=tests/tests_log4.xml &&
+                    pytest tests -m '(cli and qnn)' --ignore tests/vllm --junitxml=tests/tests_log4.xml &&
                     junitparser merge tests/tests_log4.xml tests/tests_log.xml &&
                     deactivate"
                     '''
@@ -127,7 +127,7 @@ pipeline {
                     mkdir -p $PWD/Qnn_non_cli &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_non_cli &&
-                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' and (not vllm) --junitxml=tests/tests_log5.xml &&
+                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --ignore tests/vllm --junitxml=tests/tests_log5.xml &&
                     junitparser merge tests/tests_log5.xml tests/tests_log.xml &&
                     deactivate"
                     '''

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                 steps
                 {
                     build job: 'qefficient_vllm_upstream', 
-                    parameters: [string(name: 'BUILD_TAG', value: "${BUILD_TAG}")],
+                    parameters: [string(name: 'qeff_container', value: "${BUILD_TAG}")],
                     propagate: true
                 }
         }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
    agent {
        node {
-           label 'qeff_node-63'
+           label 'qeff_node'
        }
    }
    options {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -16,14 +16,6 @@ pipeline {
                    sudo docker run --privileged -dit --name ${BUILD_TAG} -v ./:/efficient-transformers -v ${HF_PATH}:${DOCKER_HF_PATH} ${DOCKER_LATEST}:master_latest
                    sudo docker exec ${BUILD_TAG} bash -c "
                    cd /efficient-transformers &&
-                   apt update &&
-                   apt install -y python3.10-venv &&
-                   python3.10 -m venv preflight_qeff &&
-                   . preflight_qeff/bin/activate &&
-                   pip install --upgrade pip setuptools &&
-                   pip install .[test] &&
-                   pip install junitparser pytest-xdist &&
-                   pip install librosa==0.10.2 soundfile==0.13.1 && #packages needed to load example for whisper testing
                    rm -rf QEfficient"
                '''
            }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                 steps
                 {
                     build job: 'qefficient_vllm_upstream', 
-                    parameters: [string(name: 'NAME', value: "${BUILD_TAG}")],
+                    parameters: [string(name: 'NAME', value: "${param.BUILD_TAG}")],
                     propagate: true
                 }
         }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                 steps
                 {
                     build job: 'qefficient_vllm_upstream', 
-                    parameters: [string(name: 'NAME', value: "${param.BUILD_TAG}")],
+                    parameters: [string(name: 'NAME', value: "${BUILD_TAG}")],
                     propagate: true
                 }
         }
@@ -135,7 +135,7 @@ pipeline {
                    echo "Failed to delete container ${BUILD_TAG}: ${error}"
                }
            }
-           junit testResults: 'tests/tests_log.xml'
+        //    junit testResults: 'tests/tests_log.xml'
            echo 'Cleaning Workspace'
            deleteDir()
        }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -77,7 +77,7 @@ pipeline {
                            mkdir -p $PWD/cli &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/cli &&
-                           pytest tests -m '(cli and not qnn)' --ignore tests/vllm -n 5--junitxml=tests/tests_log3.xml &&
+                           pytest tests -m '(cli and not qnn)' --ignore tests/vllm -n 5 --junitxml=tests/tests_log3.xml &&
                            deactivate"
                            '''
                        }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
    agent {
        node {
-           label 'qeff_node'
+           label 'qeff_node-63'
        }
    }
    options {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -28,6 +28,7 @@ pipeline {
                '''
            }
        }
+
        stage('Non CLI Tests') {
            parallel {
                stage('Run Non-CLI Non-QAIC Tests') {
@@ -126,7 +127,8 @@ pipeline {
                 {
                     build job: 'qefficient_vllm_upstream', 
                     parameters: [string(name: 'NAME', value: "${BUILD_TAG}")],
-                    propagate: true
+                    propagate: true,
+                    wait: true
                 }
         }
     }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -127,6 +127,7 @@ pipeline {
             timeout(time: 660, unit: 'MINUTES') {
                     sh '''
                     sudo docker exec ${BUILD_TAG} bash -c "
+                    cd /efficient-transformers &&
                     . preflight_qeff/bin/activate &&
                     pytest --disable-warnings -s -v tests/vllm --junitxml=tests/tests_log4.xml &&
                     junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log.xml &&

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -121,20 +121,13 @@ pipeline {
     //     }
         stage('vLLM Test')
             {
+
                 steps
                 {
-
-            timeout(time: 660, unit: 'MINUTES') {
-                    sh '''
-                    sudo docker exec ${BUILD_TAG} bash -c "
-                    cd /efficient-transformers &&
-                    . preflight_qeff/bin/activate &&
-                    pytest --disable-warnings -s -v tests/vllm --junitxml=tests/tests_log4.xml &&
-                    junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log.xml &&
-                    deactivate"
-                    '''     
+                    build job: 'qefficient_vllm_upstream', 
+                    parameters: [string(name: 'BUILD_TAG', value: "${BUILD_TAG}")],
+                    propagate: true
                 }
-            }
         }
     }
 

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -120,6 +120,16 @@ pipeline {
     //             }
     //         }
     //     }
+      stage('vLLM Test')
+            {
+
+                steps
+                {
+                    build job: 'qefficient_vllm_upstream', 
+                    parameters: [string(name: 'NAME', value: "${BUILD_TAG}")],
+                    propagate: true
+                }
+        }
     }
 
    post {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -41,7 +41,8 @@ pipeline {
                            mkdir -p $PWD/Non_cli_qaic &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/Non_cli_qaic &&
-                           pytest tests -m '(not cli) and (not on_qaic)' --ignore tests/vllm -n auto --junitxml=tests/tests_log1.xml &&
+                           pytest tests -m '(not cli) and (not on_qaic) and (not vllm)' -n auto --junitxml=tests/tests_log1.xml &&
+                           junitparser merge tests/tests_log1.xml tests/tests_log.xml &&
                            deactivate"
                            '''
                        }
@@ -57,7 +58,8 @@ pipeline {
                            mkdir -p $PWD/Non_qaic &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/Non_qaic &&
-                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' --ignore tests/vllm -n 4 --junitxml=tests/tests_log2.xml &&
+                           pytest tests -m '(not cli) and (on_qaic) and (not qnn) and (not vllm)' -n 4 --junitxml=tests/tests_log2.xml &&
+                           junitparser merge tests/tests_log2.xml tests/tests_log.xml &&
                            deactivate"
                            '''
                        }
@@ -77,7 +79,8 @@ pipeline {
                            mkdir -p $PWD/cli &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/cli &&
-                           pytest tests -m '(cli and not qnn)' --ignore tests/vllm --junitxml=tests/tests_log3.xml &&
+                           pytest tests -m '(cli) and (not qnn) and (not vllm)' --junitxml=tests/tests_log3.xml &&
+                           junitparser merge tests/tests_log3.xml tests/tests_log.xml &&
                            deactivate"
                            '''
                        }
@@ -105,7 +108,8 @@ pipeline {
                     mkdir -p $PWD/Qnn_cli &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_cli &&
-                    pytest tests -m '(cli and qnn)' --ignore tests/vllm --junitxml=tests/tests_log4.xml &&
+                    pytest tests -m '(cli and qnn)' and (not vllm) --junitxml=tests/tests_log4.xml &&
+                    junitparser merge tests/tests_log4.xml tests/tests_log.xml &&
                     deactivate"
                     '''
                 }
@@ -123,8 +127,8 @@ pipeline {
                     mkdir -p $PWD/Qnn_non_cli &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_non_cli &&
-                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --ignore tests/vllm --junitxml=tests/tests_log5.xml &&
-                    junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
+                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' and (not vllm) --junitxml=tests/tests_log5.xml &&
+                    junitparser merge tests/tests_log5.xml tests/tests_log.xml &&
                     deactivate"
                     '''
                 }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                            mkdir -p $PWD/Non_cli_qaic &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/Non_cli_qaic &&
-                           pytest tests -m '(not cli) and (not on_qaic)' -n auto --junitxml=tests/tests_log1.xml &&
+                           pytest tests -m '(not cli) and (not on_qaic)' --ignore tests/vllm -n auto --junitxml=tests/tests_log1.xml &&
                            deactivate"
                            '''
                        }
@@ -57,7 +57,7 @@ pipeline {
                            mkdir -p $PWD/Non_qaic &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/Non_qaic &&
-                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' -n 4 --junitxml=tests/tests_log2.xml &&
+                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' --ignore tests/vllm -n 4 --junitxml=tests/tests_log2.xml &&
                            deactivate"
                            '''
                        }
@@ -77,7 +77,7 @@ pipeline {
                            mkdir -p $PWD/cli &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/cli &&
-                           pytest tests -m '(cli and not qnn)' --junitxml=tests/tests_log3.xml &&
+                           pytest tests -m '(cli and not qnn)' --ignore tests/vllm --junitxml=tests/tests_log3.xml &&
                            deactivate"
                            '''
                        }
@@ -95,7 +95,7 @@ pipeline {
                     mkdir -p $PWD/Qnn_cli &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_cli &&
-                    pytest tests -m '(cli and qnn)' --junitxml=tests/tests_log4.xml &&
+                    pytest tests -m '(cli and qnn)' --ignore tests/vllm --junitxml=tests/tests_log4.xml &&
                     deactivate"
                     '''
                 }
@@ -113,7 +113,7 @@ pipeline {
                     mkdir -p $PWD/Qnn_non_cli &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Qnn_non_cli &&
-                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --junitxml=tests/tests_log5.xml &&
+                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --ignore tests/vllm --junitxml=tests/tests_log5.xml &&
                     junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
                     deactivate"
                     '''

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
                            mkdir -p $PWD/Non_qaic &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/Non_qaic &&
-                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' --ignore tests/vllm -n 4 --junitxml=tests/tests_log2.xml &&
+                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' --ignore tests/vllm -n 5 --junitxml=tests/tests_log2.xml &&
                            deactivate"
                            '''
                        }
@@ -77,51 +77,13 @@ pipeline {
                            mkdir -p $PWD/cli &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/cli &&
-                           pytest tests -m '(cli and not qnn)' --ignore tests/vllm --junitxml=tests/tests_log3.xml &&
+                           pytest tests -m '(cli and not qnn)' --ignore tests/vllm -n 5--junitxml=tests/tests_log3.xml &&
                            deactivate"
                            '''
                        }
                    }
         }
-        // stage('QNN CLI Tests') {
-        //     steps {
-        //         timeout(time: 30, unit: 'MINUTES') {
-        //             sh '''
-        //             sudo docker exec ${BUILD_TAG} bash -c "
-        //             source /qnn_sdk/bin/envsetup.sh &&
-        //             source /qnn_sdk/bin/envcheck -c &&
-        //             cd /efficient-transformers &&
-        //             . preflight_qeff/bin/activate &&
-        //             mkdir -p $PWD/Qnn_cli &&
-        //             export TOKENIZERS_PARALLELISM=false &&
-        //             export QEFF_HOME=$PWD/Qnn_cli &&
-        //             pytest tests -m '(cli and qnn)' --ignore tests/vllm --junitxml=tests/tests_log4.xml &&
-        //             deactivate"
-        //             '''
-        //         }
-        //     }
-        // }
-        // stage('QNN Non-CLI Tests') {
-        //     steps {
-        //         timeout(time: 60, unit: 'MINUTES') {
-        //             sh '''
-        //             sudo docker exec ${BUILD_TAG} bash -c "
-        //             source /qnn_sdk/bin/envsetup.sh &&
-        //             source /qnn_sdk/bin/envcheck -c &&
-        //             cd /efficient-transformers &&
-        //             . preflight_qeff/bin/activate &&
-        //             mkdir -p $PWD/Qnn_non_cli &&
-        //             export TOKENIZERS_PARALLELISM=false &&
-        //             export QEFF_HOME=$PWD/Qnn_non_cli &&
-        //             pytest tests -m '(not cli) and (qnn) and (on_qaic)' --ignore tests/vllm --junitxml=tests/tests_log5.xml &&
-        //             junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
-        //             deactivate"
-        //             '''
-        //         }
-        //     }
-        // }
-      stage('vLLM Test')
-            {
+        stage('vLLM Tests') {
 
                 steps
                 {
@@ -131,6 +93,44 @@ pipeline {
                     wait: true
                 }
         }
+        stage('QNN CLI Tests') {
+            steps {
+                timeout(time: 30, unit: 'MINUTES') {
+                    sh '''
+                    sudo docker exec ${BUILD_TAG} bash -c "
+                    source /qnn_sdk/bin/envsetup.sh &&
+                    source /qnn_sdk/bin/envcheck -c &&
+                    cd /efficient-transformers &&
+                    . preflight_qeff/bin/activate &&
+                    mkdir -p $PWD/Qnn_cli &&
+                    export TOKENIZERS_PARALLELISM=false &&
+                    export QEFF_HOME=$PWD/Qnn_cli &&
+                    pytest tests -m '(cli and qnn)' --ignore tests/vllm -n 5 --junitxml=tests/tests_log4.xml &&
+                    deactivate"
+                    '''
+                }
+            }
+        }
+        stage('QNN Non-CLI Tests') {
+            steps {
+                timeout(time: 60, unit: 'MINUTES') {
+                    sh '''
+                    sudo docker exec ${BUILD_TAG} bash -c "
+                    source /qnn_sdk/bin/envsetup.sh &&
+                    source /qnn_sdk/bin/envcheck -c &&
+                    cd /efficient-transformers &&
+                    . preflight_qeff/bin/activate &&
+                    mkdir -p $PWD/Qnn_non_cli &&
+                    export TOKENIZERS_PARALLELISM=false &&
+                    export QEFF_HOME=$PWD/Qnn_non_cli &&
+                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --ignore tests/vllm -n 5 --junitxml=tests/tests_log5.xml &&
+                    junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
+                    deactivate"
+                    '''
+                }
+            }
+        }
+      
     }
 
    post {

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -28,95 +28,110 @@ pipeline {
                '''
            }
        }
+    //    stage('Non CLI Tests') {
+    //        parallel {
+    //            stage('Run Non-CLI Non-QAIC Tests') {
+    //                steps {
+    //                    timeout(time: 25, unit: 'MINUTES') {
+    //                        sh '''
+    //                        sudo docker exec ${BUILD_TAG} bash -c "
+    //                        cd /efficient-transformers &&
+    //                        . preflight_qeff/bin/activate &&
+    //                        mkdir -p $PWD/Non_cli_qaic &&
+    //                        export TOKENIZERS_PARALLELISM=false &&
+    //                        export QEFF_HOME=$PWD/Non_cli_qaic &&
+    //                        pytest tests -m '(not cli) and (not on_qaic)' -n auto --junitxml=tests/tests_log1.xml &&
+    //                        deactivate"
+    //                        '''
+    //                    }
+    //                }
+    //            }
+    //            stage('Run Non-CLI QAIC Tests') {
+    //                steps {
+    //                    timeout(time: 200, unit: 'MINUTES') {
+    //                        sh '''
+    //                        sudo docker exec ${BUILD_TAG} bash -c "
+    //                        cd /efficient-transformers &&
+    //                        . preflight_qeff/bin/activate &&
+    //                        mkdir -p $PWD/Non_qaic &&
+    //                        export TOKENIZERS_PARALLELISM=false &&
+    //                        export QEFF_HOME=$PWD/Non_qaic &&
+    //                        pytest tests -m '(not cli) and (on_qaic) and (not qnn)' -n 4 --junitxml=tests/tests_log2.xml &&
+    //                        deactivate"
+    //                        '''
+    //                    }
+    //                }
+    //            }
+    //        }
+    //    }
+    //    stage('CLI Tests') {
+    //                steps {
+    //                    timeout(time: 15, unit: 'MINUTES') {
+    //                        sh '''
+    //                        sudo docker exec ${BUILD_TAG} bash -c "
+    //                 	   source /qnn_sdk/bin/envsetup.sh &&
+    //                   	   source /qnn_sdk/bin/envcheck -c &&
+    //                        cd /efficient-transformers &&
+    //                        . preflight_qeff/bin/activate &&
+    //                        mkdir -p $PWD/cli &&
+    //                        export TOKENIZERS_PARALLELISM=false &&
+    //                        export QEFF_HOME=$PWD/cli &&
+    //                        pytest tests -m '(cli and not qnn)' --junitxml=tests/tests_log3.xml &&
+    //                        deactivate"
+    //                        '''
+    //                    }
+    //                }
+    //     }
+    //     stage('QNN CLI Tests') {
+    //         steps {
+    //             timeout(time: 30, unit: 'MINUTES') {
+    //                 sh '''
+    //                 sudo docker exec ${BUILD_TAG} bash -c "
+    //                 source /qnn_sdk/bin/envsetup.sh &&
+    //                 source /qnn_sdk/bin/envcheck -c &&
+    //                 cd /efficient-transformers &&
+    //                 . preflight_qeff/bin/activate &&
+    //                 mkdir -p $PWD/Qnn_cli &&
+    //                 export TOKENIZERS_PARALLELISM=false &&
+    //                 export QEFF_HOME=$PWD/Qnn_cli &&
+    //                 pytest tests -m '(cli and qnn)' --junitxml=tests/tests_log4.xml &&
+    //                 deactivate"
+    //                 '''
+    //             }
+    //         }
+    //     }
+    //     stage('QNN Non-CLI Tests') {
+    //         steps {
+    //             timeout(time: 60, unit: 'MINUTES') {
+    //                 sh '''
+    //                 sudo docker exec ${BUILD_TAG} bash -c "
+    //                 source /qnn_sdk/bin/envsetup.sh &&
+    //                 source /qnn_sdk/bin/envcheck -c &&
+    //                 cd /efficient-transformers &&
+    //                 . preflight_qeff/bin/activate &&
+    //                 mkdir -p $PWD/Qnn_non_cli &&
+    //                 export TOKENIZERS_PARALLELISM=false &&
+    //                 export QEFF_HOME=$PWD/Qnn_non_cli &&
+    //                 pytest tests -m '(not cli) and (qnn) and (on_qaic)' --junitxml=tests/tests_log5.xml &&
+    //                 junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
+    //                 deactivate"
+    //                 '''
+    //             }
+    //         }
+    //     }
+        stage('vLLM Test')
+            {
+                steps
+                {
 
-       stage('Non CLI Tests') {
-           parallel {
-               stage('Run Non-CLI Non-QAIC Tests') {
-                   steps {
-                       timeout(time: 25, unit: 'MINUTES') {
-                           sh '''
-                           sudo docker exec ${BUILD_TAG} bash -c "
-                           cd /efficient-transformers &&
-                           . preflight_qeff/bin/activate &&
-                           mkdir -p $PWD/Non_cli_qaic &&
-                           export TOKENIZERS_PARALLELISM=false &&
-                           export QEFF_HOME=$PWD/Non_cli_qaic &&
-                           pytest tests -m '(not cli) and (not on_qaic)' -n auto --junitxml=tests/tests_log1.xml &&
-                           deactivate"
-                           '''
-                       }
-                   }
-               }
-               stage('Run Non-CLI QAIC Tests') {
-                   steps {
-                       timeout(time: 200, unit: 'MINUTES') {
-                           sh '''
-                           sudo docker exec ${BUILD_TAG} bash -c "
-                           cd /efficient-transformers &&
-                           . preflight_qeff/bin/activate &&
-                           mkdir -p $PWD/Non_qaic &&
-                           export TOKENIZERS_PARALLELISM=false &&
-                           export QEFF_HOME=$PWD/Non_qaic &&
-                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' -n 4 --junitxml=tests/tests_log2.xml &&
-                           deactivate"
-                           '''
-                       }
-                   }
-               }
-           }
-       }
-       stage('CLI Tests') {
-                   steps {
-                       timeout(time: 15, unit: 'MINUTES') {
-                           sh '''
-                           sudo docker exec ${BUILD_TAG} bash -c "
-                    	   source /qnn_sdk/bin/envsetup.sh &&
-                      	   source /qnn_sdk/bin/envcheck -c &&
-                           cd /efficient-transformers &&
-                           . preflight_qeff/bin/activate &&
-                           mkdir -p $PWD/cli &&
-                           export TOKENIZERS_PARALLELISM=false &&
-                           export QEFF_HOME=$PWD/cli &&
-                           pytest tests -m '(cli and not qnn)' --junitxml=tests/tests_log3.xml &&
-                           deactivate"
-                           '''
-                       }
-                   }
-        }
-        stage('QNN CLI Tests') {
-            steps {
-                timeout(time: 30, unit: 'MINUTES') {
+            timeout(time: 660, unit: 'MINUTES') {
                     sh '''
                     sudo docker exec ${BUILD_TAG} bash -c "
-                    source /qnn_sdk/bin/envsetup.sh &&
-                    source /qnn_sdk/bin/envcheck -c &&
-                    cd /efficient-transformers &&
                     . preflight_qeff/bin/activate &&
-                    mkdir -p $PWD/Qnn_cli &&
-                    export TOKENIZERS_PARALLELISM=false &&
-                    export QEFF_HOME=$PWD/Qnn_cli &&
-                    pytest tests -m '(cli and qnn)' --junitxml=tests/tests_log4.xml &&
+                    pytest --disable-warnings -s -v tests/vllm --junitxml=tests/tests_log4.xml &&
+                    junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log.xml &&
                     deactivate"
-                    '''
-                }
-            }
-        }
-        stage('QNN Non-CLI Tests') {
-            steps {
-                timeout(time: 60, unit: 'MINUTES') {
-                    sh '''
-                    sudo docker exec ${BUILD_TAG} bash -c "
-                    source /qnn_sdk/bin/envsetup.sh &&
-                    source /qnn_sdk/bin/envcheck -c &&
-                    cd /efficient-transformers &&
-                    . preflight_qeff/bin/activate &&
-                    mkdir -p $PWD/Qnn_non_cli &&
-                    export TOKENIZERS_PARALLELISM=false &&
-                    export QEFF_HOME=$PWD/Qnn_non_cli &&
-                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --junitxml=tests/tests_log5.xml &&
-                    junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
-                    deactivate"
-                    '''
+                    '''     
                 }
             }
         }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -16,10 +16,19 @@ pipeline {
                    sudo docker run --privileged -dit --name ${BUILD_TAG} -v ./:/efficient-transformers -v ${HF_PATH}:${DOCKER_HF_PATH} ${DOCKER_LATEST}:master_latest
                    sudo docker exec ${BUILD_TAG} bash -c "
                    cd /efficient-transformers &&
+                   apt update &&
+                   apt install -y python3.10-venv &&
+                   python3.10 -m venv preflight_qeff &&
+                   . preflight_qeff/bin/activate &&
+                   pip install --upgrade pip setuptools &&
+                   pip install .[test] &&
+                   pip install junitparser pytest-xdist &&
+                   pip install librosa==0.10.2 soundfile==0.13.1 && #packages needed to load example for whisper testing
                    rm -rf QEfficient"
                '''
            }
        }
+
     //    stage('Non CLI Tests') {
     //        parallel {
     //            stage('Run Non-CLI Non-QAIC Tests') {
@@ -111,16 +120,6 @@ pipeline {
     //             }
     //         }
     //     }
-        stage('vLLM Test')
-            {
-
-                steps
-                {
-                    build job: 'qefficient_vllm_upstream', 
-                    parameters: [string(name: 'NAME', value: "${BUILD_TAG}")],
-                    propagate: true
-                }
-        }
     }
 
    post {
@@ -135,7 +134,7 @@ pipeline {
                    echo "Failed to delete container ${BUILD_TAG}: ${error}"
                }
            }
-        //    junit testResults: 'tests/tests_log.xml'
+           junit testResults: 'tests/tests_log.xml'
            echo 'Cleaning Workspace'
            deleteDir()
        }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -28,98 +28,97 @@ pipeline {
                '''
            }
        }
-
-    //    stage('Non CLI Tests') {
-    //        parallel {
-    //            stage('Run Non-CLI Non-QAIC Tests') {
-    //                steps {
-    //                    timeout(time: 25, unit: 'MINUTES') {
-    //                        sh '''
-    //                        sudo docker exec ${BUILD_TAG} bash -c "
-    //                        cd /efficient-transformers &&
-    //                        . preflight_qeff/bin/activate &&
-    //                        mkdir -p $PWD/Non_cli_qaic &&
-    //                        export TOKENIZERS_PARALLELISM=false &&
-    //                        export QEFF_HOME=$PWD/Non_cli_qaic &&
-    //                        pytest tests -m '(not cli) and (not on_qaic)' -n auto --junitxml=tests/tests_log1.xml &&
-    //                        deactivate"
-    //                        '''
-    //                    }
-    //                }
-    //            }
-    //            stage('Run Non-CLI QAIC Tests') {
-    //                steps {
-    //                    timeout(time: 200, unit: 'MINUTES') {
-    //                        sh '''
-    //                        sudo docker exec ${BUILD_TAG} bash -c "
-    //                        cd /efficient-transformers &&
-    //                        . preflight_qeff/bin/activate &&
-    //                        mkdir -p $PWD/Non_qaic &&
-    //                        export TOKENIZERS_PARALLELISM=false &&
-    //                        export QEFF_HOME=$PWD/Non_qaic &&
-    //                        pytest tests -m '(not cli) and (on_qaic) and (not qnn)' -n 4 --junitxml=tests/tests_log2.xml &&
-    //                        deactivate"
-    //                        '''
-    //                    }
-    //                }
-    //            }
-    //        }
-    //    }
-    //    stage('CLI Tests') {
-    //                steps {
-    //                    timeout(time: 15, unit: 'MINUTES') {
-    //                        sh '''
-    //                        sudo docker exec ${BUILD_TAG} bash -c "
-    //                 	   source /qnn_sdk/bin/envsetup.sh &&
-    //                   	   source /qnn_sdk/bin/envcheck -c &&
-    //                        cd /efficient-transformers &&
-    //                        . preflight_qeff/bin/activate &&
-    //                        mkdir -p $PWD/cli &&
-    //                        export TOKENIZERS_PARALLELISM=false &&
-    //                        export QEFF_HOME=$PWD/cli &&
-    //                        pytest tests -m '(cli and not qnn)' --junitxml=tests/tests_log3.xml &&
-    //                        deactivate"
-    //                        '''
-    //                    }
-    //                }
-    //     }
-    //     stage('QNN CLI Tests') {
-    //         steps {
-    //             timeout(time: 30, unit: 'MINUTES') {
-    //                 sh '''
-    //                 sudo docker exec ${BUILD_TAG} bash -c "
-    //                 source /qnn_sdk/bin/envsetup.sh &&
-    //                 source /qnn_sdk/bin/envcheck -c &&
-    //                 cd /efficient-transformers &&
-    //                 . preflight_qeff/bin/activate &&
-    //                 mkdir -p $PWD/Qnn_cli &&
-    //                 export TOKENIZERS_PARALLELISM=false &&
-    //                 export QEFF_HOME=$PWD/Qnn_cli &&
-    //                 pytest tests -m '(cli and qnn)' --junitxml=tests/tests_log4.xml &&
-    //                 deactivate"
-    //                 '''
-    //             }
-    //         }
-    //     }
-    //     stage('QNN Non-CLI Tests') {
-    //         steps {
-    //             timeout(time: 60, unit: 'MINUTES') {
-    //                 sh '''
-    //                 sudo docker exec ${BUILD_TAG} bash -c "
-    //                 source /qnn_sdk/bin/envsetup.sh &&
-    //                 source /qnn_sdk/bin/envcheck -c &&
-    //                 cd /efficient-transformers &&
-    //                 . preflight_qeff/bin/activate &&
-    //                 mkdir -p $PWD/Qnn_non_cli &&
-    //                 export TOKENIZERS_PARALLELISM=false &&
-    //                 export QEFF_HOME=$PWD/Qnn_non_cli &&
-    //                 pytest tests -m '(not cli) and (qnn) and (on_qaic)' --junitxml=tests/tests_log5.xml &&
-    //                 junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
-    //                 deactivate"
-    //                 '''
-    //             }
-    //         }
-    //     }
+       stage('Non CLI Tests') {
+           parallel {
+               stage('Run Non-CLI Non-QAIC Tests') {
+                   steps {
+                       timeout(time: 25, unit: 'MINUTES') {
+                           sh '''
+                           sudo docker exec ${BUILD_TAG} bash -c "
+                           cd /efficient-transformers &&
+                           . preflight_qeff/bin/activate &&
+                           mkdir -p $PWD/Non_cli_qaic &&
+                           export TOKENIZERS_PARALLELISM=false &&
+                           export QEFF_HOME=$PWD/Non_cli_qaic &&
+                           pytest tests -m '(not cli) and (not on_qaic)' -n auto --junitxml=tests/tests_log1.xml &&
+                           deactivate"
+                           '''
+                       }
+                   }
+               }
+               stage('Run Non-CLI QAIC Tests') {
+                   steps {
+                       timeout(time: 200, unit: 'MINUTES') {
+                           sh '''
+                           sudo docker exec ${BUILD_TAG} bash -c "
+                           cd /efficient-transformers &&
+                           . preflight_qeff/bin/activate &&
+                           mkdir -p $PWD/Non_qaic &&
+                           export TOKENIZERS_PARALLELISM=false &&
+                           export QEFF_HOME=$PWD/Non_qaic &&
+                           pytest tests -m '(not cli) and (on_qaic) and (not qnn)' -n 4 --junitxml=tests/tests_log2.xml &&
+                           deactivate"
+                           '''
+                       }
+                   }
+               }
+           }
+       }
+       stage('CLI Tests') {
+                   steps {
+                       timeout(time: 15, unit: 'MINUTES') {
+                           sh '''
+                           sudo docker exec ${BUILD_TAG} bash -c "
+                    	   source /qnn_sdk/bin/envsetup.sh &&
+                      	   source /qnn_sdk/bin/envcheck -c &&
+                           cd /efficient-transformers &&
+                           . preflight_qeff/bin/activate &&
+                           mkdir -p $PWD/cli &&
+                           export TOKENIZERS_PARALLELISM=false &&
+                           export QEFF_HOME=$PWD/cli &&
+                           pytest tests -m '(cli and not qnn)' --junitxml=tests/tests_log3.xml &&
+                           deactivate"
+                           '''
+                       }
+                   }
+        }
+        stage('QNN CLI Tests') {
+            steps {
+                timeout(time: 30, unit: 'MINUTES') {
+                    sh '''
+                    sudo docker exec ${BUILD_TAG} bash -c "
+                    source /qnn_sdk/bin/envsetup.sh &&
+                    source /qnn_sdk/bin/envcheck -c &&
+                    cd /efficient-transformers &&
+                    . preflight_qeff/bin/activate &&
+                    mkdir -p $PWD/Qnn_cli &&
+                    export TOKENIZERS_PARALLELISM=false &&
+                    export QEFF_HOME=$PWD/Qnn_cli &&
+                    pytest tests -m '(cli and qnn)' --junitxml=tests/tests_log4.xml &&
+                    deactivate"
+                    '''
+                }
+            }
+        }
+        stage('QNN Non-CLI Tests') {
+            steps {
+                timeout(time: 60, unit: 'MINUTES') {
+                    sh '''
+                    sudo docker exec ${BUILD_TAG} bash -c "
+                    source /qnn_sdk/bin/envsetup.sh &&
+                    source /qnn_sdk/bin/envcheck -c &&
+                    cd /efficient-transformers &&
+                    . preflight_qeff/bin/activate &&
+                    mkdir -p $PWD/Qnn_non_cli &&
+                    export TOKENIZERS_PARALLELISM=false &&
+                    export QEFF_HOME=$PWD/Qnn_non_cli &&
+                    pytest tests -m '(not cli) and (qnn) and (on_qaic)' --junitxml=tests/tests_log5.xml &&
+                    junitparser merge tests/tests_log1.xml tests/tests_log2.xml tests/tests_log3.xml tests/tests_log4.xml tests/tests_log5.xml tests/tests_log.xml &&
+                    deactivate"
+                    '''
+                }
+            }
+        }
       stage('vLLM Test')
             {
 

--- a/tests/vllm/test_qaic_output_consistency.py
+++ b/tests/vllm/test_qaic_output_consistency.py
@@ -1,0 +1,100 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+import random
+
+import pytest
+from vllm import LLM, SamplingParams
+
+# Model to test
+test_models = [
+    "TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+]
+
+# Constants for configuration
+SEQ_LEN = 128
+CTX_LEN = 256
+DECOE_BSZ = 4
+DTYPE = "mxfp6"
+KV_DTYPE = "mxint8"
+DEVICE_GROUP = [0]
+
+
+@pytest.mark.parametrize("model_name", test_models)
+def test_output_consistency(model_name):
+    """This pytest function is used to check the consistency of vLLM.
+       1) Single prompt test to check if the output generated in 5 different
+          runs yields the same results
+       2) Multiple prompt check to test if multiple prompts yield same results
+          if run in different slots.
+
+    Parameters
+    ----------
+    model_name : string
+        Huggingface model card name.
+    """
+    sampling_params = SamplingParams(temperature=0.0, max_tokens=None)
+
+    # Creating LLM Object
+    qllm = LLM(
+        model=model_name,
+        device_group=DEVICE_GROUP,
+        max_num_seqs=DECOE_BSZ,
+        max_model_len=CTX_LEN,
+        max_seq_len_to_capture=SEQ_LEN,
+        quantization=DTYPE,
+        kv_cache_dtype=KV_DTYPE,
+        device="qaic",
+    )
+
+    # Single prompt test
+    prompt1 = ["My name is"]
+
+    output1 = qllm.generate(prompt1 * 5, sampling_params)
+
+    check_output1 = []
+    for i, op in enumerate(output1):
+        check_output1.append(op.outputs[0].text)
+
+    # Multiple prompt test
+    outputDict = dict()
+    prompt2 = [
+        "My name is",
+        "How to eat mangosteen?",
+        "How many people died in World War II",
+        "Hello ",
+        "Who is the president of United States",
+        "Who is the president of India",
+        "When it snowfalls in San Diego",
+        "In which country yamana river flows",
+        "How many people died in World War II",
+        "Thy youth is proud livery, so gazed on now",
+        "Will be a tattered weed, of small worth held:" "Then being asked where all thy beauty lies",
+        "Where all the treasure of thy lusty days",
+        "To say, within thine own deep-sunken eyes",
+        "Where is Statue of Liberty located?",
+    ]
+
+    for p in prompt2:
+        outputDict[p] = []
+
+    for _ in range(5):
+        random.shuffle(prompt2)
+        output2 = qllm.generate(prompt2, sampling_params)
+        for i, op in enumerate(output2):
+            generated_text = op.outputs[0].text
+            outputDict[prompt2[i]].append(str(prompt2[i] + generated_text))
+
+    # Assertion to check the consistency of single prompt.
+    assert len(set(check_output1)) == 1, "Outputs from different slots for same prompt does not match!!"
+
+    # Assertion to check multiple prompts.
+    for key in outputDict.keys():
+        assert len(set(outputDict[key])) == 1, "Outputs from different slots for same prompt does not match!!"
+
+    # Assertion to check if any prompts are missed.
+    assert len(prompt2) == len(output2), "Number of Generated Tokens do not match the number of valid inputs!!"

--- a/tests/vllm/test_qaic_output_consistency.py
+++ b/tests/vllm/test_qaic_output_consistency.py
@@ -24,6 +24,7 @@ KV_DTYPE = "mxint8"
 DEVICE_GROUP = [0]
 
 
+@pytest.mark.vllm
 @pytest.mark.parametrize("model_name", test_models)
 def test_output_consistency(model_name):
     """This pytest function is used to check the consistency of vLLM.

--- a/tests/vllm/test_qaic_output_consistency.py
+++ b/tests/vllm/test_qaic_output_consistency.py
@@ -73,7 +73,7 @@ def test_output_consistency(model_name):
         "In which country yamana river flows",
         "How many people died in World War II",
         "Thy youth is proud livery, so gazed on now",
-        "Will be a tattered weed, of small worth held:" "Then being asked where all thy beauty lies",
+        "Will be a tattered weed, of small worth held:Then being asked where all thy beauty lies",
         "Where all the treasure of thy lusty days",
         "To say, within thine own deep-sunken eyes",
         "Where is Statue of Liberty located?",


### PR DESCRIPTION
Enabling VLLM test

This VLLM testing directory provides installation and testing of VLLLM to be incorporated in the efficient-transformers CI.
A basic sanity check for VLLM is provided that
a) installs the latest VLLM
b) downloads and compiles a small model (efficient-transformers)
c) checks for three sanity checks to see if the model runs correctly on VLLM and passes initial tests.