### PR TITLE
BUGFIX: changes in modeling_auto.py for InternVL mxint8 inference error

### DIFF
--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -629,7 +629,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         kv_cache_dtype = "mxint8" if mxint8_kv_cache else "float16"
         custom_io_vision["pixel_values"] = "float16"
         for output_name in output_names["vision"]:
-            custom_io_vision[output_name] = kv_cache_dtype
+            custom_io_vision[output_name] = "float16"
 
         if vision_onnx_path:
             self.vision_model.onnx_path = vision_onnx_path

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -627,7 +627,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
 
         custom_io_vision = {}
         kv_cache_dtype = "mxint8" if mxint8_kv_cache else "float16"
-        custom_io_vision["pixel_values"] = kv_cache_dtype
+        custom_io_vision["pixel_values"] = "float16"
         for output_name in output_names["vision"]:
             custom_io_vision[output_name] = kv_cache_dtype
 
@@ -657,12 +657,14 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         # Inputs
         for output_name in output_names["lang"]:
             if output_name.endswith("_RetainedState"):
-                custom_io_lang[output_name[: -len("_RetainedState")]] = kv_cache_dtype
+                custom_io_lang[output_name[: -len("_RetainedState")]] = (
+                    "float16" if "vit_embeds" in output_name else kv_cache_dtype
+                )
 
         # outputs
         for output_name in output_names["lang"]:
             if output_name.endswith("_RetainedState"):
-                custom_io_lang[output_name] = kv_cache_dtype
+                custom_io_lang[output_name] = "float16" if "vit_embeds" in output_name else kv_cache_dtype
 
         self.lang_model._compile(
             compile_dir,
@@ -947,12 +949,14 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         # inputs
         for input_name in output_names:
             if input_name.endswith("_RetainedState"):
-                custom_io[input_name[: -len("_RetainedState")]] = kv_cache_dtype
+                custom_io[input_name[: -len("_RetainedState")]] = (
+                    "float16" if "pixel_values" in input_name else kv_cache_dtype
+                )
 
         # outputs
         for output_name in output_names:
             if output_name.endswith("_RetainedState"):
-                custom_io[output_name] = kv_cache_dtype
+                custom_io[output_name] = "float16" if "pixel_values" in output_name else kv_cache_dtype
 
         self._compile(
             onnx_path,

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -629,7 +629,10 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         kv_cache_dtype = "mxint8" if mxint8_kv_cache else "float16"
         custom_io_vision["pixel_values"] = "float16"
         for output_name in output_names["vision"]:
-            custom_io_vision[output_name] = "float16"
+            if output_name.startswith("past_"):
+                custom_io_vision[output_name] = kv_cache_dtype
+            else:
+                custom_io_vision[output_name] = "float16"
 
         if vision_onnx_path:
             self.vision_model.onnx_path = vision_onnx_path


### PR DESCRIPTION
Changes made to keep `pixel_values` and `vit_embeds` as `float16` irrespective of the `kv_cache_dtype` used for compilation. Changes made for both single and dual qpc compilation.