### PR TITLE
Bug Fix: update qeff wheel package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pip install git+https://github.com/quic/efficient-transformers
 # Or build wheel package using the below command.
 pip install build wheel
 python -m build --wheel --outdir dist
-pip install dist/QEfficient-0.0.1.dev0-py3-none-any.whl
+pip install dist/qefficient-0.0.1.dev0-py3-none-any.whl
 
 ``` 
 


### PR DESCRIPTION
The wheel file name is qefficient and Not QEfficient
![image](https://github.com/user-attachments/assets/2cd21d49-e4d1-457f-9e9e-11b02beb7b7e)
