### PR TITLE
[Test-fix]: HF_TOKEN param removed from MM test Script

### DIFF
--- a/tests/transformers/models/test_image_text_to_text_models.py
+++ b/tests/transformers/models/test_image_text_to_text_models.py
@@ -156,9 +156,7 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
 ):
     model_config = {"model_name": model_name}
     model_config["img_size"] = img_size
-    config = AutoConfig.from_pretrained(
-        model_config["model_name"], trust_remote_code=True, padding=True
-    )
+    config = AutoConfig.from_pretrained(model_config["model_name"], trust_remote_code=True, padding=True)
     config = set_num_layers(config, n_layer=n_layer)
     model_hf, _ = load_image_text_to_text_model(config)
     processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True, padding=True)


### PR DESCRIPTION
### Previous Behavior:
The `HF_TOKEN` parameter in the test script was explicitly set to an empty string. This caused authentication failures with Hugging Face, as an empty token overrides the environment-provided `HF_TOKEN`, preventing its intended use.

### Current Update:
The `HF_TOKEN `parameter has been removed from the script. The script will now default to using the `HF_TOKEN `from the environment, allowing user-provided tokens to be utilized as expected.