### PR TITLE
Adding the support of dense models distilled from moe models with the same architecture

### DIFF
--- a/QEfficient/base/pytorch_transforms.py
+++ b/QEfficient/base/pytorch_transforms.py
@@ -152,10 +152,16 @@ class SplitGateUpWeightsTransform(PytorchTransform):
             # ---- build the textual prefix once per layer ----------
             if is_gpt_oss:
                 prefix = f"model.layers.{layer_idx}.mlp.experts."
-                experts = model_tmp.model.layers[layer_idx].mlp.experts
+                # experts = model_tmp.model.layers[layer_idx].mlp.experts
+                ff = model_tmp.model.layers[layer_idx].mlp
             else:
                 prefix = f"model.layers.{layer_idx}.feed_forward.experts."
-                experts = model_tmp.model.layers[layer_idx].feed_forward.experts
+                # experts = model_tmp.model.layers[layer_idx].feed_forward.experts
+                ff = model_tmp.model.layers[layer_idx].feed_forward
+
+            if not hasattr(ff, "experts"):
+                continue
+            experts = ff.experts
 
             fused_key = prefix + "gate_up_proj"
             gate_key = prefix + "gate_proj"


### PR DESCRIPTION
In this PR, we are adding the support of meta-llama/Llama-Guard-4-12B which is a dense model distilled form llama4 scout moe model. The changes in pytorch_transforms.py file can be applied to any dense model distilled from a moe model with supported architecture in QEfficient.