### PR TITLE
Onnx slim transform

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -14,7 +14,6 @@ import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, List, Optional
-import time
 import onnx
 import torch
 import pdb
@@ -253,7 +252,6 @@ class QEFFBaseModel(ABC):
         """
         if onnx_path is None and self.onnx_path is None:
             self.export()
-        t1=time.time()
         onnx_path = Path(onnx_path or self.onnx_path)
         compile_dir = Path(compile_dir or onnx_path.parent)
         qpc_path = compile_dir / "qpc"
@@ -372,6 +370,4 @@ class QEFFBaseModel(ABC):
             )
 
         self.qpc_path = qpc_path
-        t2=time.time()
-        print('qpc_path time used:', t2-t1)
         return qpc_path

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -45,9 +45,10 @@ class QEFFBaseModel(ABC):
     def _transform_names(cls) -> List[str]:
         return [x.__name__ for x in cls._pytorch_transforms + cls._onnx_transforms]
 
-    def __init__(self, model: torch.nn.Module) -> None:
+    def __init__(self, model: torch.nn.Module,onnx_slim_transfom:bool=False) -> None:
         super().__init__()
         self.model = model
+        self.onnx_slim_transform = onnx_slim_transfom
         self.onnx_path: Optional[str] = None
         self.qpc_path: Optional[str] = None
         self.qpc_session: Optional[QAICInferenceSession] = None
@@ -119,6 +120,7 @@ class QEFFBaseModel(ABC):
         example_inputs: Dict[str, torch.Tensor],
         output_names: List[str],
         dynamic_axes: Dict[str, Dict[int, str]],
+        onnx_slim_transform: bool = False,
         export_kwargs: Optional[Dict[str, any]] = None,
         onnx_transform_kwargs: Optional[Dict[str, any]] = None,
         export_dir: Optional[str] = None,
@@ -188,6 +190,7 @@ class QEFFBaseModel(ABC):
             transform_kwargs = {
                 "onnx_base_dir": str(tmp_onnx_dir),
                 "model_name": self.model_name,
+                "enable_onnx_slim_transform": onnx_slim_transform
             }
             if onnx_transform_kwargs is not None:
                 transform_kwargs.update(onnx_transform_kwargs)

--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -10,7 +10,7 @@ import numpy as np
 import onnx
 from onnx import ModelProto, external_data_helper, numpy_helper
 import onnxslim 
-import time
+
 class OnnxTransform:
     """
     OnnxTransform is the base class for graph modifications on exported onnx.
@@ -123,13 +123,10 @@ class OnnxSlimTransform(OnnxTransform):
         onnx_slim_transform = kwargs.get("enable_onnx_slim_transform", False)
         temp_onnx_path = kwargs.get("temp_onnx_path", None)
         if onnx_slim_transform:
-            # t1=time.time()
             print("onnx slim transform done")
             transformed= True
             slimmed_model = onnxslim.slim(model)
             onnx.save(slimmed_model, temp_onnx_path)
-            # t2=time.time()
-            # print(f"Time taken to slim: {t2-t1} seconds")
             return slimmed_model, transformed
         return model, transformed
    

--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -9,8 +9,7 @@ from typing import Optional, Tuple
 
 import numpy as np
 from onnx import ModelProto, external_data_helper, numpy_helper
-
-
+import onnxslim 
 class OnnxTransform:
     """
     OnnxTransform is the base class for graph modifications on exported onnx.
@@ -36,7 +35,7 @@ class FP16ClipTransform(OnnxTransform):
     """
     Clips the tensor values to be in FP16 range, but preserves -inf values.
     """
-
+    print("FP16ClipTransform is applied")
     @classmethod
     def apply(cls, model: ModelProto, *, onnx_base_dir: Optional[str] = None, **kwargs) -> Tuple[ModelProto, bool]:
         """
@@ -99,3 +98,32 @@ class SplitTensorsTransform(OnnxTransform):
                     current_file_size = tsize
                 external_data_helper.set_external_data(tensor, f"{model_name}_{file_num}.onnx.data")
         return model, transformed
