### PR TITLE
Fix llama model o_proj lora_ids passing for finite lorax in release/v1.20.0

### DIFF
--- a/QEfficient/transformers/models/llama/modeling_llama.py
+++ b/QEfficient/transformers/models/llama/modeling_llama.py
@@ -174,7 +174,7 @@ class QEffLlamaAttention(LlamaAttention):
         )
 
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
-        attn_output = self.o_proj(attn_output)
+        attn_output = self.o_proj(attn_output, **kwargs)
         return attn_output, attn_weights, past_key_value
 
 


### PR DESCRIPTION
This is regarding the issue reported in https://github.com/quic/efficient-transformers/issues/572

The finite lorax feature failed to execute when testing on a llama adapter ([jumip/llama-lora-adapter](https://huggingface.co/jumip/llama-lora-adapter)) that contains o_proj as target module.

Work in progress -- test to be added to avoid future regression