### PR TITLE
Name change fix in QNN Config Data format file

### DIFF
--- a/QEfficient/utils/generate_qnn_network_specialization_config.py
+++ b/QEfficient/utils/generate_qnn_network_specialization_config.py
@@ -173,10 +173,10 @@ def generate_data_format_config(
 
     for input in onnx_model.graph.input:
         if "past_key" in input.name or "past_value" in input.name:
-            kv_nodes.append((input.name).replace(".", "_"))
+            kv_nodes.append(input.name)
     for output in onnx_model.graph.output:
         if "past_key" in output.name or "past_value" in output.name:
-            kv_nodes.append((output.name).replace(".", "_"))
+            kv_nodes.append(output.name)
             kv_overrides = {}
 
     kv_overrides["graphs"] = [


### PR DESCRIPTION
Updated generate_data_format_config API to disable original (framework) name sanitization on AIC backend for QNN Compilation path.