### PR TITLE
CB Bug fix for Qwen3VL Dense and basic cleaning of example script and Model File

### DIFF
--- a/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -388,12 +388,6 @@ class QEffQwen3VLTextAttention(Qwen3VLTextAttention):
         key_states = self.k_norm(self.k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        # cos, sin = position_embeddings
-        # kv_seq_len = key_states.shape[-2]
-        # kv_seq_len = past_key_value.get_seq_length()
-        past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
-        # cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-
         query_states, key_states = qeff_apply_rotary_pos_emb(
             query_states,
             key_states,
@@ -409,7 +403,6 @@ class QEffQwen3VLTextAttention(Qwen3VLTextAttention):
                 "cos": cos_cached,
                 "batch_index": batch_index,
                 "position_ids": position_ids[0],
-                "past_seen_tokens": past_seen_tokens,
             }
             if comp_ctx_lengths is not None:
                 attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
@@ -503,7 +496,7 @@ class QEffQwen3VLTextDecoderLayer(Qwen3VLTextDecoderLayer):
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states[0]
+        hidden_states = residual + hidden_states
 
         outputs = (hidden_states,)
 
@@ -667,7 +660,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
     def __init__(self, model):
         super().__init__()
         self.model = model
-        self.language_model = self.model.model
+        self.language_model = self.model.model.language_model
 
     def get_submodules_for_export(self) -> Type[nn.Module]:
         """

--- a/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
+++ b/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
@@ -45,7 +45,7 @@ if skip_vision:
         aic_enable_depth_first=True,
         skip_vision=True,
         mos=1,
-        use_onnx_subfunctions=True,
+        use_onnx_subfunctions=False,
     )
 
     messages = [
@@ -84,8 +84,6 @@ else:
         num_devices=4,
         height=354,
         width=536,
-        # height=1024,
-        # width=1024,
         mxfp6_matmul=True,
         mxint8_kv_cache=True,
         aic_enable_depth_first=True,
@@ -95,10 +93,6 @@ else:
 
     ### IMAGE + TEXT ###
     image_url = "https://picsum.photos/id/237/536/354"
-    # image_url = (
-    #     "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/cat_style_layout.png"
-    # )
-
     image = Image.open(requests.get(image_url, stream=True).raw)
 
     messages_1 = [
@@ -110,16 +104,6 @@ else:
             ],
         },
     ]
-
-    # messages_2 = [
-    #     {
-    #         "role": "user",
-    #         "content": [
-    #             {"type": "image", "image": image},
-    #             {"type": "text", "text": "Describe about the color of the dog."},
-    #         ],
-    #     },
-    # ]
 
     messages = [messages_1] * batch_size
 


### PR DESCRIPTION
Issue: When running CB with single image multiple time with different prompts it was working whereas with multiple images and prompts it was failing.

Resolution: The hidden states calculation was done with index [0] every time as a result when the broadcasting was happening with batch size 4 it was taking the first image only and we were getting wrong output in CB. Taking full hidden_states ensures the error does not occur.