### PR TITLE
[QEff Finetune]: Fix for padding.

### DIFF
--- a/QEfficient/finetune/utils/dataset_utils.py
+++ b/QEfficient/finetune/utils/dataset_utils.py
@@ -4,13 +4,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # -----------------------------------------------------------------------------
-
+import datasets
 import torch
 import torch.distributed as dist
 from transformers.data import DataCollatorForSeq2Seq
 
 from QEfficient.finetune.data.sampler import DistributedLengthBasedBatchSampler
 from QEfficient.finetune.dataset.dataset_config import DATALOADER_COLLATE_FUNC, DATASET_PREPROC
+from QEfficient.finetune.utils.helper import get_num_ddp_devices
 
 
 def get_preprocessed_dataset(
@@ -54,27 +55,58 @@ def get_dataloader_kwargs(train_config, dataset, dataset_processer, split):
                 dataset, num_replicas=dist.get_world_size(), rank=dist.get_rank(), shuffle=False
             )
             kwargs["batch_size"] = batch_size
-            kwargs["drop_last"] = True
+            kwargs["drop_last"] = False
     else:
         kwargs["batch_size"] = batch_size
-        kwargs["drop_last"] = True
+        kwargs["drop_last"] = False
     kwargs["collate_fn"] = DataCollatorForSeq2Seq(dataset_processer)
     return kwargs
 
 
+def padding_dataset(train_config, dataset, batch_size):
+    if train_config.enable_ddp and train_config.enable_sorting_for_ddp:
+        if isinstance(dataset, datasets.Dataset):
+            # Hugging Face Dataset transformation
+            dataset = dataset.map(lambda x: {"input_length": len(x["input_ids"])})
+            dataset = dataset.sort("input_length")
+
+        else:
+            dataset = sorted(dataset, key=lambda x: len(x["input_ids"]))
+
+    dummy_row = next(iter(dataset))
+    dummy_row["labels"] = torch.tensor([-100] * len(dummy_row["labels"]))
+    padding_size = 0
+    num_replicas = get_num_ddp_devices()
+    remainder = len(dataset) % (num_replicas * batch_size)
+    padding_size = (num_replicas * batch_size) - remainder
+
+    dummy_data = [dummy_row.copy() for _ in range(padding_size)]
+    dummy_dataset = datasets.Dataset.from_list(dummy_data)
+    if isinstance(dataset, datasets.Dataset):
+        combined_dataset = datasets.concatenate_datasets([dataset, dummy_dataset])
+    else:
+        combined_dataset = dataset + list(dummy_dataset)
+    return combined_dataset
+
+
 def get_dataloader(tokenizer, dataset_config, train_config, split: str = "train"):
     dataset = get_preprocessed_dataset(tokenizer, dataset_config, split, context_length=train_config.context_length)
+
+    batch_size = train_config.train_batch_size if split == "train" else train_config.val_batch_size
+    dataset = padding_dataset(train_config, dataset, batch_size)
+
     dl_kwargs = get_dataloader_kwargs(train_config, dataset, tokenizer, split)
 
     # FIXME (Meet): Add custom data collator registration from the outside by the user.
     custom_data_collator = get_custom_data_collator(tokenizer, dataset_config)
+
     if custom_data_collator:
         print("custom_data_collator is used")
         dl_kwargs["collate_fn"] = custom_data_collator
 
     print(f"length of dataset_{split}", len(dataset))
-
     # Create data loader