+
+
+class OnnxSlimTransform(OnnxTransform):
+    """
+    Applies onnx-slim transformations on the given ONNX graph.
+    """
+
+    @classmethod
+    def apply(
+        cls,
+        model: ModelProto,
+        *,
+        onnx_base_dir: Optional[str] = None,
+        **kwargs,
+    ) -> Tuple[ModelProto, bool]:
+        """
+        :param enable_onnx_slim_transform: If True, applies onnx-slim transformations.
+        """
+        print(kwargs)
+        transformed=False
+        onnx_slim_transform = kwargs.get("enable_onnx_slim_transform", False)
+        if onnx_slim_transform:
+            print("onnx slim transform done")
+            transformed= True
+            slimmed_model = onnxslim.slim(model)
+            print(transformed)
+            return slimmed_model, transformed
+        return model, transformed
+   

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -161,7 +161,7 @@ class QEFFAutoModel(QEFFTransformersBase):
 
     _hf_auto_class = AutoModel
     _pytorch_transforms = [CustomOpsTransform, AwqToMatmulNbitsTransform, GPTQToMatmulNbitsTransform]
-    _onnx_transforms = [FP16ClipTransform,  OnnxSlimTransform,SplitTensorsTransform]
+    _onnx_transforms = [OnnxSlimTransform, FP16ClipTransform, SplitTensorsTransform]
 
     def __init__(self, model: nn.Module, pooling=None,onnx_slim_transform:bool=False ,**kwargs):
         super().__init__(model)
@@ -447,7 +447,7 @@ class QEffVisionEncoderForTextImageToTextModel(QEFFBaseModel):
         KVCacheTransform,
         KVCacheExternalModuleMapperTransform,
     ]
-    _onnx_transforms = [FP16ClipTransform, OnnxSlimTransform, SplitTensorsTransform]
+    _onnx_transforms = [OnnxSlimTransform, FP16ClipTransform, SplitTensorsTransform]
 
     def __init__(self, model: nn.modules,onnx_slim_transform: bool = False):
         super().__init__(model)
@@ -516,7 +516,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
         VlmKVOffloadTransform,
         SplitGateUpWeightsTransform,
     ]
-    _onnx_transforms = [FP16ClipTransform,  OnnxSlimTransform, SplitTensorsTransform]
+    _onnx_transforms = [OnnxSlimTransform, FP16ClipTransform, SplitTensorsTransform]
 
     def __init__(self, model,onnx_slim_transform: bool = False):
         super().__init__(model)
@@ -942,7 +942,7 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         VlmNoKVOffloadTransform,
         SplitGateUpWeightsTransform,
     ]
-    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform, OnnxSlimTransform]
+    _onnx_transforms = [OnnxSlimTransform, FP16ClipTransform, SplitTensorsTransform]
 
     def __init__(
         self,
@@ -1386,7 +1386,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         SplitGateUpWeightsTransform,
         KVCacheExternalModuleMapperTransform,
     ]
-    _onnx_transforms = [FP16ClipTransform, OnnxSlimTransform, SplitTensorsTransform]
+    _onnx_transforms = [OnnxSlimTransform, FP16ClipTransform, SplitTensorsTransform]
 
     def __init__(
         self,
@@ -1970,7 +1970,7 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
 
     _hf_auto_class = AutoModelForSpeechSeq2Seq
     _pytorch_transforms = [CustomOpsTransform, AwqToMatmulNbitsTransform, GPTQToMatmulNbitsTransform, KVCacheTransform]
-    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform, OnnxSlimTransform]
+    _onnx_transforms = [OnnxSlimTransform, FP16ClipTransform, SplitTensorsTransform]
 
     def __init__(self, model: nn.Module,onnx_slim_transform:bool=False, **kwargs):
         model_class_name = model.__class__.__name__

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -26,7 +26,7 @@ from transformers import (
 
 import QEfficient
 from QEfficient.base.modeling_qeff import QEFFBaseModel
-from QEfficient.base.onnx_transforms import FP16ClipTransform, SplitTensorsTransform
+from QEfficient.base.onnx_transforms import FP16ClipTransform, SplitTensorsTransform, OnnxSlimTransform
 from QEfficient.base.pytorch_transforms import SplitGateUpWeightsTransform
 from QEfficient.generation.cloud_infer import QAICInferenceSession
 from QEfficient.generation.text_generation_inference import (
@@ -82,17 +82,17 @@ class QEFFTransformersBase(QEFFBaseModel):
 
     @classmethod
     @with_replaced_quantizers
-    def from_pretrained(cls, pretrained_model_name_or_path: str, *args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path: str,onnx_slim_transform: bool=False, *args, **kwargs):
         if kwargs.get("attn_implementation", None) not in {None, "eager"}:
             logger.warning('Updating attn_implementation="eager"')
 
         if kwargs.get("low_cpu_mem_usage", None):
             logger.warning("Updating low_cpu_mem_usage=False")
 
-        kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
+        kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False,"enable_onnx_slim_transform":onnx_slim_transform})
 
         model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
