### PR TITLE
Fixing the default value of CCL in infer.py (#725)

### DIFF
--- a/QEfficient/cloud/infer.py
+++ b/QEfficient/cloud/infer.py
@@ -138,6 +138,7 @@ def main(
     enable_qnn: Optional[bool] = False,
     qnn_config: Optional[str] = None,
     trust_remote_code: Optional[bool] = False,
+    ccl_enabled: Optional[bool] = False,
     **kwargs,
 ) -> None:
     """
@@ -237,6 +238,8 @@ def main(
         if args.mxint8:
             logger.warning("mxint8 is going to be deprecated in a future release, use -mxint8_kv_cache instead.")
 
+    qaic_config = {"ccl_enabled": True} if ccl_enabled else None
+
     qeff_model = QEFFCommonLoader.from_pretrained(
         pretrained_model_name_or_path=model_name,
         cache_dir=cache_dir,
@@ -244,6 +247,7 @@ def main(
         full_batch_size=full_batch_size,
         local_model_dir=local_model_dir,
         trust_remote_code=trust_remote_code,
+        qaic_config=qaic_config,
     )
 
     image_path = kwargs.pop("image_path", None)
@@ -343,14 +347,20 @@ if __name__ == "__main__":
     parser.add_argument(
         "--comp-ctx-lengths-prefill",
         type=lambda comp_ctx_lengths_prefill: [int(x) for x in comp_ctx_lengths_prefill.split(",")],
-        default=[512],
+        default=None,
         help="Define ccl list in csv format (e.g.,--comp-ctx-lengths 512,1024,2048).",
     )
     parser.add_argument(
         "--comp-ctx-lengths-decode",
         type=lambda comp_ctx_lengths_decode: [int(x) for x in comp_ctx_lengths_decode.split(",")],
-        default=[2048],
+        default=None,
         help="Define ccl list in csv format (e.g.,--comp-ctx-lengths 512,1024,2048).",
+    )
+    parser.add_argument(
+        "--ccl_enabled",
+        "--ccl-enabled",
+        action="store_true",
+        help="If passed, ccl feature will be activated",
     )
     parser.add_argument(
         "--mxfp6",


### PR DESCRIPTION
Since CCL is deactivated by default, the value of CCL lists (ccl_prefill and ccl_decode) should be None by default. In infer.py script the value of these lists wasn't None and it caused the problem of ccl activation by default. In this PR we addressed this issue.

---------