### PR TITLE
FT-CI enabled on torch-qaic-env

### DIFF
--- a/docs/source/finetune.md
+++ b/docs/source/finetune.md
@@ -127,7 +127,8 @@ In distributed ML setups, all nodes must resolve each other’s hostnames. If DN
 
 2. Set QAIC Device Visibility
 
-``` export QAIC_VISIBLE_DEVICES=$(seq -s, 0 63)
+``` 
+export QAIC_VISIBLE_DEVICES=$(seq -s, 0 63)
 ```
 
 This exposes devices 0–63 to the training process.

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                    pip install .[test] &&
                    pip install junitparser pytest-xdist &&
                    pip install librosa==0.10.2 soundfile==0.13.1 && #packages needed to load example for whisper testing
-                   pip install --extra-index-url https://download.pytorch.org/whl/cpu timm==1.0.14 torchvision==0.22.0+cpu einops==0.8.1 && #packages to load VLMs"
+                   pip install --extra-index-url https://download.pytorch.org/whl/cpu timm==1.0.14 torchvision==0.22.0+cpu einops==0.8.1" #packages to load VLMs"
                '''
            }
        }

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -201,9 +201,10 @@ pipeline {
                     sh '''
                     sudo docker exec ${BUILD_TAG} bash -c "
                     cd /efficient-transformers &&
-                    . preflight_qeff/bin/activate &&
-                    pip install /opt/qti-aic/integrations/torch_qaic/py310/torch_qaic-0.1.0-cp310-cp310-linux_x86_64.whl &&
-                    pip install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 --index-url https://download.pytorch.org/whl/cpu &&
+                    source /opt/torch-qaic-env/bin/activate &&
+                    pip install --upgrade pip setuptools &&
+                    pip install -e .[test] &&
+                    pip install torch==2.9.1+cpu torchvision==0.24.1+cpu torchaudio==2.9.1+cpu --index-url https://download.pytorch.org/whl/cpu &&
                     mkdir -p $PWD/cli_qaic_finetuning &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/cli_qaic_finetuning &&

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
                     source /opt/torch-qaic-env/bin/activate &&
                     pip install --upgrade pip setuptools &&
                     pip install .[test] &&
+                    pip install junitparser &&
                     pip install torch==2.9.1+cpu torchvision==0.24.1+cpu torchaudio==2.9.1+cpu --index-url https://download.pytorch.org/whl/cpu &&
                     rm -rf QEfficient"
                 '''

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -24,11 +24,23 @@ pipeline {
                    pip install .[test] &&
                    pip install junitparser pytest-xdist &&
                    pip install librosa==0.10.2 soundfile==0.13.1 && #packages needed to load example for whisper testing
-                   pip install --extra-index-url https://download.pytorch.org/whl/cpu timm==1.0.14 torchvision==0.22.0+cpu einops==0.8.1 && #packages to load VLMs
-                   rm -rf QEfficient"
+                   pip install --extra-index-url https://download.pytorch.org/whl/cpu timm==1.0.14 torchvision==0.22.0+cpu einops==0.8.1 && #packages to load VLMs"
                '''
            }
        }
+       stage('Setup Finetune env') {
+            steps {
+                sh '''
+                    sudo docker exec ${BUILD_TAG} bash -c "
+                    cd /efficient-transformers &&
+                    source /opt/torch-qaic-env/bin/activate &&
+                    pip install --upgrade pip setuptools &&
+                    pip install .[test] &&
+                    pip install torch==2.9.1+cpu torchvision==0.24.1+cpu torchaudio==2.9.1+cpu --index-url https://download.pytorch.org/whl/cpu &&
+                    rm -rf QEfficient"
+                '''
+            }
+        }
        stage('HL APIs Tests') {
            parallel {
                stage('Model Export & ONNX Tests') {
@@ -202,10 +214,7 @@ pipeline {
                     sudo docker exec ${BUILD_TAG} bash -c "
                     cd /efficient-transformers &&
                     source /opt/torch-qaic-env/bin/activate &&
-                    pip install --upgrade pip setuptools &&
-                    pip install -e .[test] &&
-                    pip install torch==2.9.1+cpu torchvision==0.24.1+cpu torchaudio==2.9.1+cpu --index-url https://download.pytorch.org/whl/cpu &&
-                    mkdir -p $PWD/cli_qaic_finetuning &&
+                    mkdir -p \$PWD/cli_qaic_finetuning &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/cli_qaic_finetuning &&
                     pytest tests -m '(cli) and (on_qaic) and (not qnn) and (not multimodal) and (finetune)' --ignore tests/vllm --junitxml=tests/tests_log_finetune.xml --durations=10 &&


### PR DESCRIPTION
We are updating the Finetune (FT) CI pipeline to run using the pre‑built torch‑qaic‑env environment directly inside the Docker image instead of installing additional torch-qaic .whl on preflight-qeff env.