+
     dataloader = torch.utils.data.DataLoader(
         dataset,
         num_workers=train_config.num_workers_dataloader,

--- a/QEfficient/finetune/utils/helper.py
+++ b/QEfficient/finetune/utils/helper.py
@@ -4,8 +4,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # -----------------------------------------------------------------------------
+import os
 
 TASK_TYPE = ["generation", "seq_classification"]
 PEFT_METHOD = ["lora"]
 DEVICE = ["qaic", "cpu", "cuda"]
 BATCHING_STRATEGY = ["padding", "packing"]
+
+
+def get_num_ddp_devices():
+    return int(os.getenv("WORLD_SIZE", 1))

--- a/QEfficient/finetune/utils/train_utils.py
+++ b/QEfficient/finetune/utils/train_utils.py
@@ -151,7 +151,7 @@ def train(
 
         # enable profile for qaic
         qaic_profile.start_profiling(device, 1) if train_config.use_profiler else None
-
+        num_dummy_samples = 0
         for step, batch in enumerate(train_dataloader):
             # resume training from a particular checkpoint, assuming the dataset is not shuffled
             if train_config.use_peft and train_config.from_peft_checkpoint:
@@ -192,6 +192,17 @@ def train(
                     ) as verifier:
                         model_outputs = model(**batch)
                         loss = model_outputs.loss  # Forward call
+                        if (batch["labels"] != -100).sum() == 0:
+                            loss = loss.nan_to_num(nan=0.0)
+                            num_dummy_samples += train_config.train_batch_size
+                        else:
+                            num_dummy_samples_per_batch = (
+                                (torch.sum(batch["labels"] == -100, dim=1) == batch["labels"].shape[1]).sum().item()
+                            )
+                            if num_dummy_samples_per_batch > 0:
+                                num_dummy_samples += num_dummy_samples_per_batch
+                                loss = loss * train_config.train_batch_size / num_dummy_samples_per_batch
+
                         if train_config.task_type == "seq_classification":
                             logits = model_outputs.logits
                             labels = batch["labels"][:, 0]
@@ -201,6 +212,17 @@ def train(
                 else:
                     model_outputs = model(**batch)
                     loss = model_outputs.loss  # Forward call
+                    if (batch["labels"] != -100).sum() == 0:
+                        loss = loss.nan_to_num(nan=0.0)
+                        num_dummy_samples += train_config.train_batch_size
+                    else:
+                        num_dummy_samples_per_batch = (
+                            (torch.sum(batch["labels"] == -100, dim=1) == batch["labels"].shape[1]).sum().item()
+                        )
+                        if num_dummy_samples_per_batch > 0:
+                            num_dummy_samples += num_dummy_samples_per_batch
+                            loss = loss * train_config.train_batch_size / num_dummy_samples_per_batch
+
                     if train_config.task_type == "seq_classification":
                         logits = model_outputs.logits
                         labels = batch["labels"][:, 0]
@@ -208,8 +230,7 @@ def train(
                         acc_helper.forward(preds, labels)
 
             total_loss += loss.detach().float()
-            # Accumalate gradients
-            loss = loss / train_config.gradient_accumulation_steps
+
             if train_config.enable_ddp:
                 if local_rank == 0:
                     if loss <= train_config.convergence_loss:
@@ -236,6 +257,17 @@ def train(
                 else:
                     step_metric_val = float(torch.exp(loss.detach().float()))
                 train_step_metric.append(step_metric_val)
+
+            # Accumalate gradients
+            complete_accum_steps = (
+                len(train_dataloader) - len(train_dataloader) % train_config.gradient_accumulation_steps
+            )
+            if step < complete_accum_steps:
+                num_samples_in_cur_update = train_config.gradient_accumulation_steps
+            else:
+                num_samples_in_cur_update = len(train_dataloader) % train_config.gradient_accumulation_steps
+
+            loss = loss / num_samples_in_cur_update
 
             if train_config.grad_scaler:
                 scaler.scale(loss).backward()  # backward pass
@@ -296,15 +328,30 @@ def train(
 
         if loss_0_counter.item() == train_config.convergence_counter:
             if train_config.use_peft and train_config.from_peft_checkpoint and epoch == intermediate_epoch:
-                train_epoch_loss = total_loss / (step - intermediate_step)
+                train_epoch_loss = (
+                    0.0
+                    if total_loss == 0.0
+                    else total_loss / (step - intermediate_step - num_dummy_samples / train_config.train_batch_size)
+                )
             else:
-                train_epoch_loss = total_loss / step
+                train_epoch_loss = (
+                    0.0
+                    if total_loss == 0.0
+                    else total_loss / (step + 1 - num_dummy_samples / train_config.train_batch_size)
+                )
         else:
             if train_config.use_peft and train_config.from_peft_checkpoint and epoch == intermediate_epoch:
-                train_epoch_loss = total_loss / (len(train_dataloader) - intermediate_step)
+                train_epoch_loss = (
+                    0.0
+                    if total_loss == 0.0
+                    else total_loss / (step - intermediate_step - (num_dummy_samples / train_config.train_batch_size))
+                )
             else:
-                train_epoch_loss = total_loss / len(train_dataloader)
-
+                train_epoch_loss = (
+                    0.0
+                    if total_loss == 0.0
+                    else total_loss / (step + 1 - (num_dummy_samples / train_config.train_batch_size))
+                )
         if train_config.task_type == "seq_classification":
             metric_val = acc_helper.compute()
             acc_helper.reset()
@@ -389,7 +436,6 @@ def train(
     results["avg_checkpoint_time"] = avg_checkpoint_time
     if train_config.save_metrics:
         results["metrics_filename"] = metrics_filename
-
     return results
 
 
@@ -421,6 +467,7 @@ def evaluation_helper(model, train_config, eval_dataloader, device):
     eval_loss = 0.0  # Initialize evaluation loss
     device_type = torch.device(device).type
 
+    num_dummy_samples = 0
     for step, batch in enumerate(tqdm(eval_dataloader, colour="green", desc="evaluating Epoch", dynamic_ncols=True)):
         #  stop when the maximum number of eval steps is reached
         if train_config.max_eval_step > 0 and step > train_config.max_eval_step:
@@ -439,6 +486,17 @@ def evaluation_helper(model, train_config, eval_dataloader, device):
                 outputs = model(**batch)
             loss = outputs.loss
 
+            if (batch["labels"] != -100).sum() == 0:
+                loss = loss.nan_to_num(nan=0.0)
+                num_dummy_samples += 1
+            else:
+                num_dummy_samples_per_batch = (
+                    (torch.sum(batch["labels"] == -100, dim=1) == batch["labels"].shape[1]).sum().item()
+                )
+                if num_dummy_samples_per_batch > 0:
+                    num_dummy_samples += num_dummy_samples_per_batch
+                    loss = loss * train_config.val_batch_size / num_dummy_samples_per_batch
+
             if train_config.task_type == "seq_classification":
                 logits = outputs.logits
                 labels = batch["labels"][:, 0]
@@ -453,9 +511,10 @@ def evaluation_helper(model, train_config, eval_dataloader, device):
                 val_step_metric.append(metric_val)
 
             eval_loss += loss.detach().float()
-
     # Compute average loss and metric
-    eval_epoch_loss = eval_loss / len(eval_dataloader)
+    eval_epoch_loss = (
+        0.0 if eval_loss == 0.0 else eval_loss / (step + 1 - num_dummy_samples / train_config.val_batch_size)
+    )
     if train_config.task_type == "seq_classification":
         eval_metric = acc_helper.compute()
     else:


### PR DESCRIPTION
1. Padding the dataset with dummy samples (they won't contribute in total_loss) to make the #samples a multiple of degree of ddp*batch_size) to avoid dropping of any samples in case of
a) Fine tuning through DDP
b) train_batch_size > 1 or val_batch_size > 1
2. Repositioned loss = loss /gradient_accumulation_steps
3. Corrected the calculation of average loss in case when --max_train_steps or --max_val_steps flags are set.