-        return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path)
+        return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path,**kwargs)
 
     @property
     def model_name(self) -> str:
@@ -161,9 +161,9 @@ class QEFFAutoModel(QEFFTransformersBase):
 
     _hf_auto_class = AutoModel
     _pytorch_transforms = [CustomOpsTransform, AwqToMatmulNbitsTransform, GPTQToMatmulNbitsTransform]
-    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform]
+    _onnx_transforms = [FP16ClipTransform,  OnnxSlimTransform,SplitTensorsTransform]
 
-    def __init__(self, model: nn.Module, pooling=None, **kwargs):
+    def __init__(self, model: nn.Module, pooling=None,onnx_slim_transform:bool=False ,**kwargs):
         super().__init__(model)
 
         # Make Embedding specific transforms like appending pooling
@@ -171,12 +171,12 @@ class QEFFAutoModel(QEFFTransformersBase):
             self.model, _ = PoolingTransform.apply(self.model, pooling)
 
         self.model.base_model.config.use_cache = True
-
+        self.onnx_slim_transform = onnx_slim_transform
         self.pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None)
 
     @classmethod
     @with_replaced_quantizers
-    def from_pretrained(cls, pretrained_model_name_or_path, pooling=None, *args, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path, pooling=None,onnx_slim_transform: bool=False, *args, **kwargs):
         """
         This method serves as the easiest entry point into using QEfficient. The interface is designed to be similar to transformers.AutoModel.
         Once the model is initialized, you can use other methods such as export, compile, and generate on the same object.
@@ -228,7 +228,7 @@ class QEFFAutoModel(QEFFTransformersBase):
                 model, kv_offload=kv_offload
             )
 
-        return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path, pooling=pooling, **kwargs)
+        return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path, pooling=pooling,onnx_slim_transform=onnx_slim_transform, **kwargs)
 
     @property
     def model_hash(self) -> str:
@@ -252,7 +252,7 @@ class QEFFAutoModel(QEFFTransformersBase):
     def get_model_config(self) -> dict:
         return self.model.config.__dict__
 
-    def export(self, export_dir: Optional[str] = None) -> str:
+    def export(self, export_dir: Optional[str] = None, **kwargs) -> str:
         """
         Exports the model to ``ONNX`` format using ``torch.onnx.export``.
 
@@ -278,6 +278,7 @@ class QEFFAutoModel(QEFFTransformersBase):
             example_inputs,
             output_names,
             dynamic_axes,
+            onnx_slim_transform= self.onnx_slim_transform,
             export_dir=export_dir,
         )
 
@@ -446,14 +447,15 @@ class QEffVisionEncoderForTextImageToTextModel(QEFFBaseModel):
         KVCacheTransform,
         KVCacheExternalModuleMapperTransform,
     ]
-    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform]
+    _onnx_transforms = [FP16ClipTransform, OnnxSlimTransform, SplitTensorsTransform]
 
-    def __init__(self, model: nn.modules):
+    def __init__(self, model: nn.modules,onnx_slim_transform: bool = False):
         super().__init__(model)
         self.model = model.get_qeff_vision_encoder()
+        self.onnx_slim_transform = onnx_slim_transform
 
     def export(self, inputs, output_names, dynamic_axes, export_dir=None):
-        return self._export(inputs, output_names, dynamic_axes, export_dir)
+        return self._export(inputs, output_names, dynamic_axes, export_dir,onnx_slim_transform= self.onnx_slim_transform,)
 
     def compile(
         self,
@@ -514,14 +516,15 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
         VlmKVOffloadTransform,
         SplitGateUpWeightsTransform,
     ]
-    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform]
+    _onnx_transforms = [FP16ClipTransform,  OnnxSlimTransform, SplitTensorsTransform]
 
-    def __init__(self, model):
+    def __init__(self, model,onnx_slim_transform: bool = False):
         super().__init__(model)
         self.model = model.get_qeff_language_decoder()
