### PR TITLE
Changing the hashing methodology for cache folder creation of models.  

### DIFF
--- a/QEfficient/utils/__init__.py
+++ b/QEfficient/utils/__init__.py
@@ -25,6 +25,7 @@ from QEfficient.utils._utils import (  # noqa: F401
     load_hf_processor,
     load_hf_tokenizer,
     login_and_download_hf_lm,
+    make_serializable,
     onnx_exists,
     padding_check_and_fix,
     qpc_exists,

--- a/QEfficient/utils/_utils.py
+++ b/QEfficient/utils/_utils.py
@@ -580,6 +580,19 @@ def model_swap(func):
     return wrapper
 
 
+# Ensure input obj is JSON serializable
+def make_serializable(obj):
+    if isinstance(obj, (int, float, str, bool, type(None))):
+        return obj
+    elif isinstance(obj, (list, tuple)):
+        return [make_serializable(item) for item in obj]
+    elif isinstance(obj, dict):
+        return {key: make_serializable(value) for key, value in obj.items()}
+    elif hasattr(obj, "__dict__"):
+        return make_serializable(vars(obj))
+    return str(obj)
+
+
 @dataclass
 class IOInfo:
     name: str
@@ -666,18 +679,6 @@ def create_and_dump_qconfigs(
     onnx_path = str(onnx_path)
     specializations_file_path = str(os.path.join(os.path.dirname(qpc_path), "specializations.json"))
     compile_dir = str(os.path.dirname(qpc_path))
-
-    # Ensure all objects in the configs dictionary are JSON serializable
-    def make_serializable(obj):
-        if isinstance(obj, (int, float, str, bool, type(None))):
-            return obj
-        elif isinstance(obj, (list, tuple)):
-            return [make_serializable(item) for item in obj]
-        elif isinstance(obj, dict):
-            return {key: make_serializable(value) for key, value in obj.items()}
-        elif hasattr(obj, "__dict__"):
-            return make_serializable(vars(obj))
-        return str(obj)
 
     qconfigs = {
         "huggingface_config": make_serializable(huggingface_config),

--- a/QEfficient/utils/cache.py
+++ b/QEfficient/utils/cache.py
@@ -5,9 +5,11 @@
 #
 # ----------------------------------------------------------------------------
 
+import hashlib
 import json
 import os
 from pathlib import Path
+from typing import Dict
 
 QEFF_HOME: Path = None
 if "QEFF_HOME" in os.environ:
@@ -39,3 +41,11 @@ def to_hashable(obj) -> bytes:
         default=json_serializable,
         sort_keys=True,
     ).encode()
+
+
+def hash_dict_params(dict_items: Dict):
+    """
+    Takes a dictionary of items and returns a SHA256 hash object
+    """
+    mhash = hashlib.sha256(to_hashable(dict_items))
+    return mhash


### PR DESCRIPTION
Detaching hash function for model cache path calculation. changes for QNN compilation not included yet.

Cache folder mechanism has been modified to have a parent directory for a model based on the architecture that we retrieve from the model config. The hash calculation for the ONNX export now incorporates all model kwargs as well as export kwargs and parameters. the parameters that were used to create the hash also gets dumped as a serialized JSON file in the ONNX folder, the same happens for the compile parameters inside the respective qpc folder.