### PR TITLE
Updated reduce sum calculation to use einsum for gpt_oss to rel/v1.21.0

### DIFF
--- a/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -402,7 +402,7 @@ class QEffGptOssMLP(GptOssMLP):
 
         # Apply routing weights AFTER expert computation
         experts_out = experts_out * router_top_value.unsqueeze(-1)
-        experts_out_sum = torch.einsum('bnd->bd', experts_out)
+        experts_out_sum = torch.einsum("bnd->bd", experts_out)
         return experts_out_sum, router_logits
 
     def optimized_moe_forward(self, hidden_states: torch.Tensor):


### PR DESCRIPTION
The decode‑only GPT‑OSS model was failing when executing subfunctions due to somehow considering a dynamic dim value during reduced‑sum calculation. This caused incorrect tensor reduction and resulted in compilation errors.
The fix replaces the reduction logic with an einsum-based computation, ensuring stable and deterministic summation regardless of dimension shape.