+        self.onnx_slim_transform=onnx_slim_transform
 
     def export(self, inputs, output_names, dynamic_axes, export_dir=None):
-        return self._export(inputs, output_names, dynamic_axes, export_dir)
+        return self._export(inputs, output_names, dynamic_axes, export_dir,onnx_slim_transform= self.onnx_slim_transform,)
 
     def compile(
         self,
@@ -579,6 +582,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
     def __init__(
         self,
         model: nn.Module,
+        onnx_slim_transform: bool = False,
         **kwargs,
     ):
         if kwargs.pop("full_batch_size", None):
@@ -589,6 +593,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         self.vision_model = QEffVisionEncoderForTextImageToTextModel(model)
         self.lang_model = QEffCausalLMForTextImageToTextModel(model)
         self.input_shapes, self.output_names = None, None
+        self.onnx_slim_transform = onnx_slim_transform
 
     @property
     def model_name(self) -> str:
@@ -598,7 +603,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         return mname
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path: str, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path: str,onnx_slim_transform: bool=False, **kwargs):
         if kwargs.get("attn_implementation", None) not in {None, "eager"}:
             logger.warning('Updating attn_implementation="eager"')
 
@@ -606,8 +611,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             logger.warning("Updating low_cpu_mem_usage=False")
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
-        return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path, **kwargs)
+        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, onnx_slim_transform,**kwargs)
+        return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path,onnx_slim_transform=onnx_slim_transform, **kwargs)
 
     @property
     def onnx_path(self):
@@ -937,11 +942,12 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         VlmNoKVOffloadTransform,
         SplitGateUpWeightsTransform,
     ]
-    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform]
+    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform, OnnxSlimTransform]
 
     def __init__(
         self,
         model: nn.Module,
+        onnx_slim_transform: bool = False,
         **kwargs,
     ):
         if kwargs.pop("full_batch_size", None):
@@ -956,11 +962,12 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         else:
             self.model.config.text_config.use_cache = True
         self.pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None)
-
+        self.onnx_slim_transform=onnx_slim_transform
     @classmethod
     def from_pretrained(
         cls,
         pretrained_model_name_or_path,
+        onnx_slim_transform: bool=False,
         *args,
         **kwargs,
     ):
@@ -973,10 +980,10 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
         from transformers import AutoConfig
 
-        config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
+        config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True,onnx_slim_transform=onnx_slim_transform, **kwargs)
         config._attn_implementation = "eager"
         config.vision_config.use_flash_attn = "false"
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, config, *args, **kwargs)
+        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, config, onnx_slim_transform= onnx_slim_transform, *args, **kwargs)
 
         return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path, **kwargs)
 
@@ -988,7 +995,7 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         inputs = self.model.get_dummy_inputs()
         dynamic_axes = self.model.get_onnx_dynamic_axes()
         output_names = self.model.get_output_names()
