### PR TITLE
CB Bug fix for Qwen3VL Dense and basic cleaning of example script and Model File

### DIFF
--- a/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -383,11 +383,7 @@ class QEffQwen3VLTextAttention(Qwen3VLTextAttention):
         key_states = self.k_norm(self.k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        # cos, sin = position_embeddings
-        # kv_seq_len = key_states.shape[-2]
-        # kv_seq_len = past_key_value.get_seq_length()
         past_seen_tokens = past_key_values.get_seq_length(self.layer_idx) if past_key_values is not None else 0
-        # cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
 
         query_states, key_states = qeff_apply_rotary_pos_emb(query_states, key_states, cos_cached, sin_cached)
         blocking_config = getattr(self, "attn_blocking_config", AttentionBlockingConfig())
@@ -502,7 +498,7 @@ class QEffQwen3VLTextDecoderLayer(Qwen3VLTextDecoderLayer):
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states[0]
+        hidden_states = residual + hidden_states
 
         outputs = (hidden_states,)
 
@@ -669,7 +665,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
     def __init__(self, model):
         super().__init__()
         self.model = model
-        self.language_model = self.model.model
+        self.language_model = self.model.model.language_model
 
     def get_submodules_for_export(self) -> Type[nn.Module]:
         """

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -497,7 +497,9 @@ class QEffQwen3VLMoeTextDecoderLayer(Qwen3VLMoeTextDecoderLayer):
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states[0]
+        if isinstance(hidden_states, tuple):
+            hidden_states, _ = hidden_states
+        hidden_states = residual + hidden_states
 
         outputs = (hidden_states,)
 

--- a/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
+++ b/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
@@ -84,8 +84,6 @@ else:
         num_devices=4,
         height=354,
         width=536,
-        # height=1024,
-        # width=1024,
         mxfp6_matmul=True,
         mxint8_kv_cache=True,
         aic_enable_depth_first=True,
@@ -95,9 +93,6 @@ else:
 
     ### IMAGE + TEXT ###
     image_url = "https://picsum.photos/id/237/536/354"
-    # image_url = (
-    #     "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/datasets/cat_style_layout.png"
-    # )
 
     image = Image.open(requests.get(image_url, stream=True).raw)
 
@@ -110,16 +105,6 @@ else:
             ],
         },
     ]
-
-    # messages_2 = [
-    #     {
-    #         "role": "user",
-    #         "content": [
-    #             {"type": "image", "image": image},
-    #             {"type": "text", "text": "Describe about the color of the dog."},
-    #         ],
-    #     },
-    # ]
 
     messages = [messages_1] * batch_size
 

--- a/tests/configs/image_text_model_configs.json
+++ b/tests/configs/image_text_model_configs.json
@@ -170,7 +170,7 @@
       "num_layers": 1,
       "img_url_list":[
             "https://picsum.photos/id/237/536/354",
-            "https://picsum.photos/id/237/536/354"
+            "https://picsum.photos/id/238/536/354"
         ],
       "text_prompt_list": [
             "Can you describe the image in detail?",
@@ -235,7 +235,7 @@
       "num_layers": 1,
       "img_url_list":[
             "https://picsum.photos/id/237/536/354",
-            "https://picsum.photos/id/237/536/354"
+            "https://picsum.photos/id/238/536/354"
         ],
       "text_prompt_list": [
             "Can you describe the image in detail?",
@@ -292,7 +292,7 @@
       "num_layers": 1,
       "img_url_list":[
             "https://picsum.photos/id/237/536/354",
-            "https://picsum.photos/id/237/536/354"
+            "https://picsum.photos/id/238/536/354"
         ],
       "text_prompt_list": [
             "Can you describe the image in detail.",


### PR DESCRIPTION
Issue: When running CB with single image multiple time with different prompts it was working whereas with multiple images and prompts it was failing.

Resolution: The hidden states calculation was done with index [0] every time as a result when the broadcasting was happening with batch size 4 it was taking the first image only and we were getting wrong output in CB. Taking full hidden_states ensures the error does not occur.