### PR TITLE
Adding support for multi-node DDP training

### DIFF
--- a/QEfficient/cloud/finetune.py
+++ b/QEfficient/cloud/finetune.py
@@ -6,7 +6,6 @@
 # -----------------------------------------------------------------------------
 
 import logging
-import os
 import random
 import warnings
 from typing import Any, Optional, Union
@@ -29,7 +28,7 @@ from QEfficient.finetune.utils.config_utils import (
 )
 from QEfficient.finetune.utils.dataset_utils import get_dataloader, get_longest_seq_length
 from QEfficient.finetune.utils.device_map import get_device_map
-from QEfficient.finetune.utils.helper import Task_Mode, get_world_size
+from QEfficient.finetune.utils.helper import Task_Mode, get_local_rank, get_local_world_size, get_rank, get_world_size
 from QEfficient.finetune.utils.logging_utils import logger
 from QEfficient.finetune.utils.parser import get_finetune_parser
 from QEfficient.finetune.utils.train_utils import print_model_size, print_trainable_parameters, train
@@ -92,13 +91,10 @@ def setup_distributed_training(train_config: TrainConfig) -> None:
     assert torch_device.index is None, f"DDP requires only device type (qaic/cuda), got: {torch_device}"
 
     # Torchrun-provided env vars
-    world_size = int(os.environ.get("WORLD_SIZE", "1"))
-    rank = int(os.environ.get("RANK", "0"))
-    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-    local_world_size = int(os.environ.get("LOCAL_WORLD_SIZE", "1"))
-
-    # Sanity check vs helper
-    assert world_size == get_world_size(), f"WORLD_SIZE={world_size} but get_world_size()={get_world_size()}"
+    world_size = get_world_size()
+    rank = get_rank()
+    local_rank = get_local_rank()
+    local_world_size = get_local_world_size()
 
     # Per-node device validation
     num_available_devices = getattr(torch, torch_device.type).device_count()

--- a/QEfficient/finetune/utils/device_map.py
+++ b/QEfficient/finetune/utils/device_map.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 from transformers import AutoConfig
 
-from QEfficient.finetune.utils.helper import get_rank
+from QEfficient.finetune.utils.helper import get_local_rank
 from QEfficient.utils._utils import get_num_layers_from_config
 
 
@@ -81,9 +81,9 @@ def custom_device_map(train_config):
     model_config = AutoConfig.from_pretrained(train_config.model_name)
     num_layers = get_num_layers_from_config(model_config)
     num_pp_stages = train_config.num_pp_stages
-    rank = get_rank()
-    first_device = rank * num_pp_stages
-    last_device = rank * num_pp_stages + (num_pp_stages - 1)
+    local_rank = get_local_rank()
+    first_device = local_rank * num_pp_stages
+    last_device = local_rank * num_pp_stages + (num_pp_stages - 1)
 
     if model_config.tie_word_embeddings:
         lm_head_device = first_device
@@ -102,6 +102,6 @@ def custom_device_map(train_config):
     pp_device_map = np.repeat(pp_stage_ids, n_layer_per_stage)
 
     for i in range(num_layers):
-        device_map[f"model.layers.{i}"] = pp_device_map[i] + rank * num_pp_stages
+        device_map[f"model.layers.{i}"] = pp_device_map[i] + local_rank * num_pp_stages
 
     return device_map

--- a/QEfficient/finetune/utils/helper.py
+++ b/QEfficient/finetune/utils/helper.py
@@ -55,6 +55,15 @@ def get_rank() -> int:
     return int(os.getenv("RANK", 0))
 
 
+def get_local_rank() -> int:
+    """Get the current local rank of the process.
+
+    In DDP, this should correspond to the 'LOCAL_RANK' environment variable set by torchrun.
+    In non-DDP use case, returns 0.
+    """
+    return int(os.getenv("LOCAL_RANK", 0))
+
+
 def is_rank_zero() -> bool:
     """Checks whether the current process is in rank-0 in case of DDP. For
     non-DDP use case it will always return True.
@@ -75,6 +84,18 @@ def get_world_size() -> int:
         int: Number of DDP devices.
     """
     return int(os.getenv("WORLD_SIZE", 1))
+
+
+def get_local_world_size() -> int:
+    """Get total multiprocesses invoked for DDP setting for that node. For pure DDP use case,
+    this will correlate with number of devices being used. For PP+DDP use case,
+    this will give number of processes initiated (i.e. number of model replicas).
+    In case of non-DDP use case, this will return 1.
+
+    Returns:
+        int: Number of DDP devices available on that node.
+    """
+    return int(os.getenv("LOCAL_WORLD_SIZE", 1))
 
 
 def get_autocast_ctx(use_autocast: bool, device_type: str, dtype: torch.dtype = torch.float16) -> ContextManager:

--- a/QEfficient/finetune/utils/train_utils.py
+++ b/QEfficient/finetune/utils/train_utils.py
@@ -66,7 +66,7 @@ def train(
     """
     device = train_config.device
     device_type = torch.device(device).type
-    local_rank = get_rank()
+    rank = get_rank()
 
     train_metric = []
     train_loss = []
@@ -77,7 +77,7 @@ def train(
         if not os.path.exists(train_config.output_dir):
             os.makedirs(train_config.output_dir, exist_ok=True)
         metrics_filename = (
-            f"{train_config.output_dir}/metrics_data_{local_rank}-{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json"
+            f"{train_config.output_dir}/metrics_data_{rank}-{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.json"
         )
         train_step_metric = []
         train_step_loss = []


### PR DESCRIPTION
Add support for multi-node Distributed Data Parallel (DDP) training to the QEfficient finetuning pipeline. This enables scaling training across multiple nodes while keeping the existing single-node behavior unchanged.

Commands for DDP across 2 servers:
For the Master Addr or the Primary Machine, use node-rank as 0:
QAIC_VISIBLE_DEVICES=0,1,2,3 torchrun --nnodes=2 --nproc-per-node=4 --seed 0 --node-rank=0 --master_addr=<MASTER_NODE_IP> --master_port=8000 -m QEfficient.cloud.finetune --device qaic --enable_ddp --model_name "meta-llama/Llama-3.2-1B" --dataset alpaca_dataset --train_batch_size 1 --val_batch_size 1 --num_epochs 1 --max_train_step 200 --max_eval_step 50

For Node 1, use node-rank as 1:
QAIC_VISIBLE_DEVICES=0,1,2,3 torchrun --nnodes=2 --nproc-per-node=4 --seed 0 --node-rank=1 --master_addr=<MASTER_NODE_IP> --master_port=8000 -m QEfficient.cloud.finetune --device qaic --enable_ddp --model_name "meta-llama/Llama-3.2-1B" --dataset alpaca_dataset --train_batch_size 1 --val_batch_size 1 --num_epochs 1 --max_train_step 200 --max_eval_step 50