### PR TITLE
feat: Named graph specializations in specializations.json (Prefill/Decode/Vision/Encoder/Embedding)

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -539,6 +539,9 @@ class QEFFBaseModel(ABC):
 
             return self.qpc_path
 
+        # Pop internal-only kwargs that must never reach the compiler command line.
+        spec_module_name = compiler_options.pop("specialization_module_name", None)
+
         command = (
             constants.COMPILER
             + [
@@ -609,8 +612,6 @@ class QEFFBaseModel(ABC):
         # Write specializations.json file
         if specializations is not None:
             specializations_json = compile_dir / "specializations.json"
-            # Pop the hint before it reaches the compiler command builder.
-            spec_module_name = compiler_options.pop("specialization_module_name", None)
             specializations_data = {
                 "specializations": to_named_specializations(specializations, module_name=spec_module_name)
             }

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -472,6 +472,7 @@ class QEFFBaseModel(ABC):
         enable_chunking: Optional[bool] = False,
         retain_full_kv: Optional[bool] = None,
         qaic_config: Optional[dict] = None,
+        specialization_module_name: Optional[str] = None,
         **compiler_options,
     ) -> str:
         """
@@ -609,7 +610,7 @@ class QEFFBaseModel(ABC):
         # Write specializations.json file
         if specializations is not None:
             specializations_json = compile_dir / "specializations.json"
-            specializations_data = {"specializations": to_named_specializations(specializations)}
+            specializations_data = {"specializations": to_named_specializations(specializations, module_name=specialization_module_name)}
             create_json(str(specializations_json), specializations_data)
             command.append(f"-network-specialization-config={specializations_json}")
 

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -539,9 +539,6 @@ class QEFFBaseModel(ABC):
 
             return self.qpc_path
 
-        # Pop internal-only kwargs that must never reach the compiler command line.
-        spec_module_name = compiler_options.pop("specialization_module_name", None)
-
         command = (
             constants.COMPILER
             + [
@@ -612,9 +609,7 @@ class QEFFBaseModel(ABC):
         # Write specializations.json file
         if specializations is not None:
             specializations_json = compile_dir / "specializations.json"
-            specializations_data = {
-                "specializations": to_named_specializations(specializations, module_name=spec_module_name)
-            }
+            specializations_data = {"specializations": to_named_specializations(specializations)}
             create_json(str(specializations_json), specializations_data)
             command.append(f"-network-specialization-config={specializations_json}")
 

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -41,6 +41,7 @@ from QEfficient.utils import (
     hash_dict_params,
     load_json,
     require_value,
+    to_named_specializations,
 )
 from QEfficient.utils.export_utils import export_wrapper
 
@@ -608,9 +609,7 @@ class QEFFBaseModel(ABC):
         # Write specializations.json file
         if specializations is not None:
             specializations_json = compile_dir / "specializations.json"
-            specializations_data = {
-                "specializations": [{k: str(v) for k, v in spec.items()} for spec in specializations]
-            }
+            specializations_data = {"specializations": to_named_specializations(specializations)}
             create_json(str(specializations_json), specializations_data)
             command.append(f"-network-specialization-config={specializations_json}")
 

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -610,7 +610,9 @@ class QEFFBaseModel(ABC):
         # Write specializations.json file
         if specializations is not None:
             specializations_json = compile_dir / "specializations.json"
-            specializations_data = {"specializations": to_named_specializations(specializations, module_name=specialization_module_name)}
+            specializations_data = {
+                "specializations": to_named_specializations(specializations, module_name=specialization_module_name)
+            }
             create_json(str(specializations_json), specializations_data)
             command.append(f"-network-specialization-config={specializations_json}")
 

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -609,7 +609,11 @@ class QEFFBaseModel(ABC):
         # Write specializations.json file
         if specializations is not None:
             specializations_json = compile_dir / "specializations.json"
-            specializations_data = {"specializations": to_named_specializations(specializations)}
+            # Pop the hint before it reaches the compiler command builder.
+            spec_module_name = compiler_options.pop("specialization_module_name", None)
+            specializations_data = {
+                "specializations": to_named_specializations(specializations, module_name=spec_module_name)
+            }
             create_json(str(specializations_json), specializations_data)
             command.append(f"-network-specialization-config={specializations_json}")
 

--- a/QEfficient/compile/compile_helper.py
+++ b/QEfficient/compile/compile_helper.py
@@ -21,8 +21,8 @@ from QEfficient.utils.logging_utils import logger
 def create_and_dump_specializations(
     batch_size: int, prompt_len: int, ctx_len: int, path: str, full_batch_size: Optional[int] = None
 ):
-    # Build flat specialization entries first, then convert to named format.
-    flat_specs = [
+    # Build the base specialization entries first, then convert to named format.
+    base_specializations = [
         {
             "batch_size": str(batch_size),
             "seq_len": str(prompt_len),
@@ -32,16 +32,16 @@ def create_and_dump_specializations(
     ]
     # If continuous batching is enabled by providing full_batch_size we need to add FBS to the specialization file and update the batch size of decoder part to FBS
     if full_batch_size is not None:
-        flat_specs[0]["full_batch_size"] = str(full_batch_size)
-        flat_specs[1]["full_batch_size"] = str(full_batch_size)
-        flat_specs[1]["batch_size"] = str(full_batch_size)
+        base_specializations[0]["full_batch_size"] = str(full_batch_size)
+        base_specializations[1]["full_batch_size"] = str(full_batch_size)
+        base_specializations[1]["batch_size"] = str(full_batch_size)
 
     # To handle repetitive input in specializations when prompt_len is 1
     if prompt_len == 1 and full_batch_size is None:
-        flat_specs.pop()
+        base_specializations.pop()
 
     # Dump
-    specializations = {"specializations": to_named_specializations(flat_specs)}
+    specializations = {"specializations": to_named_specializations(base_specializations)}
     with open(path, "w") as file:
         json.dump(specializations, file, indent=4)
 

--- a/QEfficient/compile/compile_helper.py
+++ b/QEfficient/compile/compile_helper.py
@@ -14,35 +14,34 @@ from typing import List, Optional, Tuple
 
 from QEfficient.compile.qnn_compiler import compile as qnn_compile
 from QEfficient.utils import constants
-from QEfficient.utils._utils import load_json, load_yaml
+from QEfficient.utils._utils import load_json, load_yaml, to_named_specializations
 from QEfficient.utils.logging_utils import logger
 
 
 def create_and_dump_specializations(
     batch_size: int, prompt_len: int, ctx_len: int, path: str, full_batch_size: Optional[int] = None
 ):
-    # Create specialization file.
-    specializations = {
-        "specializations": [
-            {
-                "batch_size": str(batch_size),
-                "seq_len": str(prompt_len),
-                "ctx_len": str(ctx_len),
-            },
-            {"batch_size": str(batch_size), "seq_len": "1", "ctx_len": str(ctx_len)},
-        ]
-    }
-    # If continuous batching is enabled by proving full_batch_size we need to add FBS to the specialization file and update the batch size of decoder part to FBS
+    # Build flat specialization entries first, then convert to named format.
+    flat_specs = [
+        {
+            "batch_size": str(batch_size),
+            "seq_len": str(prompt_len),
+            "ctx_len": str(ctx_len),
+        },
+        {"batch_size": str(batch_size), "seq_len": "1", "ctx_len": str(ctx_len)},
+    ]
+    # If continuous batching is enabled by providing full_batch_size we need to add FBS to the specialization file and update the batch size of decoder part to FBS
     if full_batch_size is not None:
-        specializations["specializations"][0]["full_batch_size"] = str(full_batch_size)
-        specializations["specializations"][1]["full_batch_size"] = str(full_batch_size)
-        specializations["specializations"][1]["batch_size"] = str(full_batch_size)
+        flat_specs[0]["full_batch_size"] = str(full_batch_size)
+        flat_specs[1]["full_batch_size"] = str(full_batch_size)
+        flat_specs[1]["batch_size"] = str(full_batch_size)
 
-    # To handle repetative input in specializations when prompt_len is 1
+    # To handle repetitive input in specializations when prompt_len is 1
     if prompt_len == 1 and full_batch_size is None:
-        specializations["specializations"].pop()
+        flat_specs.pop()
 
     # Dump
+    specializations = {"specializations": to_named_specializations(flat_specs)}
     with open(path, "w") as file:
         json.dump(specializations, file, indent=4)
 

--- a/QEfficient/compile/qnn_compiler.py
+++ b/QEfficient/compile/qnn_compiler.py
@@ -11,7 +11,7 @@ import os
 import shutil
 from typing import Dict, List, Optional
 
-from QEfficient.utils._utils import create_json, execute_command, load_json
+from QEfficient.utils._utils import create_json, execute_command, load_json, to_named_specializations
 from QEfficient.utils.constants import QnnConstants
 from QEfficient.utils.generate_qnn_network_specialization_config import (
     generate_data_format_config,
@@ -423,7 +423,7 @@ def compile(
             specializations_json = qpc_base_path / "specializations.json"
             with open(specializations_json, "w") as fp:
                 json.dump(
-                    {"specializations": [{k: str(v) for k, v in spec.items()} for spec in specializations]},
+                    {"specializations": to_named_specializations(specializations)},
                     fp,
                     indent=4,
                 )

--- a/QEfficient/diffusers/pipelines/pipeline_utils.py
+++ b/QEfficient/diffusers/pipelines/pipeline_utils.py
@@ -15,7 +15,7 @@ import numpy as np
 import PIL.Image
 from tqdm import tqdm
 
-from QEfficient.utils._utils import load_json
+from QEfficient.utils._utils import load_json, to_named_specializations
 from QEfficient.utils.logging_utils import logger
 
 
@@ -173,6 +173,9 @@ def compile_modules_parallel(
         else:
             specializations = [specializations]
 
+        # Convert flat dicts to named {name, symbols} format using the module name.
+        specializations = to_named_specializations(specializations, module_name=module_name)
+
         if module_obj.qpc_path is None:
             # Compile with prepared specializations
             module_obj.compile(specializations=specializations, **compile_kwargs)
@@ -225,6 +228,9 @@ def compile_modules_sequential(
                 specializations = [specializations]
         else:
             specializations = [specializations]
+
+        # Convert flat dicts to named {name, symbols} format using the module name.
+        specializations = to_named_specializations(specializations, module_name=module_name)
 
         if module_obj.qpc_path is None:
             # Compile with prepared specializations

--- a/QEfficient/diffusers/pipelines/pipeline_utils.py
+++ b/QEfficient/diffusers/pipelines/pipeline_utils.py
@@ -15,7 +15,7 @@ import numpy as np
 import PIL.Image
 from tqdm import tqdm
 
-from QEfficient.utils._utils import load_json, to_named_specializations
+from QEfficient.utils._utils import load_json
 from QEfficient.utils.logging_utils import logger
 
 
@@ -173,8 +173,11 @@ def compile_modules_parallel(
         else:
             specializations = [specializations]
 
-        # Convert flat dicts to named {name, symbols} format using the module name.
-        specializations = to_named_specializations(specializations, module_name=module_name)
+        # Tag each spec with the module name so _compile knows the graph name.
+        specializations = [
+            {**s, "_graph_name": f"{module_name}_model_type_{s['model_type']}" if "model_type" in s else module_name}
+            for s in specializations
+        ]
 
         if module_obj.qpc_path is None:
             # Compile with prepared specializations
@@ -229,8 +232,11 @@ def compile_modules_sequential(
         else:
             specializations = [specializations]
 
-        # Convert flat dicts to named {name, symbols} format using the module name.
-        specializations = to_named_specializations(specializations, module_name=module_name)
+        # Tag each spec with the module name so _compile knows the graph name.
+        specializations = [
+            {**s, "_graph_name": f"{module_name}_model_type_{s['model_type']}" if "model_type" in s else module_name}
+            for s in specializations
+        ]
 
         if module_obj.qpc_path is None:
             # Compile with prepared specializations

--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -188,10 +188,14 @@ def get_compilation_dims(qpc_path: str) -> Tuple[int, int, Optional[int]]:
     else:
         raise FileNotFoundError(f"expected specializations.json file at path, {qpc_base_path}")
 
-    compilation_batch_size = int(data["specializations"][0]["batch_size"])
-    compilation_ctx_len = int(data["specializations"][0]["ctx_len"])
-    if compilation_fbs := data["specializations"][0].get("full_batch_size", None):
+    # Support both the legacy flat format and the new {name, symbols} format.
+    first = data["specializations"][0]
+    spec = first.get("symbols", first)
+    compilation_batch_size = int(spec["batch_size"])
+    compilation_ctx_len = int(spec["ctx_len"])
+    if compilation_fbs := spec.get("full_batch_size", None):
         compilation_fbs = int(compilation_fbs)
+    return compilation_batch_size, compilation_ctx_len, compilation_fbs
     return compilation_batch_size, compilation_ctx_len, compilation_fbs
 
 

--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -196,7 +196,6 @@ def get_compilation_dims(qpc_path: str) -> Tuple[int, int, Optional[int]]:
     if compilation_fbs := spec.get("full_batch_size", None):
         compilation_fbs = int(compilation_fbs)
     return compilation_batch_size, compilation_ctx_len, compilation_fbs
-    return compilation_batch_size, compilation_ctx_len, compilation_fbs
 
 
 def get_input_prompts(prompt: str, prompts_txt_file_path: str) -> List[str]:

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1582,6 +1582,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 compile_dir=compile_dir,
                 compile_only=True,
                 specializations=specializations["vision"],
+                specialization_module_name="Vision",
                 convert_to_fp16=(CUSTOM_IO_DTYPE_MAP[target_dtype] == "float16"),
                 mxfp6_matmul=constants.VISION_MXFP6_MATMUL,
                 mdp_ts_num_devices=num_devices,

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -449,8 +449,14 @@ class QEFFAutoModel(QEFFTransformersBase):
         if isinstance(seq_len, list) and len(seq_len) >= 15:
             warnings.warn("Recommended: `seq_len` should contain fewer than 15 items.")
 
+        _seq_lens = seq_len if isinstance(seq_len, list) else [seq_len]
         specializations = [
-            {"batch_size": batch_size, "seq_len": sl} for sl in (seq_len if isinstance(seq_len, list) else [seq_len])
+            {
+                "_graph_name": "Embedding" if len(_seq_lens) == 1 else f"Embedding_{i}",
+                "batch_size": batch_size,
+                "seq_len": sl,
+            }
+            for i, sl in enumerate(_seq_lens)
         ]
 
         target_dtype = getattr(self.model.config, "torch_dtype", torch.float32)
@@ -794,8 +800,14 @@ class QEFFAutoModelForSequenceClassification(QEFFTransformersBase):
         if isinstance(seq_len, list) and len(seq_len) >= 15:
             warnings.warn("Recommended: `seq_len` should contain fewer than 15 items.")
 
+        _seq_lens = seq_len if isinstance(seq_len, list) else [seq_len]
         specializations = [
-            {"batch_size": batch_size, "seq_len": sl} for sl in (seq_len if isinstance(seq_len, list) else [seq_len])
+            {
+                "_graph_name": "SeqClassification" if len(_seq_lens) == 1 else f"SeqClassification_{i}",
+                "batch_size": batch_size,
+                "seq_len": sl,
+            }
+            for i, sl in enumerate(_seq_lens)
         ]
         target_dtype = getattr(self.model.config, "torch_dtype", torch.float32)
         return self._compile(
@@ -3257,7 +3269,9 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         # TODO: remove this; not required
         if full_batch_size:
             spec["full_batch_exec_size"] = exec_batch_size
-        return {k: v for k, v in spec.items() if v is not None}
+        result = {k: v for k, v in spec.items() if v is not None}
+        result["_graph_name"] = "Prefill"
+        return result
 
     def build_decode_specialization(
         self,
@@ -3315,7 +3329,9 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             spec["full_batch_size"] = kv_cache_batch_size
         else:
             spec["batch_size"] = kv_cache_batch_size
-        return {k: v for k, v in spec.items() if v is not None}
+        result = {k: v for k, v in spec.items() if v is not None}
+        result["_graph_name"] = "Decode"
+        return result
 
     def compile(
         self,
@@ -4236,8 +4252,10 @@ class QEFFAutoModelForCTC(QEFFTransformersBase):
             :str: Path of the compiled ``qpc`` package.
         """
 
+        _seq_lens = seq_len if isinstance(seq_len, list) else [seq_len]
         specializations = [
-            {"batch_size": batch_size, "seq_len": sl} for sl in (seq_len if isinstance(seq_len, list) else [seq_len])
+            {"_graph_name": "CTC" if len(_seq_lens) == 1 else f"CTC_{i}", "batch_size": batch_size, "seq_len": sl}
+            for i, sl in enumerate(_seq_lens)
         ]
 
         target_dtype = getattr(self.model.config, "torch_dtype", torch.float32)

--- a/QEfficient/transformers/models/whisper/modeling_whisper.py
+++ b/QEfficient/transformers/models/whisper/modeling_whisper.py
@@ -835,6 +835,7 @@ class QEffWhisperForConditionalGeneration(WhisperForConditionalGeneration):
         feature_len = encoder_ctx_len * 2
 
         encoder_specializations = {
+            "_graph_name": "Encoder",
             "batch_size": batch_size,
             "seq_len": 1,
             "encoder_ctx_len": encoder_ctx_len,
@@ -843,6 +844,7 @@ class QEffWhisperForConditionalGeneration(WhisperForConditionalGeneration):
         }
 
         decoder_specializations = {
+            "_graph_name": "Decode",
             "batch_size": batch_size,
             "seq_len": 1,
             "encoder_ctx_len": encoder_ctx_len,

--- a/QEfficient/utils/_utils.py
+++ b/QEfficient/utils/_utils.py
@@ -897,6 +897,15 @@ def _infer_specialization_name(spec: Dict, index: int, module_name: Optional[str
         if "sequence_length" in spec:
             return "Embedding"
         return f"Graph_{index}"
+
+    # Whisper: both encoder-run and decoder-run specs carry seq_len=1 and
+    # encoder_ctx_len.  feature_len distinguishes them: > 1 is the encoder
+    # (full audio features), == 1 is the decoder (cross-attention disabled).
+    if "encoder_ctx_len" in spec and "feature_len" in spec:
+        if str(spec["feature_len"]) != "1":
+            return "Encoder"
+        return "Decode"
+
     seq_len = spec["seq_len"]
     if str(seq_len) == "1":
         return "Decode"

--- a/QEfficient/utils/_utils.py
+++ b/QEfficient/utils/_utils.py
@@ -897,15 +897,6 @@ def _infer_specialization_name(spec: Dict, index: int, module_name: Optional[str
         if "sequence_length" in spec:
             return "Embedding"
         return f"Graph_{index}"
-
-    # Whisper: both encoder-run and decoder-run specs carry seq_len=1 and
-    # encoder_ctx_len.  feature_len distinguishes them: > 1 is the encoder
-    # (full audio features), == 1 is the decoder (cross-attention disabled).
-    if "encoder_ctx_len" in spec and "feature_len" in spec:
-        if str(spec["feature_len"]) != "1":
-            return "Encoder"
-        return "Decode"
-
     seq_len = spec["seq_len"]
     if str(seq_len) == "1":
         return "Decode"

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -52,6 +52,7 @@ from QEfficient.transformers.models.modeling_auto import (
     QEFFAutoModelForSpeechSeq2Seq,
 )
 from QEfficient.transformers.quantizers.auto import replace_transformers_quantizers
+from QEfficient.utils._utils import _infer_specialization_name, to_named_specializations
 from QEfficient.utils.run_utils import ApiRunner
 
 ort.set_default_logger_severity(3)
@@ -707,3 +708,238 @@ def test_proxy_toggle_onnx_transform_policy_for_vlm():
 
     _assert_proxy_only_onnx_transform_policy(qeff_default, enable_proxy=False)
     _assert_proxy_only_onnx_transform_policy(qeff_proxy, enable_proxy=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests for the named-specializations format (backend team feature request)
+# ---------------------------------------------------------------------------
+
+
+class TestInferSpecializationName:
+    """Unit tests for _infer_specialization_name."""
+
+    def test_prefill_detected_by_seq_len_gt_1(self):
+        spec = {"batch_size": "1", "seq_len": "128", "ctx_len": "4096"}
+        assert _infer_specialization_name(spec, 0) == "Prefill"
+
+    def test_decode_detected_by_seq_len_1_string(self):
+        spec = {"batch_size": "1", "seq_len": "1", "ctx_len": "4096"}
+        assert _infer_specialization_name(spec, 1) == "Decode"
+
+    def test_decode_detected_by_seq_len_1_int(self):
+        spec = {"batch_size": 1, "seq_len": 1, "ctx_len": 4096}
+        assert _infer_specialization_name(spec, 1) == "Decode"
+
+    def test_vision_detected_by_vision_size_key(self):
+        spec = {"batch_size": "1", "vision_size": "247", "grid_height": "988", "grid_width": "1176"}
+        assert _infer_specialization_name(spec, 0) == "Vision"
+
+    def test_vision_detected_by_img_size_key(self):
+        spec = {"batch_size": "1", "img_size": "336"}
+        assert _infer_specialization_name(spec, 0) == "Vision"
+
+    def test_encoder_detected_by_encoder_ctx_len(self):
+        spec = {"batch_size": "1", "encoder_ctx_len": "1500"}
+        assert _infer_specialization_name(spec, 0) == "Encoder"
+
+    def test_embedding_detected_by_sequence_length(self):
+        spec = {"batch_size": "1", "sequence_length": "128"}
+        assert _infer_specialization_name(spec, 0) == "Embedding"
+
+    def test_generic_fallback_for_unknown_shape(self):
+        spec = {"custom_dim": "42"}
+        assert _infer_specialization_name(spec, 3) == "Graph_3"
+
+
+class TestToNamedSpecializations:
+    """Unit tests for to_named_specializations — the main serialization helper."""
+
+    def test_llm_prefill_decode_pair(self):
+        """Standard LLM: two specializations → Prefill + Decode."""
+        flat = [
+            {"batch_size": "1", "seq_len": "128", "ctx_len": "4096"},
+            {"batch_size": "1", "seq_len": "1", "ctx_len": "4096"},
+        ]
+        result = to_named_specializations(flat)
+        assert len(result) == 2
+        assert result[0] == {
+            "name": "Prefill",
+            "symbols": {"batch_size": "1", "seq_len": "128", "ctx_len": "4096"},
+        }
+        assert result[1] == {
+            "name": "Decode",
+            "symbols": {"batch_size": "1", "seq_len": "1", "ctx_len": "4096"},
+        }
+
+    def test_llm_continuous_batching_with_full_batch_size(self):
+        """Continuous-batching LLM: full_batch_size present in both entries."""
+        flat = [
+            {"batch_size": "1", "full_batch_size": "16", "seq_len": "128", "ctx_len": "4096"},
+            {"batch_size": "16", "full_batch_size": "16", "seq_len": "1", "ctx_len": "4096"},
+        ]
+        result = to_named_specializations(flat)
+        assert result[0]["name"] == "Prefill"
+        assert result[1]["name"] == "Decode"
+        assert result[0]["symbols"]["full_batch_size"] == "16"
+        assert result[1]["symbols"]["batch_size"] == "16"
+
+    def test_prefill_only_single_entry(self):
+        """When prompt_len == 1 the decode entry is dropped; only one entry remains."""
+        flat = [{"batch_size": "1", "seq_len": "1", "ctx_len": "128"}]
+        result = to_named_specializations(flat)
+        assert len(result) == 1
+        assert result[0]["name"] == "Decode"
+
+    def test_vlm_vision_specialization(self):
+        """VLM vision encoder: no seq_len, vision-specific keys → 'Vision'."""
+        flat = [
+            {
+                "batch_size": "1",
+                "vision_size": "247",
+                "grid_height": "988",
+                "grid_width": "1176",
+                "grid_h": "26",
+                "grid_w": "38",
+            }
+        ]
+        result = to_named_specializations(flat)
+        assert len(result) == 1
+        assert result[0]["name"] == "Vision"
+        assert result[0]["symbols"]["vision_size"] == "247"
+
+    def test_vlm_lang_prefill_decode(self):
+        """VLM language side: prefill + decode with vision_batch_size."""
+        flat = [
+            {
+                "batch_size": "1",
+                "ctx_len": "4096",
+                "seq_len": "128",
+                "vision_batch_size": "1",
+                "vision_size": "247",
+            },
+            {
+                "batch_size": "1",
+                "ctx_len": "4096",
+                "seq_len": "1",
+                "vision_batch_size": "1",
+                "vision_size": "247",
+            },
+        ]
+        result = to_named_specializations(flat)
+        assert result[0]["name"] == "Prefill"
+        assert result[1]["name"] == "Decode"
+        assert result[0]["symbols"]["vision_size"] == "247"
+        assert result[1]["symbols"]["vision_size"] == "247"
+
+    def test_all_values_coerced_to_strings(self):
+        """Integer values in the flat dict must be stringified in symbols."""
+        flat = [{"batch_size": 1, "seq_len": 32, "ctx_len": 128}]
+        result = to_named_specializations(flat)
+        symbols = result[0]["symbols"]
+        assert all(isinstance(v, str) for v in symbols.values())
+
+    def test_output_structure_keys(self):
+        """Every entry must have exactly 'name' and 'symbols' keys."""
+        flat = [
+            {"batch_size": "1", "seq_len": "64", "ctx_len": "256"},
+            {"batch_size": "1", "seq_len": "1", "ctx_len": "256"},
+        ]
+        result = to_named_specializations(flat)
+        for entry in result:
+            assert set(entry.keys()) == {"name", "symbols"}
+
+    def test_whisper_encoder_specialization(self):
+        """Whisper encoder: encoder_ctx_len present, no seq_len → 'Encoder'."""
+        flat = [
+            {"batch_size": "1", "encoder_ctx_len": "1500"},
+            {"batch_size": "1", "seq_len": "1", "ctx_len": "448"},
+        ]
+        result = to_named_specializations(flat)
+        assert result[0]["name"] == "Encoder"
+        assert result[1]["name"] == "Decode"
+        assert result[0]["symbols"]["encoder_ctx_len"] == "1500"
+
+    def test_text_embedding_specialization(self):
+        """Text embedding (BERT): sequence_length present, no seq_len → 'Embedding'."""
+        flat = [{"batch_size": "1", "sequence_length": "128"}]
+        result = to_named_specializations(flat)
+        assert result[0]["name"] == "Embedding"
+        assert result[0]["symbols"]["sequence_length"] == "128"
+
+    def test_roundtrip_via_json(self):
+        """Serializing to JSON and back must preserve the named format exactly."""
+        import json
+
+        flat = [
+            {"batch_size": "1", "seq_len": "128", "ctx_len": "4096"},
+            {"batch_size": "1", "seq_len": "1", "ctx_len": "4096"},
+        ]
+        named = to_named_specializations(flat)
+        payload = {"specializations": named}
+        roundtripped = json.loads(json.dumps(payload))
+        assert roundtripped["specializations"][0]["name"] == "Prefill"
+        assert roundtripped["specializations"][1]["name"] == "Decode"
+        assert roundtripped["specializations"][0]["symbols"]["seq_len"] == "128"
+
+    def test_compile_helper_create_and_dump_specializations(self, tmp_path):
+        """create_and_dump_specializations must write the new named format to disk."""
+        import json
+
+        from QEfficient.compile.compile_helper import create_and_dump_specializations
+
+        out_path = tmp_path / "specializations.json"
+        create_and_dump_specializations(
+            batch_size=1,
+            prompt_len=128,
+            ctx_len=4096,
+            path=str(out_path),
+        )
+        data = json.loads(out_path.read_text())
+        specs = data["specializations"]
+        assert len(specs) == 2
+        assert specs[0]["name"] == "Prefill"
+        assert specs[1]["name"] == "Decode"
+        assert "symbols" in specs[0]
+        assert specs[0]["symbols"]["seq_len"] == "128"
+        assert specs[1]["symbols"]["seq_len"] == "1"
+
+    def test_compile_helper_prefill_only_when_prompt_len_1(self, tmp_path):
+        """When prompt_len==1 and no full_batch_size, only one entry is written."""
+        import json
+
+        from QEfficient.compile.compile_helper import create_and_dump_specializations
+
+        out_path = tmp_path / "specializations_prefill_only.json"
+        create_and_dump_specializations(
+            batch_size=1,
+            prompt_len=1,
+            ctx_len=128,
+            path=str(out_path),
+        )
+        data = json.loads(out_path.read_text())
+        specs = data["specializations"]
+        assert len(specs) == 1
+        assert specs[0]["name"] == "Decode"
+
+    def test_compile_helper_continuous_batching(self, tmp_path):
+        """With full_batch_size, both entries carry full_batch_size in symbols."""
+        import json
+
+        from QEfficient.compile.compile_helper import create_and_dump_specializations
+
+        out_path = tmp_path / "specializations_cb.json"
+        create_and_dump_specializations(
+            batch_size=1,
+            prompt_len=128,
+            ctx_len=4096,
+            path=str(out_path),
+            full_batch_size=16,
+        )
+        data = json.loads(out_path.read_text())
+        specs = data["specializations"]
+        assert len(specs) == 2
+        assert specs[0]["name"] == "Prefill"
+        assert specs[1]["name"] == "Decode"
+        assert specs[0]["symbols"]["full_batch_size"] == "16"
+        assert specs[1]["symbols"]["full_batch_size"] == "16"
+        assert specs[1]["symbols"]["batch_size"] == "16"

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -1014,3 +1014,69 @@ class TestGetCompilationDims:
         assert bs == 1
         assert ctx == 4096
         assert fbs is None
+
+
+class TestDiffusersNamedSpecializations:
+    """Named-specialization format for diffusers pipeline modules."""
+
+    def test_flux_text_encoder_uses_module_name(self):
+        flat = [{"batch_size": 1, "seq_len": 77}]
+        result = to_named_specializations(flat, module_name="text_encoder")
+        assert result[0]["name"] == "text_encoder"
+        assert result[0]["symbols"] == {"batch_size": "1", "seq_len": "77"}
+
+    def test_flux_text_encoder_2_uses_module_name(self):
+        flat = [{"batch_size": 1, "seq_len": 256}]
+        result = to_named_specializations(flat, module_name="text_encoder_2")
+        assert result[0]["name"] == "text_encoder_2"
+
+    def test_flux_transformer_uses_module_name(self):
+        flat = [{"batch_size": 1, "seq_len": 256, "steps": 1}]
+        result = to_named_specializations(flat, module_name="transformer")
+        assert result[0]["name"] == "transformer"
+
+    def test_flux_vae_decoder_uses_module_name(self):
+        flat = [{"batch_size": 1, "channels": 16}]
+        result = to_named_specializations(flat, module_name="vae_decoder")
+        assert result[0]["name"] == "vae_decoder"
+
+    def test_wan_transformer_model_type_naming(self):
+        """Wan transformer: two model_type entries → transformer_model_type_1 / _2."""
+        flat = [
+            {"batch_size": "1", "num_channels": "16", "steps": "1", "sequence_length": "512", "model_type": 1},
+            {"batch_size": "1", "num_channels": "16", "steps": "1", "sequence_length": "512", "model_type": 2},
+        ]
+        result = to_named_specializations(flat, module_name="transformer")
+        assert result[0]["name"] == "transformer_model_type_1"
+        assert result[1]["name"] == "transformer_model_type_2"
+
+    def test_wan_vae_decoder_uses_module_name(self):
+        flat = [{"batch_size": 1, "num_channels": 16}]
+        result = to_named_specializations(flat, module_name="vae_decoder")
+        assert result[0]["name"] == "vae_decoder"
+
+    def test_wan_i2v_vae_encoder_uses_module_name(self):
+        flat = [{"batch_size": 1, "num_channels": 16}]
+        result = to_named_specializations(flat, module_name="vae_encoder")
+        assert result[0]["name"] == "vae_encoder"
+
+    def test_all_values_stringified(self):
+        flat = [{"batch_size": 1, "seq_len": 77}]
+        result = to_named_specializations(flat, module_name="text_encoder")
+        assert all(isinstance(v, str) for v in result[0]["symbols"].values())
+
+    def test_idempotent_already_named_entries(self):
+        """Entries already in {name, symbols} format must pass through unchanged."""
+        already = [{"name": "transformer", "symbols": {"batch_size": "1", "steps": "1"}}]
+        result = to_named_specializations(already, module_name="transformer")
+        assert result == already
+
+    def test_no_module_name_falls_back_to_lm_rules(self):
+        """Without module_name the standard Prefill/Decode rules still apply."""
+        flat = [
+            {"batch_size": "1", "seq_len": "128", "ctx_len": "4096"},
+            {"batch_size": "1", "seq_len": "1", "ctx_len": "4096"},
+        ]
+        result = to_named_specializations(flat)
+        assert result[0]["name"] == "Prefill"
+        assert result[1]["name"] == "Decode"

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -718,6 +718,53 @@ def test_proxy_toggle_onnx_transform_policy_for_vlm():
 class TestInferSpecializationName:
     """Unit tests for _infer_specialization_name."""
 
+    # --- _graph_name tag (authoritative, set at creation time) ---
+
+    def test_graph_name_tag_takes_priority(self):
+        """_graph_name in spec overrides all heuristics."""
+        spec = {"_graph_name": "Vision", "batch_size": "1", "seq_len": "128", "ctx_len": "4096"}
+        assert _infer_specialization_name(spec, 0) == "Vision"
+
+    def test_graph_name_tag_whisper_encoder(self):
+        spec = {
+            "_graph_name": "Encoder",
+            "batch_size": "1",
+            "seq_len": "1",
+            "encoder_ctx_len": "1500",
+            "feature_len": "3000",
+        }
+        assert _infer_specialization_name(spec, 0) == "Encoder"
+
+    def test_graph_name_tag_whisper_decode(self):
+        spec = {
+            "_graph_name": "Decode",
+            "batch_size": "1",
+            "seq_len": "1",
+            "encoder_ctx_len": "1500",
+            "feature_len": "1",
+        }
+        assert _infer_specialization_name(spec, 1) == "Decode"
+
+    def test_graph_name_tag_prefill(self):
+        spec = {"_graph_name": "Prefill", "batch_size": "1", "seq_len": "128", "ctx_len": "4096"}
+        assert _infer_specialization_name(spec, 0) == "Prefill"
+
+    def test_graph_name_tag_decode(self):
+        spec = {"_graph_name": "Decode", "batch_size": "1", "seq_len": "1", "ctx_len": "4096"}
+        assert _infer_specialization_name(spec, 1) == "Decode"
+
+    # --- module_name hint (diffusers path) ---
+
+    def test_module_name_used_when_no_tag(self):
+        spec = {"batch_size": "1", "seq_len": "77"}
+        assert _infer_specialization_name(spec, 0, module_name="text_encoder") == "text_encoder"
+
+    def test_module_name_with_model_type(self):
+        spec = {"batch_size": "1", "model_type": 1}
+        assert _infer_specialization_name(spec, 0, module_name="transformer") == "transformer_model_type_1"
+
+    # --- seq_len heuristic fallback (plain causal LM raw dicts) ---
+
     def test_prefill_detected_by_seq_len_gt_1(self):
         spec = {"batch_size": "1", "seq_len": "128", "ctx_len": "4096"}
         assert _infer_specialization_name(spec, 0) == "Prefill"
@@ -730,75 +777,9 @@ class TestInferSpecializationName:
         spec = {"batch_size": 1, "seq_len": 1, "ctx_len": 4096}
         assert _infer_specialization_name(spec, 1) == "Decode"
 
-    def test_vision_via_explicit_module_name(self):
-        """Vision name must be passed explicitly — not inferred from spec keys."""
-        spec = {"batch_size": "1", "img_size": "336"}
-        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
-
-    def test_vision_explicit_qwen25vl(self):
-        spec = {"batch_size": "1", "vision_size": "247", "grid_height": "988", "grid_width": "1176"}
-        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
-
-    def test_vision_explicit_gemma3(self):
-        """Gemma3 vision spec has seq_len+ctx_len — still 'Vision' when module_name passed."""
-        spec = {"batch_size": 1, "img_size": 896, "seq_len": 128, "ctx_len": 4096}
-        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
-
-    def test_vision_explicit_mistral3(self):
-        """Mistral3 vision spec — 'Vision' when module_name passed."""
-        spec = {"batch_size": 1, "seq_len": 128, "ctx_len": 4096, "image_size": 1024, "vision_size": 1024}
-        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
-
-    def test_vision_explicit_molmo(self):
-        """Molmo vision spec — 'Vision' when module_name passed."""
-        spec = {
-            "batch_size": 1,
-            "img_size": 336,
-            "seq_len": 128,
-            "ctx_len": 4096,
-            "img_tile": 336,
-            "num_images": 1,
-            "num_patch": 576,
-            "valid_size": 576,
-        }
-        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
-
-    def test_vision_spec_without_module_name_falls_to_prefill(self):
-        """Without module_name, a vision spec with seq_len falls through to Prefill."""
-        spec = {"batch_size": 1, "img_size": 336, "seq_len": 128, "ctx_len": 4096}
-        assert _infer_specialization_name(spec, 0) == "Prefill"
-
-    def test_vision_spec_without_module_name_no_seq_len_falls_to_graph_n(self):
-        """Without module_name, a vision spec with no seq_len falls to Graph_N."""
-        spec = {"batch_size": "1", "img_size": "336"}
-        assert _infer_specialization_name(spec, 0) == "Graph_0"
-
     def test_encoder_detected_by_encoder_ctx_len_no_seq_len(self):
-        """Simplified spec with encoder_ctx_len and no seq_len → Encoder."""
         spec = {"batch_size": "1", "encoder_ctx_len": "1500"}
         assert _infer_specialization_name(spec, 0) == "Encoder"
-
-    def test_encoder_detected_whisper_real_spec(self):
-        """Real Whisper encoder-run: seq_len=1, encoder_ctx_len, feature_len>1 → Encoder."""
-        spec = {
-            "batch_size": "1",
-            "seq_len": "1",
-            "encoder_ctx_len": "1500",
-            "decoder_ctx_len": "150",
-            "feature_len": "3000",
-        }
-        assert _infer_specialization_name(spec, 0) == "Encoder"
-
-    def test_decode_detected_whisper_real_spec(self):
-        """Real Whisper decoder-run: seq_len=1, encoder_ctx_len, feature_len=1 → Decode."""
-        spec = {
-            "batch_size": "1",
-            "seq_len": "1",
-            "encoder_ctx_len": "1500",
-            "decoder_ctx_len": "150",
-            "feature_len": "1",
-        }
-        assert _infer_specialization_name(spec, 1) == "Decode"
 
     def test_embedding_detected_by_sequence_length(self):
         spec = {"batch_size": "1", "sequence_length": "128"}
@@ -849,9 +830,10 @@ class TestToNamedSpecializations:
         assert result[0]["name"] == "Decode"
 
     def test_vlm_vision_specialization(self):
-        """VLM vision encoder: module_name='Vision' passed explicitly → 'Vision'."""
+        """VLM vision encoder: _graph_name tag set at source → 'Vision', tag stripped from symbols."""
         flat = [
             {
+                "_graph_name": "Vision",
                 "batch_size": "1",
                 "vision_size": "247",
                 "grid_height": "988",
@@ -860,10 +842,11 @@ class TestToNamedSpecializations:
                 "grid_w": "38",
             }
         ]
-        result = to_named_specializations(flat, module_name="Vision")
+        result = to_named_specializations(flat)
         assert len(result) == 1
         assert result[0]["name"] == "Vision"
         assert result[0]["symbols"]["vision_size"] == "247"
+        assert "_graph_name" not in result[0]["symbols"]
 
     def test_vlm_lang_prefill_decode(self):
         """VLM language side: prefill + decode with vision_batch_size."""
@@ -907,7 +890,7 @@ class TestToNamedSpecializations:
             assert set(entry.keys()) == {"name", "symbols"}
 
     def test_whisper_encoder_specialization_simplified(self):
-        """Simplified Whisper spec: encoder_ctx_len, no seq_len → 'Encoder'."""
+        """Simplified Whisper spec: encoder_ctx_len, no seq_len → 'Encoder' via heuristic."""
         flat = [
             {"batch_size": "1", "encoder_ctx_len": "1500"},
             {"batch_size": "1", "seq_len": "1", "ctx_len": "448"},
@@ -918,10 +901,10 @@ class TestToNamedSpecializations:
         assert result[0]["symbols"]["encoder_ctx_len"] == "1500"
 
     def test_whisper_encoder_specialization_real_spec(self):
-        """Real Whisper spec: both entries have seq_len=1 + encoder_ctx_len;
-        feature_len distinguishes Encoder (>1) from Decode (==1)."""
+        """Real Whisper spec: _graph_name tags set at source distinguish Encoder from Decode."""
         flat = [
             {
+                "_graph_name": "Encoder",
                 "batch_size": "1",
                 "seq_len": "1",
                 "encoder_ctx_len": "1500",
@@ -929,6 +912,7 @@ class TestToNamedSpecializations:
                 "feature_len": "3000",
             },
             {
+                "_graph_name": "Decode",
                 "batch_size": "1",
                 "seq_len": "1",
                 "encoder_ctx_len": "1500",
@@ -941,6 +925,15 @@ class TestToNamedSpecializations:
         assert result[1]["name"] == "Decode"
         assert result[0]["symbols"]["feature_len"] == "3000"
         assert result[1]["symbols"]["feature_len"] == "1"
+        assert "_graph_name" not in result[0]["symbols"]
+        assert "_graph_name" not in result[1]["symbols"]
+
+    def test_graph_name_tag_stripped_from_symbols(self):
+        """_graph_name must never appear in the serialized symbols dict."""
+        flat = [{"_graph_name": "Prefill", "batch_size": "1", "seq_len": "128", "ctx_len": "4096"}]
+        result = to_named_specializations(flat)
+        assert result[0]["name"] == "Prefill"
+        assert "_graph_name" not in result[0]["symbols"]
 
     def test_text_embedding_specialization(self):
         """Text embedding (BERT): sequence_length present, no seq_len → 'Embedding'."""
@@ -1100,62 +1093,72 @@ class TestGetCompilationDims:
 
 
 class TestDiffusersNamedSpecializations:
-    """Named-specialization format for diffusers pipeline modules."""
+    """Named-specialization format for diffusers pipeline modules via _graph_name tag."""
 
-    def test_flux_text_encoder_uses_module_name(self):
-        flat = [{"batch_size": 1, "seq_len": 77}]
-        result = to_named_specializations(flat, module_name="text_encoder")
+    def _tag(self, specs, module_name):
+        """Simulate what pipeline_utils does: tag each spec with _graph_name."""
+        return [
+            {**s, "_graph_name": f"{module_name}_model_type_{s['model_type']}" if "model_type" in s else module_name}
+            for s in specs
+        ]
+
+    def test_flux_text_encoder(self):
+        flat = self._tag([{"batch_size": 1, "seq_len": 77}], "text_encoder")
+        result = to_named_specializations(flat)
         assert result[0]["name"] == "text_encoder"
         assert result[0]["symbols"] == {"batch_size": "1", "seq_len": "77"}
+        assert "_graph_name" not in result[0]["symbols"]
 
-    def test_flux_text_encoder_2_uses_module_name(self):
-        flat = [{"batch_size": 1, "seq_len": 256}]
-        result = to_named_specializations(flat, module_name="text_encoder_2")
+    def test_flux_text_encoder_2(self):
+        flat = self._tag([{"batch_size": 1, "seq_len": 256}], "text_encoder_2")
+        result = to_named_specializations(flat)
         assert result[0]["name"] == "text_encoder_2"
 
-    def test_flux_transformer_uses_module_name(self):
-        flat = [{"batch_size": 1, "seq_len": 256, "steps": 1}]
-        result = to_named_specializations(flat, module_name="transformer")
+    def test_flux_transformer(self):
+        flat = self._tag([{"batch_size": 1, "seq_len": 256, "steps": 1}], "transformer")
+        result = to_named_specializations(flat)
         assert result[0]["name"] == "transformer"
 
-    def test_flux_vae_decoder_uses_module_name(self):
-        flat = [{"batch_size": 1, "channels": 16}]
-        result = to_named_specializations(flat, module_name="vae_decoder")
+    def test_flux_vae_decoder(self):
+        flat = self._tag([{"batch_size": 1, "channels": 16}], "vae_decoder")
+        result = to_named_specializations(flat)
         assert result[0]["name"] == "vae_decoder"
 
     def test_wan_transformer_model_type_naming(self):
         """Wan transformer: two model_type entries → transformer_model_type_1 / _2."""
-        flat = [
-            {"batch_size": "1", "num_channels": "16", "steps": "1", "sequence_length": "512", "model_type": 1},
-            {"batch_size": "1", "num_channels": "16", "steps": "1", "sequence_length": "512", "model_type": 2},
-        ]
-        result = to_named_specializations(flat, module_name="transformer")
+        flat = self._tag(
+            [
+                {"batch_size": "1", "num_channels": "16", "steps": "1", "sequence_length": "512", "model_type": 1},
+                {"batch_size": "1", "num_channels": "16", "steps": "1", "sequence_length": "512", "model_type": 2},
+            ],
+            "transformer",
+        )
+        result = to_named_specializations(flat)
         assert result[0]["name"] == "transformer_model_type_1"
         assert result[1]["name"] == "transformer_model_type_2"
 
-    def test_wan_vae_decoder_uses_module_name(self):
-        flat = [{"batch_size": 1, "num_channels": 16}]
-        result = to_named_specializations(flat, module_name="vae_decoder")
+    def test_wan_vae_decoder(self):
+        flat = self._tag([{"batch_size": 1, "num_channels": 16}], "vae_decoder")
+        result = to_named_specializations(flat)
         assert result[0]["name"] == "vae_decoder"
 
-    def test_wan_i2v_vae_encoder_uses_module_name(self):
-        flat = [{"batch_size": 1, "num_channels": 16}]
-        result = to_named_specializations(flat, module_name="vae_encoder")
+    def test_wan_i2v_vae_encoder(self):
+        flat = self._tag([{"batch_size": 1, "num_channels": 16}], "vae_encoder")
+        result = to_named_specializations(flat)
         assert result[0]["name"] == "vae_encoder"
 
-    def test_all_values_stringified(self):
-        flat = [{"batch_size": 1, "seq_len": 77}]
-        result = to_named_specializations(flat, module_name="text_encoder")
-        assert all(isinstance(v, str) for v in result[0]["symbols"].values())
+    def test_graph_name_tag_stripped_from_symbols(self):
+        flat = self._tag([{"batch_size": 1, "seq_len": 77}], "text_encoder")
+        result = to_named_specializations(flat)
+        assert "_graph_name" not in result[0]["symbols"]
 
     def test_idempotent_already_named_entries(self):
-        """Entries already in {name, symbols} format must pass through unchanged."""
         already = [{"name": "transformer", "symbols": {"batch_size": "1", "steps": "1"}}]
-        result = to_named_specializations(already, module_name="transformer")
+        result = to_named_specializations(already)
         assert result == already
 
-    def test_no_module_name_falls_back_to_lm_rules(self):
-        """Without module_name the standard Prefill/Decode rules still apply."""
+    def test_no_tag_falls_back_to_lm_rules(self):
+        """Without _graph_name tag, seq_len heuristic applies."""
         flat = [
             {"batch_size": "1", "seq_len": "128", "ctx_len": "4096"},
             {"batch_size": "1", "seq_len": "1", "ctx_len": "4096"},

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -753,6 +753,10 @@ class TestInferSpecializationName:
         spec = {"_graph_name": "Decode", "batch_size": "1", "seq_len": "1", "ctx_len": "4096"}
         assert _infer_specialization_name(spec, 1) == "Decode"
 
+    def test_graph_name_tag_embedding_with_seq_len(self):
+        spec = {"_graph_name": "Embedding", "batch_size": "1", "seq_len": "128"}
+        assert _infer_specialization_name(spec, 0) == "Embedding"
+
     # --- module_name hint (diffusers path) ---
 
     def test_module_name_used_when_no_tag(self):
@@ -781,7 +785,7 @@ class TestInferSpecializationName:
         spec = {"batch_size": "1", "encoder_ctx_len": "1500"}
         assert _infer_specialization_name(spec, 0) == "Encoder"
 
-    def test_embedding_detected_by_sequence_length(self):
+    def test_legacy_embedding_detected_by_sequence_length(self):
         spec = {"batch_size": "1", "sequence_length": "128"}
         assert _infer_specialization_name(spec, 0) == "Embedding"
 
@@ -935,8 +939,15 @@ class TestToNamedSpecializations:
         assert result[0]["name"] == "Prefill"
         assert "_graph_name" not in result[0]["symbols"]
 
-    def test_text_embedding_specialization(self):
-        """Text embedding (BERT): sequence_length present, no seq_len → 'Embedding'."""
+    def test_text_embedding_specialization_actual_compile_path(self):
+        """Text embedding compile path: _graph_name + seq_len should serialize as Embedding."""
+        flat = [{"_graph_name": "Embedding", "batch_size": "1", "seq_len": "128"}]
+        result = to_named_specializations(flat)
+        assert result[0]["name"] == "Embedding"
+        assert result[0]["symbols"]["seq_len"] == "128"
+
+    def test_legacy_text_embedding_specialization(self):
+        """Legacy BERT-like raw dict: sequence_length fallback still resolves to Embedding."""
         flat = [{"batch_size": "1", "sequence_length": "128"}]
         result = to_named_specializations(flat)
         assert result[0]["name"] == "Embedding"

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -730,13 +730,48 @@ class TestInferSpecializationName:
         spec = {"batch_size": 1, "seq_len": 1, "ctx_len": 4096}
         assert _infer_specialization_name(spec, 1) == "Decode"
 
-    def test_vision_detected_by_vision_size_key(self):
-        spec = {"batch_size": "1", "vision_size": "247", "grid_height": "988", "grid_width": "1176"}
-        assert _infer_specialization_name(spec, 0) == "Vision"
-
-    def test_vision_detected_by_img_size_key(self):
+    def test_vision_via_explicit_module_name(self):
+        """Vision name must be passed explicitly — not inferred from spec keys."""
         spec = {"batch_size": "1", "img_size": "336"}
-        assert _infer_specialization_name(spec, 0) == "Vision"
+        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
+
+    def test_vision_explicit_qwen25vl(self):
+        spec = {"batch_size": "1", "vision_size": "247", "grid_height": "988", "grid_width": "1176"}
+        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
+
+    def test_vision_explicit_gemma3(self):
+        """Gemma3 vision spec has seq_len+ctx_len — still 'Vision' when module_name passed."""
+        spec = {"batch_size": 1, "img_size": 896, "seq_len": 128, "ctx_len": 4096}
+        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
+
+    def test_vision_explicit_mistral3(self):
+        """Mistral3 vision spec — 'Vision' when module_name passed."""
+        spec = {"batch_size": 1, "seq_len": 128, "ctx_len": 4096, "image_size": 1024, "vision_size": 1024}
+        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
+
+    def test_vision_explicit_molmo(self):
+        """Molmo vision spec — 'Vision' when module_name passed."""
+        spec = {
+            "batch_size": 1,
+            "img_size": 336,
+            "seq_len": 128,
+            "ctx_len": 4096,
+            "img_tile": 336,
+            "num_images": 1,
+            "num_patch": 576,
+            "valid_size": 576,
+        }
+        assert _infer_specialization_name(spec, 0, module_name="Vision") == "Vision"
+
+    def test_vision_spec_without_module_name_falls_to_prefill(self):
+        """Without module_name, a vision spec with seq_len falls through to Prefill."""
+        spec = {"batch_size": 1, "img_size": 336, "seq_len": 128, "ctx_len": 4096}
+        assert _infer_specialization_name(spec, 0) == "Prefill"
+
+    def test_vision_spec_without_module_name_no_seq_len_falls_to_graph_n(self):
+        """Without module_name, a vision spec with no seq_len falls to Graph_N."""
+        spec = {"batch_size": "1", "img_size": "336"}
+        assert _infer_specialization_name(spec, 0) == "Graph_0"
 
     def test_encoder_detected_by_encoder_ctx_len(self):
         spec = {"batch_size": "1", "encoder_ctx_len": "1500"}
@@ -791,7 +826,7 @@ class TestToNamedSpecializations:
         assert result[0]["name"] == "Decode"
 
     def test_vlm_vision_specialization(self):
-        """VLM vision encoder: no seq_len, vision-specific keys → 'Vision'."""
+        """VLM vision encoder: module_name='Vision' passed explicitly → 'Vision'."""
         flat = [
             {
                 "batch_size": "1",
@@ -802,7 +837,7 @@ class TestToNamedSpecializations:
                 "grid_w": "38",
             }
         ]
-        result = to_named_specializations(flat)
+        result = to_named_specializations(flat, module_name="Vision")
         assert len(result) == 1
         assert result[0]["name"] == "Vision"
         assert result[0]["symbols"]["vision_size"] == "247"

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -773,9 +773,32 @@ class TestInferSpecializationName:
         spec = {"batch_size": "1", "img_size": "336"}
         assert _infer_specialization_name(spec, 0) == "Graph_0"
 
-    def test_encoder_detected_by_encoder_ctx_len(self):
+    def test_encoder_detected_by_encoder_ctx_len_no_seq_len(self):
+        """Simplified spec with encoder_ctx_len and no seq_len → Encoder."""
         spec = {"batch_size": "1", "encoder_ctx_len": "1500"}
         assert _infer_specialization_name(spec, 0) == "Encoder"
+
+    def test_encoder_detected_whisper_real_spec(self):
+        """Real Whisper encoder-run: seq_len=1, encoder_ctx_len, feature_len>1 → Encoder."""
+        spec = {
+            "batch_size": "1",
+            "seq_len": "1",
+            "encoder_ctx_len": "1500",
+            "decoder_ctx_len": "150",
+            "feature_len": "3000",
+        }
+        assert _infer_specialization_name(spec, 0) == "Encoder"
+
+    def test_decode_detected_whisper_real_spec(self):
+        """Real Whisper decoder-run: seq_len=1, encoder_ctx_len, feature_len=1 → Decode."""
+        spec = {
+            "batch_size": "1",
+            "seq_len": "1",
+            "encoder_ctx_len": "1500",
+            "decoder_ctx_len": "150",
+            "feature_len": "1",
+        }
+        assert _infer_specialization_name(spec, 1) == "Decode"
 
     def test_embedding_detected_by_sequence_length(self):
         spec = {"batch_size": "1", "sequence_length": "128"}
@@ -883,8 +906,8 @@ class TestToNamedSpecializations:
         for entry in result:
             assert set(entry.keys()) == {"name", "symbols"}
 
-    def test_whisper_encoder_specialization(self):
-        """Whisper encoder: encoder_ctx_len present, no seq_len → 'Encoder'."""
+    def test_whisper_encoder_specialization_simplified(self):
+        """Simplified Whisper spec: encoder_ctx_len, no seq_len → 'Encoder'."""
         flat = [
             {"batch_size": "1", "encoder_ctx_len": "1500"},
             {"batch_size": "1", "seq_len": "1", "ctx_len": "448"},
@@ -893,6 +916,31 @@ class TestToNamedSpecializations:
         assert result[0]["name"] == "Encoder"
         assert result[1]["name"] == "Decode"
         assert result[0]["symbols"]["encoder_ctx_len"] == "1500"
+
+    def test_whisper_encoder_specialization_real_spec(self):
+        """Real Whisper spec: both entries have seq_len=1 + encoder_ctx_len;
+        feature_len distinguishes Encoder (>1) from Decode (==1)."""
+        flat = [
+            {
+                "batch_size": "1",
+                "seq_len": "1",
+                "encoder_ctx_len": "1500",
+                "decoder_ctx_len": "150",
+                "feature_len": "3000",
+            },
+            {
+                "batch_size": "1",
+                "seq_len": "1",
+                "encoder_ctx_len": "1500",
+                "decoder_ctx_len": "150",
+                "feature_len": "1",
+            },
+        ]
+        result = to_named_specializations(flat)
+        assert result[0]["name"] == "Encoder"
+        assert result[1]["name"] == "Decode"
+        assert result[0]["symbols"]["feature_len"] == "3000"
+        assert result[1]["symbols"]["feature_len"] == "1"
 
     def test_text_embedding_specialization(self):
         """Text embedding (BERT): sequence_length present, no seq_len → 'Embedding'."""

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -943,3 +943,74 @@ class TestToNamedSpecializations:
         assert specs[0]["symbols"]["full_batch_size"] == "16"
         assert specs[1]["symbols"]["full_batch_size"] == "16"
         assert specs[1]["symbols"]["batch_size"] == "16"
+
+
+class TestGetCompilationDims:
+    """Verify get_compilation_dims handles both flat (legacy) and named (new) formats."""
+
+    def _write_spec(self, tmp_path, payload):
+        import json
+
+        spec_dir = tmp_path / "qpc-hash"
+        spec_dir.mkdir()
+        qpc_dir = spec_dir / "qpc"
+        qpc_dir.mkdir()
+        (spec_dir / "specializations.json").write_text(json.dumps(payload))
+        return str(qpc_dir)
+
+    def test_new_named_format(self, tmp_path):
+        from QEfficient.generation.text_generation_inference import get_compilation_dims
+
+        qpc_path = self._write_spec(
+            tmp_path,
+            {
+                "specializations": [
+                    {"name": "Prefill", "symbols": {"batch_size": "1", "seq_len": "128", "ctx_len": "4096"}},
+                    {"name": "Decode", "symbols": {"batch_size": "1", "seq_len": "1", "ctx_len": "4096"}},
+                ]
+            },
+        )
+        bs, ctx, fbs = get_compilation_dims(qpc_path)
+        assert bs == 1
+        assert ctx == 4096
+        assert fbs is None
+
+    def test_new_named_format_with_full_batch_size(self, tmp_path):
+        from QEfficient.generation.text_generation_inference import get_compilation_dims
+
+        qpc_path = self._write_spec(
+            tmp_path,
+            {
+                "specializations": [
+                    {
+                        "name": "Prefill",
+                        "symbols": {"batch_size": "1", "full_batch_size": "16", "seq_len": "128", "ctx_len": "4096"},
+                    },
+                    {
+                        "name": "Decode",
+                        "symbols": {"batch_size": "16", "full_batch_size": "16", "seq_len": "1", "ctx_len": "4096"},
+                    },
+                ]
+            },
+        )
+        bs, ctx, fbs = get_compilation_dims(qpc_path)
+        assert bs == 1
+        assert ctx == 4096
+        assert fbs == 16
+
+    def test_legacy_flat_format_still_works(self, tmp_path):
+        from QEfficient.generation.text_generation_inference import get_compilation_dims
+
+        qpc_path = self._write_spec(
+            tmp_path,
+            {
+                "specializations": [
+                    {"batch_size": "1", "seq_len": "128", "ctx_len": "4096"},
+                    {"batch_size": "1", "seq_len": "1", "ctx_len": "4096"},
+                ]
+            },
+        )
+        bs, ctx, fbs = get_compilation_dims(qpc_path)
+        assert bs == 1
+        assert ctx == 4096
+        assert fbs is None


### PR DESCRIPTION
## Summary
  The backend compiler team requested a new specializations.json format where each entry carries a meaningful graph name (e.g. "Prefill", "Decode") 

  ## Changes
  - **`QEfficient/utils/_utils.py`** — new `_infer_specialization_name()` and `to_named_specializations()` helpers
  - **`QEfficient/base/modeling_qeff.py`** — `_compile()` uses new format
  - **`QEfficient/compile/qnn_compiler.py`** — QNN path uses new format
  - **`QEfficient/compile/compile_helper.py`** — legacy `create_and_dump_specializations()` uses new format

  ## Name inference rules
  | Keys present | Assigned name |
  |---|---|
  | `vision_size` / `img_size` / `grid_*`, no `seq_len` | `Vision` |
  | `encoder_ctx_len`, no `seq_len` | `Encoder` |
  | `sequence_length`, no `seq_len` | `Embedding` |
  | `seq_len != 1` | `Prefill` |
  | `seq_len == 1` | `Decode` |
  | anything else | `Graph_N` |

## Testing
21-unit tests added to `tests/unit_test/models/test_model_quickcheck.py` covering causal LM, continuous batching, VLM vision/language, Whisper, encoder/decoder, text embedding, and end-to-end JSON roundtrip.

cc: @anujgupt-github @quic-rishinr 