### PR TITLE
[QEff. Finetune]: For grad checkpointing, changed the preserve_rng_state to True

### DIFF
--- a/QEfficient/cloud/finetune.py
+++ b/QEfficient/cloud/finetune.py
@@ -174,7 +174,7 @@ def load_model_and_tokenizer(
     if train_config.gradient_checkpointing:
         # Note: below attribute and method is only available in HuggingFace Transformer models.
         if hasattr(model, "supports_gradient_checkpointing") and model.supports_gradient_checkpointing:
-            model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"preserve_rng_state": False})
+            model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"preserve_rng_state": True})
         else:
             logger.raise_error(
                 "Given model doesn't support gradient checkpointing. Please disable it and run it.", RuntimeError

--- a/QEfficient/finetune/configs/training.py
+++ b/QEfficient/finetune/configs/training.py
@@ -24,7 +24,7 @@ class TrainConfig:
         val_batch_size (int): Batch size for validation (default: 1).
         context_length (Optional[int]): Maximum sequence length for inputs (default: None).
         gradient_accumulation_steps (int): Steps for gradient accumulation (default: 4).
-        gradient checkpointing (bool): Enable gradient checkpointing to save the memory by compromising the speed. (default: False).
+        gradient_checkpointing (bool): Enable gradient checkpointing to save the memory by compromising the speed. (default: False).
         use_autocast (bool): Use autocast for mixed precision (default: True).
         grad_scaler (bool): Use gradient scaler (default: True).
         num_epochs (int): Number of training epochs (default: 1).


### PR DESCRIPTION
- When grad checkpointing enabled, at that time we had provided preserve_rng_state as False because keeping it True was failing due to not setting rng state. Now that issue is solved hence we can set preserve_rng_state as True. 
- With this the runs with and without --gradient_checkpointing flag should produce identical results.