### PR TITLE
[Docs Fix: ]QEFFAutoModelForImageTextToText Typing mistake Resolved

### DIFF
--- a/docs/source/validate.md
+++ b/docs/source/validate.md
@@ -54,7 +54,7 @@
 ## Multimodal Language Models
 
 ### Vision-Language Models (Text + Image Generation)
-**QEff Auto Class:** `QEFFAutoModelImageTextToText`
+**QEff Auto Class:** `QEFFAutoModelForImageTextToText`
 
 | Architecture                | Model Family | Representative Models                  |
 |-----------------------------|--------------|----------------------------------------|


### PR DESCRIPTION
This PR is created for resolving a typing mistake in the name of `QEFFAutoModelForImageTextToText ` in the `validate.md`