-        return self._export(inputs, output_names, dynamic_axes, export_dir=export_dir)
+        return self._export(inputs, output_names, dynamic_axes, export_dir=export_dir,onnx_slim_transform=self.onnx_slim_transform,)
 
     def compile(
         self,
@@ -1308,7 +1315,7 @@ class QEFFAutoModelForImageTextToText:
 
     @classmethod
     @with_replaced_quantizers
-    def from_pretrained(cls, pretrained_model_name_or_path: str, kv_offload: Optional[bool] = None, **kwargs):
+    def from_pretrained(cls, pretrained_model_name_or_path: str,onnx_slim_transform: bool=False, kv_offload: Optional[bool] = None, **kwargs):
         """Used to load models supported by transformers.AutoModelForImageTextToText for Cloud AI 100.
 
         Args:
@@ -1329,8 +1336,8 @@ class QEFFAutoModelForImageTextToText:
             NotImplementedError("Continuous batching is not supported for image-text-to-text models yet.")
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
-        return cls(model, kv_offload=kv_offload, pretrained_model_name_or_path=pretrained_model_name_or_path, **kwargs)
+        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path,onnx_slim_transform=onnx_slim_transform, **kwargs)
+        return cls(model, kv_offload=kv_offload, pretrained_model_name_or_path=pretrained_model_name_or_path, onnx_slim_transform=onnx_slim_transform, **kwargs)
 
 
 MISCLASSIFIED_CAUSAL_LM_TO_QEFF_AUTO_CLASS_MAP = {"InternVLChatModel": QEFFAutoModelForImageTextToText}
@@ -1379,13 +1386,14 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         SplitGateUpWeightsTransform,
         KVCacheExternalModuleMapperTransform,
     ]
-    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform]
+    _onnx_transforms = [FP16ClipTransform, OnnxSlimTransform, SplitTensorsTransform]
 
     def __init__(
         self,
         model: nn.Module,
         continuous_batching: bool = False,
         qaic_config: Optional[dict] = None,
+        onnx_slim_transform: bool = False,
         **kwargs,
     ):
         model_class_name = model.__class__.__name__
@@ -1414,6 +1422,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         self.pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None)
         self.model, transformed = SpDTransform.apply(self.model, qaic_config, **kwargs)
         self.is_tlm = transformed
+        self.onnx_slim_transform = onnx_slim_transform
 
         # ---Sampling---
         # Note: SamplerTransform should be applied after all other transforms
@@ -1440,6 +1449,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         pretrained_model_name_or_path,
         continuous_batching: bool = False,
         qaic_config: Optional[dict] = None,
+        onnx_slim_transform: bool=False,
         *args,
         **kwargs,
     ):
@@ -1509,6 +1519,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             continuous_batching=continuous_batching,
             qaic_config=qaic_config,
             pretrained_model_name_or_path=pretrained_model_name_or_path,
+            onnx_slim_transform=onnx_slim_transform,
             **kwargs,
         )
 
@@ -1614,6 +1625,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             output_names,
             dynamic_axes,
             export_dir=export_dir,
+            onnx_slim_transform=self.onnx_slim_transform
         )
 
     def get_sampling_inputs_and_outputs(
@@ -1958,9 +1970,9 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
 
     _hf_auto_class = AutoModelForSpeechSeq2Seq
     _pytorch_transforms = [CustomOpsTransform, AwqToMatmulNbitsTransform, GPTQToMatmulNbitsTransform, KVCacheTransform]
-    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform]
+    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform, OnnxSlimTransform]
 
-    def __init__(self, model: nn.Module, **kwargs):
+    def __init__(self, model: nn.Module,onnx_slim_transform:bool=False, **kwargs):
         model_class_name = model.__class__.__name__
         if not (model_class_name.endswith("ForConditionalGeneration")):
             raise TypeError(f"Required pytorch module with ForConditionalGeneration, got {model_class_name}")
@@ -1969,7 +1981,7 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
         self.model.config.use_cache = True
         self.num_layers = model.config.num_hidden_layers
         self.pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None)
-
+        self.onnx_slim_transform = onnx_slim_transform
     @property
     def model_hash(self) -> str:
         # NOTE: model_config.to_diff_dict() has "_name_or_path" attribute which is the model card name or path.
@@ -2003,7 +2015,7 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
         inputs = self.model.get_dummy_inputs()
         dynamic_axes = self.model.get_onnx_dynamic_axes()
         output_names = self.model.get_output_names()
-        return self._export(inputs, output_names, dynamic_axes, export_dir=export_dir)
+        return self._export(inputs, output_names, dynamic_axes, export_dir=export_dir,onnx_slim_transform=self.onnx_slim_transform)
 
     def compile(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy==1.26.4",
     "protobuf==6.31.0",
     "onnxscript==0.2.5",
+    "onnxslim==0.1.64",
     "pillow===10.4.0",
     "sympy",
     "tensorboard",


### PR DESCRIPTION
Performance comparison with  onnx-slim transformed model and original model for GPT2 model.
========================= Performance Stats with Onnx-Slim=========================
Average Prefill time a.k.a TTFT is= 0.01 sec        
Decode is= 408.75 tokens/sec        
Total is= 399.23 tokens/sec        
Total (E2E) inference time is= 0.31 sec
onnx file size=420K
qpc file size=391M
GPT2LMHeadModel_0.onnx.data=622.94M
time taken to slim 19 seconds
compile time=39.90 seconds
===============================================================

========================= Performance Stats without Onnx-Slim =========================
Average Prefill time a.k.a TTFT is= 0.01 sec        
Decode is= 384.3 tokens/sec        
Total is= 374.99 tokens/sec        
Total (E2E) inference time is= 0.33 sec
onnx file size=516K
qpc file size= 391M
GPT2LMHeadModel_0.onnx.data=622.94M
compile time =36.44 seconds
=====================================================================