### PR TITLE
First Block Caching Infra for diffusers

### DIFF
--- a/QEfficient/diffusers/first_block_cache/__init__.py
+++ b/QEfficient/diffusers/first_block_cache/__init__.py
@@ -1,0 +1,13 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# ----------------------------------------------------------------------------
+
+from QEfficient.diffusers.first_block_cache.wan import (
+    enable_wan_first_block_cache,
+    run_wan_non_unified_first_block_cache_denoise,
+)
+
+__all__ = ["enable_wan_first_block_cache", "run_wan_non_unified_first_block_cache_denoise"]

--- a/QEfficient/diffusers/first_block_cache/__init__.py
+++ b/QEfficient/diffusers/first_block_cache/__init__.py
@@ -5,9 +5,14 @@
 #
 # ----------------------------------------------------------------------------
 
+from QEfficient.diffusers.first_block_cache.flux import enable_flux_first_block_cache
 from QEfficient.diffusers.first_block_cache.wan import (
     enable_wan_first_block_cache,
     run_wan_non_unified_first_block_cache_denoise,
 )
 
-__all__ = ["enable_wan_first_block_cache", "run_wan_non_unified_first_block_cache_denoise"]
+__all__ = [
+    "enable_flux_first_block_cache",
+    "enable_wan_first_block_cache",
+    "run_wan_non_unified_first_block_cache_denoise",
+]

--- a/QEfficient/diffusers/first_block_cache/flux.py
+++ b/QEfficient/diffusers/first_block_cache/flux.py
@@ -1,0 +1,270 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# ----------------------------------------------------------------------------
+"""
+FLUX first-block-cache monkey patch utilities.
+
+These helpers patch a Flux transformer wrapper instance at runtime:
+1. patch underlying transformer `forward` to expose retained-state cache IO,
+2. patch wrapper `get_onnx_params` to export retained-state tensors, and
+3. patch wrapper `compile` to enable retained-state compilation with custom IO.
+"""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any, Dict, Optional, Union
+
+import numpy as np
+import torch
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+
+def _check_similarity(first_hidden_states_residuals: torch.Tensor, prev_first_hidden_states_residuals: torch.Tensor):
+    """
+    Compute normalized L1 difference between current and previous first-block residuals.
+    """
+    scale = 1.0 / 1024.0
+    current = first_hidden_states_residuals * scale
+    previous = prev_first_hidden_states_residuals * scale
+    diff = (current - previous).abs().mean()
+    norm = current.abs().mean()
+    return diff / (norm + 1e-8)
+
+
+def _flux_forward_with_first_block_cache(
+    self,
+    hidden_states: torch.Tensor,
+    encoder_hidden_states: torch.Tensor = None,
+    pooled_projections: torch.Tensor = None,
+    timestep: torch.LongTensor = None,
+    img_ids: torch.Tensor = None,
+    txt_ids: torch.Tensor = None,
+    adaln_emb: torch.Tensor = None,
+    adaln_single_emb: torch.Tensor = None,
+    adaln_out: torch.Tensor = None,
+    guidance: torch.Tensor = None,
+    joint_attention_kwargs: Optional[Dict[str, Any]] = None,
+    controlnet_block_samples=None,
+    controlnet_single_block_samples=None,
+    prev_first_hidden_states_residuals: Optional[torch.Tensor] = None,
+    prev_hidden_states_residuals: Optional[torch.Tensor] = None,
+    cache_threshold: Optional[float] = None,
+    return_dict: bool = True,
+    controlnet_blocks_repeat: bool = False,
+) -> Union[torch.Tensor, Transformer2DModelOutput]:
+    """
+    Patched FLUX transformer forward with first-block-cache retained-state support.
+    """
+    if cache_threshold is None:
+        return self._qeff_original_forward(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            pooled_projections=pooled_projections,
+            timestep=timestep,
+            img_ids=img_ids,
+            txt_ids=txt_ids,
+            adaln_emb=adaln_emb,
+            adaln_single_emb=adaln_single_emb,
+            adaln_out=adaln_out,
+            guidance=guidance,
+            joint_attention_kwargs=joint_attention_kwargs,
+            controlnet_block_samples=controlnet_block_samples,
+            controlnet_single_block_samples=controlnet_single_block_samples,
+            return_dict=return_dict,
+            controlnet_blocks_repeat=controlnet_blocks_repeat,
+        )
+
+    hidden_states = self.x_embedder(hidden_states)
+
+    timestep = timestep.to(hidden_states.dtype) * 1000
+    if guidance is not None:
+        guidance = guidance.to(hidden_states.dtype) * 1000
+
+    encoder_hidden_states = self.context_embedder(encoder_hidden_states)
+
+    ids = torch.cat((txt_ids, img_ids), dim=0)
+    image_rotary_emb = self.pos_embed(ids)
+
+    if joint_attention_kwargs is not None and "ip_adapter_image_embeds" in joint_attention_kwargs:
+        ip_adapter_image_embeds = joint_attention_kwargs.pop("ip_adapter_image_embeds")
+        ip_hidden_states = self.encoder_hid_proj(ip_adapter_image_embeds)
+        joint_attention_kwargs.update({"ip_hidden_states": ip_hidden_states})
+
+    # First dual block output is the cache-key source.
+    original_hidden_states = hidden_states
+    encoder_hidden_states, hidden_states = self.transformer_blocks[0](
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        temb=adaln_emb[0],
+        image_rotary_emb=image_rotary_emb,
+        joint_attention_kwargs=joint_attention_kwargs,
+    )
+    current_first_hidden_states_residuals = hidden_states - original_hidden_states
+
+    ds_factor = self._qeff_first_block_cache_downsample_factor
+    downsampled_first_hidden_states_residuals = current_first_hidden_states_residuals[..., ::ds_factor].contiguous()
+    difference = _check_similarity(downsampled_first_hidden_states_residuals, prev_first_hidden_states_residuals)
+
+    # Compute residual from the remaining blocks.
+    remaining_hidden_states = hidden_states
+    remaining_encoder_hidden_states = encoder_hidden_states
+
+    for index_block, block in enumerate(self.transformer_blocks[1:], start=1):
+        remaining_encoder_hidden_states, remaining_hidden_states = block(
+            hidden_states=remaining_hidden_states,
+            encoder_hidden_states=remaining_encoder_hidden_states,
+            temb=adaln_emb[index_block],
+            image_rotary_emb=image_rotary_emb,
+            joint_attention_kwargs=joint_attention_kwargs,
+        )
+
+        if controlnet_block_samples is not None:
+            interval_control = len(self.transformer_blocks) / len(controlnet_block_samples)
+            interval_control = int(np.ceil(interval_control))
+            if controlnet_blocks_repeat:
+                remaining_hidden_states = (
+                    remaining_hidden_states + controlnet_block_samples[index_block % len(controlnet_block_samples)]
+                )
+            else:
+                remaining_hidden_states = (
+                    remaining_hidden_states + controlnet_block_samples[index_block // interval_control]
+                )
+
+    for index_block, block in enumerate(self.single_transformer_blocks):
+        remaining_encoder_hidden_states, remaining_hidden_states = block(
+            hidden_states=remaining_hidden_states,
+            encoder_hidden_states=remaining_encoder_hidden_states,
+            temb=adaln_single_emb[index_block],
+            image_rotary_emb=image_rotary_emb,
+            joint_attention_kwargs=joint_attention_kwargs,
+        )
+
+        if controlnet_single_block_samples is not None:
+            interval_control = len(self.single_transformer_blocks) / len(controlnet_single_block_samples)
+            interval_control = int(np.ceil(interval_control))
+            remaining_hidden_states = (
+                remaining_hidden_states + controlnet_single_block_samples[index_block // interval_control]
+            )
+
+    current_hidden_states_residuals = remaining_hidden_states - hidden_states
+
+    cache_hit = difference < cache_threshold
+    final_hidden_states_residuals = torch.where(
+        cache_hit,
+        prev_hidden_states_residuals,
+        current_hidden_states_residuals,
+    )
+
+    hidden_states = hidden_states + final_hidden_states_residuals
+    hidden_states = self.norm_out(hidden_states, adaln_out)
+    output = self.proj_out(hidden_states)
+
+    if not return_dict:
+        return (output, downsampled_first_hidden_states_residuals, final_hidden_states_residuals)
+
+    return (
+        Transformer2DModelOutput(sample=output),
+        downsampled_first_hidden_states_residuals,
+        final_hidden_states_residuals,
+    )
+
+
+def _get_onnx_params_with_first_block_cache(self):
+    """
+    Wrapper-level ONNX params for retained-state first-block-cache export.
+    """
+    example_inputs, dynamic_axes, output_names = self._qeff_original_get_onnx_params()
+
+    hidden_states = example_inputs["hidden_states"]
+    batch_size = hidden_states.shape[0]
+    cl = hidden_states.shape[1]
+
+    hidden_size = getattr(self.model, "inner_dim", None)
+    if hidden_size is None:
+        num_heads = self.model.config.get("num_attention_heads")
+        head_dim = self.model.config.get("attention_head_dim")
+        hidden_size = num_heads * head_dim
+
+    ds_factor = self.model._qeff_first_block_cache_downsample_factor
+    example_inputs["prev_hidden_states_residuals"] = torch.randn(batch_size, cl, hidden_size, dtype=torch.float32)
+    example_inputs["prev_first_hidden_states_residuals"] = torch.randn(
+        batch_size, cl, hidden_size // ds_factor, dtype=torch.float32
+    )
+    example_inputs["cache_threshold"] = torch.tensor(0.0, dtype=torch.float32)
+
+    output_names.extend(
+        [
+            "prev_first_hidden_states_residuals_RetainedState",
+            "prev_hidden_states_residuals_RetainedState",
+        ]
+    )
+
+    dynamic_axes["prev_hidden_states_residuals"] = {0: "batch_size", 1: "cl"}
+    dynamic_axes["prev_first_hidden_states_residuals"] = {0: "batch_size", 1: "cl"}
+
+    return example_inputs, dynamic_axes, output_names
+
+
+def _compile_with_first_block_cache(self, specializations, **compiler_options):
+    """
+    Wrapper-level compile with retained-state custom IO enabled.
+    """
+    custom_io = {
+        "prev_first_hidden_states_residuals": "float16",
+        "prev_hidden_states_residuals": "float16",
+        "prev_first_hidden_states_residuals_RetainedState": "float16",
+        "prev_hidden_states_residuals_RetainedState": "float16",
+    }
+    return self._compile(
+        specializations=specializations,
+        retained_state=True,
+        custom_io=custom_io,
+        **compiler_options,
+    )
+
+
+def enable_flux_first_block_cache(transformer_wrapper: Any, downsample_factor: int = 4) -> Any:
+    """
+    Enable first-block-cache on a FLUX transformer wrapper instance.
+
+    Args:
+        transformer_wrapper: QEff Flux transformer wrapper (`QEffFluxTransformerModel`)
+        downsample_factor: hidden-dim downsampling factor for first-block cache key.
+    """
+    if getattr(transformer_wrapper, "_qeff_first_block_cache_enabled", False):
+        return transformer_wrapper
+
+    if downsample_factor <= 0:
+        raise ValueError(f"downsample_factor must be > 0, got {downsample_factor}")
+
+    hidden_size = getattr(transformer_wrapper.model, "inner_dim", None)
+    if hidden_size is None:
+        num_heads = transformer_wrapper.model.config.get("num_attention_heads")
+        head_dim = transformer_wrapper.model.config.get("attention_head_dim")
+        hidden_size = num_heads * head_dim
+    if hidden_size % downsample_factor != 0:
+        raise ValueError(
+            f"downsample_factor must divide hidden_size exactly, got hidden_size={hidden_size}, "
+            f"downsample_factor={downsample_factor}"
+        )
+
+    transformer_model = transformer_wrapper.model
+    if not getattr(transformer_model, "_qeff_first_block_cache_patched", False):
+        transformer_model._qeff_original_forward = transformer_model.forward
+        transformer_model._qeff_first_block_cache_downsample_factor = downsample_factor
+        transformer_model.forward = MethodType(_flux_forward_with_first_block_cache, transformer_model)
+        transformer_model._qeff_first_block_cache_patched = True
+
+    transformer_wrapper._qeff_original_get_onnx_params = transformer_wrapper.get_onnx_params
+    transformer_wrapper.get_onnx_params = MethodType(_get_onnx_params_with_first_block_cache, transformer_wrapper)
+    transformer_wrapper.compile = MethodType(_compile_with_first_block_cache, transformer_wrapper)
+    transformer_wrapper._qeff_first_block_cache_enabled = True
+
+    transformer_wrapper.hash_params["first_block_cache"] = True
+    transformer_wrapper.hash_params["first_block_cache_downsample_factor"] = downsample_factor
+
+    return transformer_wrapper

--- a/QEfficient/diffusers/first_block_cache/wan.py
+++ b/QEfficient/diffusers/first_block_cache/wan.py
@@ -1,0 +1,357 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# ----------------------------------------------------------------------------
+"""
+WAN first-block-cache monkey patch utilities.
+
+These helpers patch a non-unified WAN transformer wrapper instance at runtime:
+1. patch underlying transformer `forward` to expose retained-state cache IO,
+2. patch wrapper `get_onnx_params` to export retained-state tensors, and
+3. patch wrapper `compile` to enable retained-state compilation with custom IO.
+"""
+
+from __future__ import annotations
+
+import time
+from types import MethodType
+from typing import Any, Callable, Dict, List, Optional, Union
+
+import numpy as np
+import torch
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+from QEfficient.utils import constants
+
+
+def _check_similarity(first_block_residuals: torch.Tensor, prev_first_block_residuals: torch.Tensor) -> torch.Tensor:
+    """
+    Compute normalized L1 difference between current and previous first-block residuals.
+    """
+    scale = 1.0 / 1024.0
+    current = first_block_residuals * scale
+    previous = prev_first_block_residuals * scale
+    diff = (current - previous).abs().mean()
+    norm = current.abs().mean()
+    return diff / (norm + 1e-8)
+
+
+def _wan_forward_with_first_block_cache(
+    self,
+    hidden_states: torch.Tensor,
+    encoder_hidden_states: torch.Tensor,
+    rotary_emb: torch.Tensor,
+    temb: torch.Tensor,
+    timestep_proj: torch.Tensor,
+    encoder_hidden_states_image: Optional[torch.Tensor] = None,
+    prev_first_block_residuals: Optional[torch.Tensor] = None,
+    prev_remain_block_residuals: Optional[torch.Tensor] = None,
+    cache_threshold: Optional[float] = None,
+    attention_kwargs: Optional[Dict[str, Any]] = None,
+    return_dict: bool = True,
+) -> Union[torch.Tensor, Dict[str, torch.Tensor]]:
+    """
+    Patched WAN transformer forward with first-block-cache retained-state support.
+    """
+    if cache_threshold is None:
+        return self._qeff_original_forward(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            rotary_emb=rotary_emb,
+            temb=temb,
+            timestep_proj=timestep_proj,
+            encoder_hidden_states_image=encoder_hidden_states_image,
+            attention_kwargs=attention_kwargs,
+            return_dict=return_dict,
+        )
+
+    rotary_emb = torch.split(rotary_emb, 1, dim=0)
+    hidden_states = self.patch_embedding(hidden_states)
+    hidden_states = hidden_states.flatten(2).transpose(1, 2)
+
+    if encoder_hidden_states_image is not None:
+        encoder_hidden_states = torch.concat([encoder_hidden_states_image, encoder_hidden_states], dim=1)
+
+    first_block_out = self.blocks[0](hidden_states, encoder_hidden_states, timestep_proj, rotary_emb)
+    current_first_block_residuals = first_block_out - hidden_states
+
+    ds_factor = self._qeff_first_block_cache_downsample_factor
+    downsampled_first_block_residuals = current_first_block_residuals[..., ::ds_factor].contiguous()
+
+    difference = _check_similarity(downsampled_first_block_residuals, prev_first_block_residuals)
+
+    remaining_hidden_state = first_block_out
+    for block in self.blocks[1:]:
+        remaining_hidden_state = block(remaining_hidden_state, encoder_hidden_states, timestep_proj, rotary_emb)
+    current_remain_block_residuals = remaining_hidden_state - first_block_out
+
+    cache_hit = difference < cache_threshold
+    final_remaining_block_residual = torch.where(
+        cache_hit,
+        prev_remain_block_residuals,
+        current_remain_block_residuals,
+    )
+
+    hidden_states = final_remaining_block_residual + first_block_out
+
+    if temb.ndim == 3:
+        shift, scale = (self.scale_shift_table.unsqueeze(0) + temb.unsqueeze(2)).chunk(2, dim=2)
+        shift = shift.squeeze(2)
+        scale = scale.squeeze(2)
+    else:
+        shift, scale = (self.scale_shift_table + temb.unsqueeze(1)).chunk(2, dim=1)
+
+    shift = shift.to(hidden_states.device)
+    scale = scale.to(hidden_states.device)
+    hidden_states = (self.norm_out(hidden_states.float()) * (1 + scale) + shift).type_as(hidden_states)
+    output = self.proj_out(hidden_states)
+
+    if not return_dict:
+        return (output, downsampled_first_block_residuals, final_remaining_block_residual)
+
+    return (
+        Transformer2DModelOutput(sample=output),
+        downsampled_first_block_residuals,
+        final_remaining_block_residual,
+    )
+
+
+def _get_onnx_params_with_first_block_cache(self):
+    """
+    Wrapper-level ONNX params for retained-state first-block-cache export.
+    """
+    example_inputs, dynamic_axes, output_names = self._qeff_original_get_onnx_params()
+
+    batch_size = constants.WAN_ONNX_EXPORT_BATCH_SIZE
+    cl = constants.WAN_ONNX_EXPORT_CL_45P
+    cfg = self.model.config
+    hidden_size = getattr(cfg, "hidden_size", None)
+    if hidden_size is None and hasattr(cfg, "get"):
+        hidden_size = cfg.get("hidden_size")
+    if hidden_size is None:
+        num_heads = getattr(cfg, "num_attention_heads", None)
+        if num_heads is None and hasattr(cfg, "get"):
+            num_heads = cfg.get("num_attention_heads")
+        head_dim = getattr(cfg, "attention_head_dim", None)
+        if head_dim is None and hasattr(cfg, "get"):
+            head_dim = cfg.get("attention_head_dim")
+        hidden_size = num_heads * head_dim
+
+    ds_factor = self.model._qeff_first_block_cache_downsample_factor
+
+    example_inputs["prev_remain_block_residuals"] = torch.randn(batch_size, cl, hidden_size, dtype=torch.float32)
+    example_inputs["prev_first_block_residuals"] = torch.randn(
+        batch_size, cl, hidden_size // ds_factor, dtype=torch.float32
+    )
+    example_inputs["cache_threshold"] = torch.tensor(0.0, dtype=torch.float32)
+
+    output_names.extend(
+        [
+            "prev_first_block_residuals_RetainedState",
+            "prev_remain_block_residuals_RetainedState",
+        ]
+    )
+
+    dynamic_axes["prev_remain_block_residuals"] = {0: "batch_size", 1: "cl"}
+    dynamic_axes["prev_first_block_residuals"] = {0: "batch_size", 1: "cl"}
+
+    return example_inputs, dynamic_axes, output_names
+
+
+def _compile_with_first_block_cache(self, specializations, **compiler_options):
+    """
+    Wrapper-level compile with retained-state custom IO enabled.
+    """
+    custom_io = {
+        "prev_first_block_residuals": "float16",
+        "prev_remain_block_residuals": "float16",
+        "prev_first_block_residuals_RetainedState": "float16",
+        "prev_remain_block_residuals_RetainedState": "float16",
+    }
+    return self._compile(
+        specializations=specializations,
+        retained_state=True,
+        custom_io=custom_io,
+        **compiler_options,
+    )
+
+
+def enable_wan_first_block_cache(transformer_wrapper: Any, downsample_factor: int = 4) -> Any:
+    """
+    Enable first-block-cache on a non-unified WAN transformer wrapper instance.
+
+    Args:
+        transformer_wrapper: QEff WAN non-unified transformer wrapper (`QEffWanTransformer`)
+        downsample_factor: hidden-dim downsampling factor for first-block cache key.
+    """
+    if getattr(transformer_wrapper, "_qeff_first_block_cache_enabled", False):
+        return transformer_wrapper
+
+    if downsample_factor <= 0:
+        raise ValueError(f"downsample_factor must be > 0, got {downsample_factor}")
+
+    transformer_model = transformer_wrapper.model
+    if not getattr(transformer_model, "_qeff_first_block_cache_patched", False):
+        transformer_model._qeff_original_forward = transformer_model.forward
+        transformer_model._qeff_first_block_cache_downsample_factor = downsample_factor
+        transformer_model.forward = MethodType(_wan_forward_with_first_block_cache, transformer_model)
+        transformer_model._qeff_first_block_cache_patched = True
+
+    transformer_wrapper._qeff_original_get_onnx_params = transformer_wrapper.get_onnx_params
+    transformer_wrapper.get_onnx_params = MethodType(_get_onnx_params_with_first_block_cache, transformer_wrapper)
+    transformer_wrapper.compile = MethodType(_compile_with_first_block_cache, transformer_wrapper)
+    transformer_wrapper._qeff_first_block_cache_enabled = True
+
+    transformer_wrapper.hash_params["first_block_cache"] = True
+    transformer_wrapper.hash_params["first_block_cache_downsample_factor"] = downsample_factor
+
+    return transformer_wrapper
+
+
+def run_wan_non_unified_first_block_cache_denoise(
+    pipeline: Any,
+    latents: torch.Tensor,
+    timesteps: torch.Tensor,
+    batch_size: int,
+    guidance_scale: float,
+    guidance_scale_2: float,
+    boundary_timestep: Optional[float],
+    transformer_dtype: torch.dtype,
+    prompt_embeds: torch.Tensor,
+    negative_prompt_embeds: Optional[torch.Tensor],
+    mask: torch.Tensor,
+    num_inference_steps: int,
+    num_warmup_steps: int,
+    callback_on_step_end: Optional[Callable],
+    callback_on_step_end_tensor_inputs: List[str],
+    cache_threshold_high: Optional[float] = None,
+    cache_threshold_low: Optional[float] = None,
+):
+    """
+    Cache-aware non-unified WAN denoise loop.
+
+    This is intentionally module-scoped so cache runtime behavior lives next to the
+    first-block-cache adapter patching logic and stays out of the core pipeline class.
+    """
+    transformer_perf = []
+    low_stage_counter = 0
+
+    with pipeline.model.progress_bar(total=num_inference_steps) as progress_bar:
+        for i, t in enumerate(timesteps):
+            if pipeline._interrupt:
+                continue
+
+            pipeline._current_timestep = t
+
+            if boundary_timestep is None or t >= boundary_timestep:
+                current_transformer_module = pipeline.transformer_high
+                current_guidance_scale = guidance_scale
+                stage_cache_threshold = 0.0 if cache_threshold_high is None else cache_threshold_high
+            else:
+                current_transformer_module = pipeline.transformer_low
+                current_guidance_scale = guidance_scale_2
+                low_stage_counter += 1
+                low_threshold = 0.0 if cache_threshold_low is None else cache_threshold_low
+                # Keep first few low-noise steps uncached to stabilize rollout.
+                stage_cache_threshold = 0.0 if low_stage_counter < 3 else low_threshold
+
+            current_model = current_transformer_module.model
+
+            latent_model_input = latents.to(transformer_dtype)
+            if pipeline.model.config.expand_timesteps:
+                temp_ts = (mask[0][0][:, ::2, ::2] * t).flatten()
+                timestep = temp_ts.unsqueeze(0).expand(latents.shape[0], -1)
+            else:
+                timestep = t.expand(latents.shape[0])
+
+            _, _, latent_frames, latent_height, latent_width = latents.shape
+            p_t, p_h, p_w = current_model.config.patch_size
+            post_patch_num_frames = latent_frames // p_t
+            post_patch_height = latent_height // p_h
+            post_patch_width = latent_width // p_w
+
+            rotary_emb = current_model.rope(latent_model_input)
+            rotary_emb = torch.cat(rotary_emb, dim=0)
+            timestep = timestep.flatten()
+
+            temb, timestep_proj, encoder_hidden_states, _ = current_model.condition_embedder(
+                timestep, prompt_embeds, encoder_hidden_states_image=None, timestep_seq_len=None
+            )
+
+            if pipeline.do_classifier_free_guidance:
+                _, _, encoder_hidden_states_neg, _ = current_model.condition_embedder(
+                    timestep,
+                    negative_prompt_embeds,
+                    encoder_hidden_states_image=None,
+                    timestep_seq_len=None,
+                )
+
+            timestep_proj = timestep_proj.unflatten(1, (6, -1))
+            inputs_aic = {
+                "hidden_states": latents.detach().numpy(),
+                "encoder_hidden_states": encoder_hidden_states.detach().numpy(),
+                "rotary_emb": rotary_emb.detach().numpy(),
+                "temb": temb.detach().numpy(),
+                "timestep_proj": timestep_proj.detach().numpy(),
+                "cache_threshold": np.array(stage_cache_threshold, dtype=np.float32),
+            }
+
+            if pipeline.do_classifier_free_guidance:
+                inputs_aic2 = {
+                    "hidden_states": latents.detach().numpy(),
+                    "encoder_hidden_states": encoder_hidden_states_neg.detach().numpy(),
+                    "rotary_emb": rotary_emb.detach().numpy(),
+                    "temb": temb.detach().numpy(),
+                    "timestep_proj": timestep_proj.detach().numpy(),
+                    "cache_threshold": np.array(stage_cache_threshold, dtype=np.float32),
+                }
+
+            with current_model.cache_context("cond"):
+                start_transformer_step_time = time.perf_counter()
+                outputs = current_transformer_module.qpc_session.run(inputs_aic)
+                end_transformer_step_time = time.perf_counter()
+                transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
+                noise_pred = pipeline._reshape_noise_prediction(
+                    outputs,
+                    batch_size,
+                    post_patch_num_frames,
+                    post_patch_height,
+                    post_patch_width,
+                    p_t,
+                    p_h,
+                    p_w,
+                )
+
+            if pipeline.do_classifier_free_guidance:
+                with current_model.cache_context("uncond"):
+                    start_transformer_step_time = time.perf_counter()
+                    outputs = current_transformer_module.qpc_session.run(inputs_aic2)
+                    end_transformer_step_time = time.perf_counter()
+                    transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
+                    noise_uncond = pipeline._reshape_noise_prediction(
+                        outputs,
+                        batch_size,
+                        post_patch_num_frames,
+                        post_patch_height,
+                        post_patch_width,
+                        p_t,
+                        p_h,
+                        p_w,
+                    )
+                    noise_pred = noise_uncond + current_guidance_scale * (noise_pred - noise_uncond)
+
+            latents = pipeline.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+
+            if callback_on_step_end is not None:
+                callback_kwargs = {k: locals()[k] for k in callback_on_step_end_tensor_inputs}
+                callback_outputs = callback_on_step_end(pipeline, i, t, callback_kwargs)
+                latents = callback_outputs.pop("latents", latents)
+                prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
+                negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
+
+            if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % pipeline.scheduler.order == 0):
+                progress_bar.update()
+
+    return latents, transformer_perf

--- a/QEfficient/diffusers/models/transformers/transformer_wan.py
+++ b/QEfficient/diffusers/models/transformers/transformer_wan.py
@@ -213,6 +213,12 @@ class QEffWanTransformer3DModel(WanTransformer3DModel):
         weights = scale_expansion_fn(self, weights)
         set_weights_and_activate_adapters(self, adapter_names, weights)
 
+    def get_submodules_for_export(self) -> Type[nn.Module]:
+        """
+        Return repeated block classes used for ONNX subfunction extraction.
+        """
+        return {WanTransformerBlock}
+
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/QEfficient/diffusers/models/transformers/transformer_wan.py
+++ b/QEfficient/diffusers/models/transformers/transformer_wan.py
@@ -218,6 +218,12 @@ class QEffWanTransformer3DModel(WanTransformer3DModel):
         weights = scale_expansion_fn(self, weights)
         set_weights_and_activate_adapters(self, adapter_names, weights)
 
+    def get_submodules_for_export(self) -> Type[nn.Module]:
+        """
+        Return repeated block classes used for ONNX subfunction extraction.
+        """
+        return {WanTransformerBlock}
+
     def forward(
         self,
         hidden_states: torch.Tensor,

--- a/QEfficient/diffusers/pipelines/configs/wan_non_unified_config.json
+++ b/QEfficient/diffusers/pipelines/configs/wan_non_unified_config.json
@@ -1,0 +1,73 @@
+{
+  "description": "Default configuration for Wan pipeline in non-unified mode with separate transformer_high and transformer_low modules",
+  "modules": {
+    "transformer_high": {
+      "specializations": {
+        "batch_size": "1",
+        "num_channels": "16",
+        "steps": "1",
+        "sequence_length": "512"
+      },
+      "compilation": {
+        "onnx_path": null,
+        "compile_dir": null,
+        "mdp_ts_num_devices": 16,
+        "mxfp6_matmul": true,
+        "convert_to_fp16": true,
+        "compile_only": true,
+        "aic_num_cores": 16,
+        "mos": 1,
+        "mdts_mos": 1
+      },
+      "execute": {
+        "device_ids": null,
+        "qpc_path": null
+      }
+    },
+    "transformer_low": {
+      "specializations": {
+        "batch_size": "1",
+        "num_channels": "16",
+        "steps": "1",
+        "sequence_length": "512"
+      },
+      "compilation": {
+        "onnx_path": null,
+        "compile_dir": null,
+        "mdp_ts_num_devices": 16,
+        "mxfp6_matmul": true,
+        "convert_to_fp16": true,
+        "compile_only": true,
+        "aic_num_cores": 16,
+        "mos": 1,
+        "mdts_mos": 1
+      },
+      "execute": {
+        "device_ids": null,
+        "qpc_path": null
+      }
+    },
+    "vae_decoder": {
+      "specializations": {
+        "batch_size": 1,
+        "num_channels": 16
+      },
+      "compilation": {
+        "onnx_path": null,
+        "compile_dir": null,
+        "mdp_ts_num_devices": 8,
+        "mxfp6_matmul": false,
+        "convert_to_fp16": true,
+        "aic_num_cores": 16,
+        "aic-enable-depth-first": true,
+        "compile_only": true,
+        "mos": 1,
+        "mdts_mos": 1
+      },
+      "execute": {
+        "device_ids": null,
+        "qpc_path": null
+      }
+    }
+  }
+}

--- a/QEfficient/diffusers/pipelines/flux/pipeline_flux.py
+++ b/QEfficient/diffusers/pipelines/flux/pipeline_flux.py
@@ -22,6 +22,7 @@ from diffusers import FluxPipeline
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import retrieve_timesteps
 from tqdm import tqdm
 
+from QEfficient.diffusers.first_block_cache.flux import enable_flux_first_block_cache
 from QEfficient.diffusers.pipelines.pipeline_module import (
     QEffFluxTransformerModel,
     QEffTextEncoder,
@@ -80,7 +81,14 @@ class QEffFluxPipeline:
 
     _hf_auto_class = FluxPipeline
 
-    def __init__(self, model, *args, **kwargs):
+    def __init__(
+        self,
+        model,
+        enable_first_block_cache: bool = False,
+        first_block_cache_downsample_factor: int = 4,
+        *args,
+        **kwargs,
+    ):
         """
         Initialize the QEfficient Flux pipeline.
 
@@ -91,14 +99,24 @@ class QEffFluxPipeline:
 
         Args:
             model: Pre-loaded FluxPipeline model
+            enable_first_block_cache (bool): Enable retained-state first-block-cache path.
+            first_block_cache_downsample_factor (int): Downsample factor for the first-block
+                residual cache key. Used only when first-block-cache is enabled.
             **kwargs: Additional arguments including height and width
         """
 
         # Wrap model components with QEfficient optimized versions
         self.model = model
+        self.enable_first_block_cache = enable_first_block_cache
+        self.first_block_cache_downsample_factor = first_block_cache_downsample_factor
         self.text_encoder = QEffTextEncoder(model.text_encoder)
         self.text_encoder_2 = QEffTextEncoder(model.text_encoder_2)
         self.transformer = QEffFluxTransformerModel(model.transformer)
+        if self.enable_first_block_cache:
+            enable_flux_first_block_cache(
+                self.transformer,
+                downsample_factor=self.first_block_cache_downsample_factor,
+            )
         self.vae_decode = QEffVAE(model.vae, "decoder")
 
         # Store all modules in a dictionary for easy iteration during export/compile
@@ -130,6 +148,8 @@ class QEffFluxPipeline:
     def from_pretrained(
         cls,
         pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
+        enable_first_block_cache: bool = False,
+        first_block_cache_downsample_factor: int = 4,
         **kwargs,
     ):
         """
@@ -142,6 +162,9 @@ class QEffFluxPipeline:
         Args:
             pretrained_model_name_or_path (str or os.PathLike): Either a HuggingFace model identifier
                 (e.g., "black-forest-labs/FLUX.1-schnell") or a local path to a saved model directory.
+            enable_first_block_cache (bool, optional): Enables retained-state first-block-cache path.
+            first_block_cache_downsample_factor (int, optional): Downsample factor for the first-block
+                residual cache key when cache is enabled.
             **kwargs: Additional keyword arguments passed to FluxPipeline.from_pretrained().
 
         Returns:
@@ -176,6 +199,8 @@ class QEffFluxPipeline:
 
         return cls(
             model=model,
+            enable_first_block_cache=enable_first_block_cache,
+            first_block_cache_downsample_factor=first_block_cache_downsample_factor,
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             **kwargs,
         )
@@ -574,6 +599,7 @@ class QEffFluxPipeline:
         custom_config_path: Optional[str] = None,
         parallel_compile: bool = False,
         use_onnx_subfunctions: bool = False,
+        cache_threshold: Optional[float] = None,
     ):
         """
         Generate images from text prompts using the QEfficient-optimized Flux pipeline on QAIC hardware.
@@ -609,6 +635,8 @@ class QEffFluxPipeline:
             custom_config_path (str, optional): Path to custom JSON configuration file for compilation settings.
             parallel_compile (bool, optional): Whether to compile modules in parallel. Default: False.
             use_onnx_subfunctions (bool, optional): Whether to export transformer blocks as ONNX subfunctions. Default: False.
+            cache_threshold (float, optional): First-block-cache threshold.
+                Used only when `enable_first_block_cache=True`.
 
         Returns:
             QEffPipelineOutput: A dataclass containing:
@@ -664,6 +692,11 @@ class QEffFluxPipeline:
 
         self._guidance_scale = guidance_scale
         self._interrupt = False
+        if not self.enable_first_block_cache and cache_threshold is not None:
+            logger.warning(
+                "Ignoring cache_threshold because first-block-cache is disabled. "
+                "Set `enable_first_block_cache=True` to enable it."
+            )
 
         # Step 2: Determine batch size from inputs
         if prompt is not None and isinstance(prompt, str):
@@ -733,6 +766,16 @@ class QEffFluxPipeline:
             "output": np.random.rand(batch_size, cl, self.transformer.model.config.in_channels).astype(np.float32),
         }
         self.transformer.qpc_session.set_buffers(output_buffer)
+        if self.enable_first_block_cache:
+            self.transformer.qpc_session.skip_buffers(
+                [
+                    tensor_name
+                    for tensor_name in (
+                        self.transformer.qpc_session.input_names + self.transformer.qpc_session.output_names
+                    )
+                    if tensor_name.startswith("prev_") or tensor_name.endswith("_RetainedState")
+                ]
+            )
 
         transformer_perf = []
         self.scheduler.set_begin_index(0)
@@ -781,11 +824,15 @@ class QEffFluxPipeline:
                     "adaln_single_emb": adaln_single_emb.detach().numpy(),
                     "adaln_out": adaln_out.detach().numpy(),
                 }
+                if self.enable_first_block_cache:
+                    stage_cache_threshold = 0.0 if cache_threshold is None else cache_threshold
+                    inputs_aic["cache_threshold"] = np.array(stage_cache_threshold, dtype=np.float32)
 
                 # Run transformer inference and measure time
                 start_transformer_step_time = time.perf_counter()
                 outputs = self.transformer.qpc_session.run(inputs_aic)
                 end_transformer_step_time = time.perf_counter()
+                print("Time taken", end_transformer_step_time - start_transformer_step_time)
                 transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
 
                 noise_pred = torch.from_numpy(outputs["output"])

--- a/QEfficient/diffusers/pipelines/pipeline_module.py
+++ b/QEfficient/diffusers/pipelines/pipeline_module.py
@@ -545,6 +545,93 @@ class QEffFluxTransformerModel(QEFFBaseModel):
         self._compile(specializations=specializations, **compiler_options)
 
 
+class QEffWanTransformer(QEFFBaseModel):
+    """
+    Wrapper for a single WAN Transformer3D model with ONNX export and QAIC compilation.
+
+    This wrapper is used by the non-unified WAN pipeline mode where high-noise and low-noise
+    transformers are exported/compiled/executed as separate modules.
+    """
+
+    _pytorch_transforms = [AttentionTransform, CustomOpsTransform, NormalizationTransform]
+    _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform]
+
+    def __init__(self, transformer, module_name: str = "transformer"):
+        super().__init__(transformer, module_name=module_name)
+        self.model = transformer
+        # Ensure high/low non-unified transformers get distinct export hashes/paths
+        # even when configs are identical.
+        self.hash_params["module_name"] = module_name
+
+    @property
+    def get_model_config(self) -> Dict:
+        return self.model.config.__dict__
+
+    def get_onnx_params(self):
+        batch_size = constants.WAN_ONNX_EXPORT_BATCH_SIZE
+        example_inputs = {
+            "hidden_states": torch.randn(
+                batch_size,
+                self.model.config.in_channels,
+                constants.WAN_ONNX_EXPORT_LATENT_FRAMES,
+                constants.WAN_ONNX_EXPORT_LATENT_HEIGHT_45P,
+                constants.WAN_ONNX_EXPORT_LATENT_WIDTH_45P,
+                dtype=torch.float32,
+            ),
+            "encoder_hidden_states": torch.randn(
+                batch_size, constants.WAN_ONNX_EXPORT_SEQ_LEN, constants.WAN_TEXT_EMBED_DIM, dtype=torch.float32
+            ),
+            "rotary_emb": torch.randn(
+                2, constants.WAN_ONNX_EXPORT_CL_45P, 1, constants.WAN_ONNX_EXPORT_ROTARY_DIM, dtype=torch.float32
+            ),
+            "temb": torch.randn(batch_size, constants.WAN_TEXT_EMBED_DIM, dtype=torch.float32),
+            "timestep_proj": torch.randn(
+                batch_size,
+                constants.WAN_PROJECTION_DIM,
+                constants.WAN_TEXT_EMBED_DIM,
+                dtype=torch.float32,
+            ),
+            "return_dict": False,
+        }
+
+        output_names = ["output"]
+        dynamic_axes = {
+            "hidden_states": {
+                0: "batch_size",
+                1: "num_channels",
+                2: "latent_frames",
+                3: "latent_height",
+                4: "latent_width",
+            },
+            "encoder_hidden_states": {0: "batch_size", 1: "sequence_length"},
+            "rotary_emb": {1: "cl"},
+            "temb": {0: "batch_size"},
+            "timestep_proj": {0: "batch_size"},
+        }
+
+        return example_inputs, dynamic_axes, output_names
+
+    def export(
+        self,
+        inputs: Dict,
+        output_names: List[str],
+        dynamic_axes: Dict,
+        export_dir: str = None,
+        use_onnx_subfunctions: bool = False,
+    ) -> str:
+        return self._export(
+            example_inputs=inputs,
+            output_names=output_names,
+            dynamic_axes=dynamic_axes,
+            export_dir=export_dir,
+            offload_pt_weights=True,
+            use_onnx_subfunctions=use_onnx_subfunctions,
+        )
+
+    def compile(self, specializations, **compiler_options) -> None:
+        self._compile(specializations=specializations, **compiler_options)
+
+
 class QEffWanUnifiedTransformer(QEFFBaseModel):
     """
     Wrapper for WAN Unified Transformer with ONNX export and QAIC compilation capabilities.

--- a/QEfficient/diffusers/pipelines/pipeline_utils.py
+++ b/QEfficient/diffusers/pipelines/pipeline_utils.py
@@ -316,4 +316,4 @@ class QEffPipelineOutput:
 
 # List of module name that require special handling during export
 # when use_onnx_subfunctions is enabled
-ONNX_SUBFUNCTION_MODULE = ["transformer"]
+ONNX_SUBFUNCTION_MODULE = ["transformer", "transformer_high", "transformer_low"]

--- a/QEfficient/diffusers/pipelines/wan/pipeline_wan.py
+++ b/QEfficient/diffusers/pipelines/wan/pipeline_wan.py
@@ -18,6 +18,7 @@ TODO: 1. Update umt5 to Qaic; present running on cpu
 
 import os
 import time
+from functools import partial
 from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -26,6 +27,10 @@ import torch
 from diffusers import WanPipeline
 from tqdm import tqdm
 
+from QEfficient.diffusers.first_block_cache.wan import (
+    enable_wan_first_block_cache,
+    run_wan_non_unified_first_block_cache_denoise,
+)
 from QEfficient.diffusers.models.transformers.transformer_wan import QEffWanUnifiedWrapper
 from QEfficient.diffusers.pipelines.pipeline_module import QEffVAE, QEffWanTransformer, QEffWanUnifiedTransformer
 from QEfficient.diffusers.pipelines.pipeline_utils import (
@@ -86,7 +91,14 @@ class QEffWanPipeline:
 
     _hf_auto_class = WanPipeline
 
-    def __init__(self, model, use_unified: bool = True, **kwargs):
+    def __init__(
+        self,
+        model,
+        use_unified: bool = True,
+        enable_first_block_cache: bool = False,
+        first_block_cache_downsample_factor: int = 4,
+        **kwargs,
+    ):
         """
         Initialize the QEfficient WAN pipeline.
 
@@ -100,13 +112,22 @@ class QEffWanPipeline:
             use_unified (bool): If True, use a unified transformer module that internally
                 selects high/low stage by `tsp`. If False, keep high/low transformers as
                 separate compiled modules and dispatch explicitly at runtime.
+            enable_first_block_cache (bool): Enable retained-state first-block-cache path.
+                Supported only for non-unified mode.
+            first_block_cache_downsample_factor (int): Downsample factor for the first-block
+                residual cache key. Used only when first-block-cache is enabled.
             **kwargs: Additional keyword arguments including configuration parameters
         """
         # Store original model and configuration
         self.model = model
         self.use_unified = use_unified
+        self.enable_first_block_cache = enable_first_block_cache
+        self.first_block_cache_downsample_factor = first_block_cache_downsample_factor
         self.kwargs = kwargs
         self.custom_config = None
+
+        if self.enable_first_block_cache and self.use_unified:
+            raise ValueError("First-block-cache is currently supported only for non-unified WAN (`use_unified=False`).")
 
         # Text encoder (TODO: Replace with QEfficient UMT5 optimization)
         self.text_encoder = model.text_encoder
@@ -123,11 +144,24 @@ class QEffWanPipeline:
             self.unified_wrapper = None
             self.transformer_high = QEffWanTransformer(model.transformer, module_name="transformer_high")
             self.transformer_low = QEffWanTransformer(model.transformer_2, module_name="transformer_low")
+            if self.enable_first_block_cache:
+                enable_wan_first_block_cache(
+                    self.transformer_high,
+                    downsample_factor=self.first_block_cache_downsample_factor,
+                )
+                enable_wan_first_block_cache(
+                    self.transformer_low,
+                    downsample_factor=self.first_block_cache_downsample_factor,
+                )
             self.modules = {
                 "transformer_high": self.transformer_high,
                 "transformer_low": self.transformer_low,
             }
-            self._denoise_impl = self._run_denoise_loop_non_unified
+            self._denoise_impl = (
+                partial(run_wan_non_unified_first_block_cache_denoise, self)
+                if self.enable_first_block_cache
+                else self._run_denoise_loop_non_unified
+            )
             # Keep a lightweight compatibility handle for existing scripts that access
             # `pipeline.transformer.model.transformer_high/low` to attach LoRA adapters.
             self.transformer = SimpleNamespace(
@@ -170,6 +204,8 @@ class QEffWanPipeline:
         cls,
         pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
         use_unified: bool = True,
+        enable_first_block_cache: bool = False,
+        first_block_cache_downsample_factor: int = 4,
         **kwargs,
     ):
         """
@@ -186,6 +222,10 @@ class QEffWanPipeline:
             use_unified (bool, optional): Selects WAN execution architecture.
                 - True: unified high/low transformer module
                 - False: separate high and low transformer modules
+            enable_first_block_cache (bool, optional): Enables retained-state first-block-cache
+                for non-unified mode.
+            first_block_cache_downsample_factor (int, optional): Downsample factor for first-block
+                cache key when cache is enabled.
             **kwargs: Additional keyword arguments passed to WanPipeline.from_pretrained().
 
         Returns:
@@ -220,6 +260,8 @@ class QEffWanPipeline:
         return cls(
             model=model,
             use_unified=use_unified,
+            enable_first_block_cache=enable_first_block_cache,
+            first_block_cache_downsample_factor=first_block_cache_downsample_factor,
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             **kwargs,
         )
@@ -423,6 +465,14 @@ class QEffWanPipeline:
             ).astype(np.int32),
         }
         module_obj.qpc_session.set_buffers(output_buffer)
+        if getattr(module_obj, "_qeff_first_block_cache_enabled", False):
+            module_obj.qpc_session.skip_buffers(
+                [
+                    tensor_name
+                    for tensor_name in (module_obj.qpc_session.input_names + module_obj.qpc_session.output_names)
+                    if tensor_name.startswith("prev_") or tensor_name.endswith("_RetainedState")
+                ]
+            )
 
     def _prepare_transformer_sessions(self, batch_size: int, cl: int) -> None:
         if self.use_unified:
@@ -465,6 +515,8 @@ class QEffWanPipeline:
         num_warmup_steps: int,
         callback_on_step_end: Optional[Callable],
         callback_on_step_end_tensor_inputs: List[str],
+        cache_threshold_high: Optional[float] = None,
+        cache_threshold_low: Optional[float] = None,
     ):
         transformer_perf = []
         with self.model.progress_bar(total=num_inference_steps) as progress_bar:
@@ -596,6 +648,8 @@ class QEffWanPipeline:
         num_warmup_steps: int,
         callback_on_step_end: Optional[Callable],
         callback_on_step_end_tensor_inputs: List[str],
+        cache_threshold_high: Optional[float] = None,
+        cache_threshold_low: Optional[float] = None,
     ):
         transformer_perf = []
         with self.model.progress_bar(total=num_inference_steps) as progress_bar:
@@ -731,6 +785,8 @@ class QEffWanPipeline:
         max_sequence_length: int = 512,
         custom_config_path: Optional[str] = None,
         use_onnx_subfunctions: bool = False,
+        cache_threshold_high: Optional[float] = None,
+        cache_threshold_low: Optional[float] = None,
         parallel_compile: bool = True,
     ):
         """
@@ -773,6 +829,10 @@ class QEffWanPipeline:
             custom_config_path (str, optional): Path to custom JSON configuration file for compilation.
             use_onnx_subfunctions (bool, optional): Whether to export transformer blocks as ONNX subfunctions.
                 Default: False.
+            cache_threshold_high (float, optional): First-block-cache threshold for high-noise stage.
+                Used only when `enable_first_block_cache=True`.
+            cache_threshold_low (float, optional): First-block-cache threshold for low-noise stage.
+                Used only when `enable_first_block_cache=True`.
             parallel_compile (bool, optional): Whether to compile modules in parallel. Default: True.
 
         Returns:
@@ -836,6 +896,12 @@ class QEffWanPipeline:
 
         if self.model.config.boundary_ratio is not None and guidance_scale_2 is None:
             guidance_scale_2 = guidance_scale
+
+        if not self.enable_first_block_cache and (cache_threshold_high is not None or cache_threshold_low is not None):
+            logger.warning(
+                "Ignoring cache thresholds because first-block-cache is disabled. "
+                "Set `enable_first_block_cache=True` and `use_unified=False` to enable it."
+            )
 
         # Initialize pipeline state
         self._guidance_scale = guidance_scale
@@ -928,6 +994,8 @@ class QEffWanPipeline:
             num_warmup_steps=num_warmup_steps,
             callback_on_step_end=callback_on_step_end,
             callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+            cache_threshold_high=cache_threshold_high,
+            cache_threshold_low=cache_threshold_low,
         )
 
         self._current_timestep = None

--- a/QEfficient/diffusers/pipelines/wan/pipeline_wan.py
+++ b/QEfficient/diffusers/pipelines/wan/pipeline_wan.py
@@ -9,13 +9,16 @@ QEfficient WAN Pipeline Implementation
 
 This module provides an optimized implementation of the WAN pipeline
 for high-performance text-to-video generation on Qualcomm AI hardware.
-The pipeline supports WAN 2.2 architectures with unified transformer.
+The pipeline supports WAN 2.2 architectures in:
+1) unified mode (single transformer module with stage routing), and
+2) non-unified mode (separate high/low transformer modules).
 
 TODO: 1. Update umt5 to Qaic; present running on cpu
 """
 
 import os
 import time
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import numpy as np
@@ -24,7 +27,7 @@ from diffusers import WanPipeline
 from tqdm import tqdm
 
 from QEfficient.diffusers.models.transformers.transformer_wan import QEffWanUnifiedWrapper
-from QEfficient.diffusers.pipelines.pipeline_module import QEffVAE, QEffWanUnifiedTransformer
+from QEfficient.diffusers.pipelines.pipeline_module import QEffVAE, QEffWanTransformer, QEffWanUnifiedTransformer
 from QEfficient.diffusers.pipelines.pipeline_utils import (
     ONNX_SUBFUNCTION_MODULE,
     ModulePerf,
@@ -57,8 +60,10 @@ class QEffWanPipeline:
 
     Attributes:
         text_encoder: UMT5 text encoder for semantic text understanding (TODO: QEfficient optimization)
-        unified_wrapper (QEffWanUnifiedWrapper): Wrapper combining transformer stages
-        transformer (QEffWanUnifiedTransformer): Optimized unified transformer for denoising
+        unified_wrapper (QEffWanUnifiedWrapper): Wrapper combining transformer stages (unified mode)
+        transformer (QEffWanUnifiedTransformer): Optimized unified transformer for denoising (unified mode)
+        transformer_high (QEffWanTransformer): High-noise transformer module (non-unified mode)
+        transformer_low (QEffWanTransformer): Low-noise transformer module (non-unified mode)
         vae_decode: VAE decoder for latent-to-video conversion
         modules (Dict[str, Any]): Dictionary of pipeline modules for batch operations
         model (WanPipeline): Original HuggingFace WAN model reference
@@ -81,7 +86,7 @@ class QEffWanPipeline:
 
     _hf_auto_class = WanPipeline
 
-    def __init__(self, model, **kwargs):
+    def __init__(self, model, use_unified: bool = True, **kwargs):
         """
         Initialize the QEfficient WAN pipeline.
 
@@ -92,25 +97,50 @@ class QEffWanPipeline:
 
         Args:
             model: Pre-loaded WanPipeline model with transformer and transformer_2 components
+            use_unified (bool): If True, use a unified transformer module that internally
+                selects high/low stage by `tsp`. If False, keep high/low transformers as
+                separate compiled modules and dispatch explicitly at runtime.
             **kwargs: Additional keyword arguments including configuration parameters
         """
         # Store original model and configuration
         self.model = model
+        self.use_unified = use_unified
         self.kwargs = kwargs
         self.custom_config = None
 
         # Text encoder (TODO: Replace with QEfficient UMT5 optimization)
         self.text_encoder = model.text_encoder
 
-        # Create unified transformer wrapper combining dual-stage models(high, low noise DiTs)
-        self.unified_wrapper = QEffWanUnifiedWrapper(model.transformer, model.transformer_2)
-        self.transformer = QEffWanUnifiedTransformer(self.unified_wrapper)
+        # Build transformer modules based on selected architecture mode.
+        if self.use_unified:
+            # Unified mode: one wrapper containing both stages.
+            self.unified_wrapper = QEffWanUnifiedWrapper(model.transformer, model.transformer_2)
+            self.transformer = QEffWanUnifiedTransformer(self.unified_wrapper)
+            self.modules = {"transformer": self.transformer}
+            self._denoise_impl = self._run_denoise_loop_unified
+        else:
+            # Non-unified mode: independent high/low modules.
+            self.unified_wrapper = None
+            self.transformer_high = QEffWanTransformer(model.transformer, module_name="transformer_high")
+            self.transformer_low = QEffWanTransformer(model.transformer_2, module_name="transformer_low")
+            self.modules = {
+                "transformer_high": self.transformer_high,
+                "transformer_low": self.transformer_low,
+            }
+            self._denoise_impl = self._run_denoise_loop_non_unified
+            # Keep a lightweight compatibility handle for existing scripts that access
+            # `pipeline.transformer.model.transformer_high/low` to attach LoRA adapters.
+            self.transformer = SimpleNamespace(
+                model=SimpleNamespace(
+                    transformer_high=self.transformer_high.model,
+                    transformer_low=self.transformer_low.model,
+                )
+            )
 
         # VAE decoder for latent-to-video conversion
         self.vae_decoder = QEffVAE(model.vae, "decoder")
-        # Store all modules in a dictionary for easy iteration during export/compile
         # TODO: add text encoder on QAIC
-        self.modules = {"transformer": self.transformer, "vae_decoder": self.vae_decoder}
+        self.modules["vae_decoder"] = self.vae_decoder
 
         # Copy tokenizers and scheduler from the original model
         self.tokenizer = model.tokenizer
@@ -123,7 +153,7 @@ class QEffWanPipeline:
 
         self.vae_decoder.get_onnx_params = self.vae_decoder.get_video_onnx_params
         # Extract patch dimensions from transformer configuration
-        _, self.patch_height, self.patch_width = self.transformer.model.config.patch_size
+        _, self.patch_height, self.patch_width = model.transformer.config.patch_size
 
     @property
     def do_classifier_free_guidance(self):
@@ -139,6 +169,7 @@ class QEffWanPipeline:
     def from_pretrained(
         cls,
         pretrained_model_name_or_path: Optional[Union[str, os.PathLike]],
+        use_unified: bool = True,
         **kwargs,
     ):
         """
@@ -152,6 +183,9 @@ class QEffWanPipeline:
             pretrained_model_name_or_path (str or os.PathLike): Either a HuggingFace model identifier
                 or a local path to a saved WAN model directory. Should contain transformer, transformer_2,
                 text_encoder, and VAE components.
+            use_unified (bool, optional): Selects WAN execution architecture.
+                - True: unified high/low transformer module
+                - False: separate high and low transformer modules
             **kwargs: Additional keyword arguments passed to WanPipeline.from_pretrained().
 
         Returns:
@@ -185,6 +219,7 @@ class QEffWanPipeline:
         )
         return cls(
             model=model,
+            use_unified=use_unified,
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             **kwargs,
         )
@@ -246,15 +281,15 @@ class QEffWanPipeline:
             if module_obj.qpc_path is None:
                 module_obj.export(**export_params)
 
-    @staticmethod
-    def get_default_config_path():
+    def get_default_config_path(self):
         """
         Get the default configuration file path for WAN pipeline.
 
         Returns:
             str: Path to the default WAN configuration JSON file.
         """
-        return os.path.join(os.path.dirname(os.path.dirname(__file__)), "configs/wan_config.json")
+        config_name = "wan_config.json" if self.use_unified else "wan_non_unified_config.json"
+        return os.path.join(os.path.dirname(os.path.dirname(__file__)), f"configs/{config_name}")
 
     def compile(
         self,
@@ -311,13 +346,8 @@ class QEffWanPipeline:
         set_execute_params(self)
 
         # Ensure all modules are exported to ONNX before compilation
-        if any(
-            path is None
-            for path in [
-                self.transformer.onnx_path,
-                self.vae_decoder.onnx_path,
-            ]
-        ):
+        onnx_paths = [module.onnx_path for module in self.modules.values()]
+        if any(path is None for path in onnx_paths):
             self.export(use_onnx_subfunctions=use_onnx_subfunctions)
 
         # Configure pipeline dimensions and calculate compressed latent parameters
@@ -330,36 +360,353 @@ class QEffWanPipeline:
             self.patch_height,
             self.patch_width,
         )
-        # Prepare dynamic specialization updates based on video dimensions
-        specialization_updates = {
-            "transformer": [
-                # high noise
-                {
-                    "cl": cl,  # Compressed latent dimension
-                    "latent_height": latent_height,  # Latent space height
-                    "latent_width": latent_width,  # Latent space width
-                    "latent_frames": latent_frames,  # Latent frames
+        if self.use_unified:
+            # Unified mode: one transformer module with two model_type specializations.
+            specialization_updates = {
+                "transformer": [
+                    {
+                        "cl": cl,
+                        "latent_height": latent_height,
+                        "latent_width": latent_width,
+                        "latent_frames": latent_frames,
+                    },
+                    {
+                        "cl": cl,
+                        "latent_height": latent_height,
+                        "latent_width": latent_width,
+                        "latent_frames": latent_frames,
+                    },
+                ],
+                "vae_decoder": {
+                    "latent_frames": latent_frames,
+                    "latent_height": latent_height,
+                    "latent_width": latent_width,
                 },
-                # low noise
-                {
-                    "cl": cl,  # Compressed latent dimension
-                    "latent_height": latent_height,  # Latent space height
-                    "latent_width": latent_width,  # Latent space width
-                    "latent_frames": latent_frames,  # Latent frames
-                },
-            ],
-            "vae_decoder": {
-                "latent_frames": latent_frames,
+            }
+        else:
+            # Non-unified mode: independent high/low modules.
+            shared_transformer_spec = {
+                "cl": cl,
                 "latent_height": latent_height,
                 "latent_width": latent_width,
-            },
-        }
+                "latent_frames": latent_frames,
+            }
+            specialization_updates = {
+                "transformer_high": shared_transformer_spec.copy(),
+                "transformer_low": shared_transformer_spec.copy(),
+                "vae_decoder": {
+                    "latent_frames": latent_frames,
+                    "latent_height": latent_height,
+                    "latent_width": latent_width,
+                },
+            }
 
         # Use generic utility functions for compilation
         if parallel:
             compile_modules_parallel(self.modules, self.custom_config, specialization_updates)
         else:
             compile_modules_sequential(self.modules, self.custom_config, specialization_updates)
+
+    def _get_transformer_dtype(self) -> torch.dtype:
+        if self.use_unified:
+            return self.transformer.model.transformer_high.dtype
+        return self.transformer_high.model.dtype
+
+    def _setup_transformer_session(self, module_obj, batch_size: int, cl: int) -> None:
+        if module_obj.qpc_session is None:
+            module_obj.qpc_session = QAICInferenceSession(str(module_obj.qpc_path), device_ids=module_obj.device_ids)
+        output_buffer = {
+            "output": np.random.rand(
+                batch_size,
+                cl,
+                constants.WAN_DIT_OUT_CHANNELS,
+            ).astype(np.int32),
+        }
+        module_obj.qpc_session.set_buffers(output_buffer)
+
+    def _prepare_transformer_sessions(self, batch_size: int, cl: int) -> None:
+        if self.use_unified:
+            self._setup_transformer_session(self.transformer, batch_size, cl)
+        else:
+            self._setup_transformer_session(self.transformer_high, batch_size, cl)
+            self._setup_transformer_session(self.transformer_low, batch_size, cl)
+
+    @staticmethod
+    def _reshape_noise_prediction(
+        outputs: Dict[str, np.ndarray],
+        batch_size: int,
+        post_patch_num_frames: int,
+        post_patch_height: int,
+        post_patch_width: int,
+        p_t: int,
+        p_h: int,
+        p_w: int,
+    ) -> torch.Tensor:
+        hidden_states = torch.tensor(outputs["output"])
+        hidden_states = hidden_states.reshape(
+            batch_size, post_patch_num_frames, post_patch_height, post_patch_width, p_t, p_h, p_w, -1
+        )
+        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
+        return hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+    def _run_denoise_loop_unified(
+        self,
+        latents: torch.Tensor,
+        timesteps: torch.Tensor,
+        batch_size: int,
+        guidance_scale: float,
+        guidance_scale_2: float,
+        boundary_timestep: Optional[float],
+        transformer_dtype: torch.dtype,
+        prompt_embeds: torch.Tensor,
+        negative_prompt_embeds: Optional[torch.Tensor],
+        mask: torch.Tensor,
+        num_inference_steps: int,
+        num_warmup_steps: int,
+        callback_on_step_end: Optional[Callable],
+        callback_on_step_end_tensor_inputs: List[str],
+    ):
+        transformer_perf = []
+        with self.model.progress_bar(total=num_inference_steps) as progress_bar:
+            for i, t in enumerate(timesteps):
+                if self._interrupt:
+                    continue
+
+                self._current_timestep = t
+
+                if boundary_timestep is None or t >= boundary_timestep:
+                    current_model = self.transformer.model.transformer_high
+                    current_guidance_scale = guidance_scale
+                    model_type = torch.ones(1, dtype=torch.int64)
+                else:
+                    current_model = self.transformer.model.transformer_low
+                    current_guidance_scale = guidance_scale_2
+                    model_type = torch.ones(2, dtype=torch.int64)
+
+                latent_model_input = latents.to(transformer_dtype)
+                if self.model.config.expand_timesteps:
+                    temp_ts = (mask[0][0][:, ::2, ::2] * t).flatten()
+                    timestep = temp_ts.unsqueeze(0).expand(latents.shape[0], -1)
+                else:
+                    timestep = t.expand(latents.shape[0])
+
+                _, _, latent_frames, latent_height, latent_width = latents.shape
+                p_t, p_h, p_w = current_model.config.patch_size
+                post_patch_num_frames = latent_frames // p_t
+                post_patch_height = latent_height // p_h
+                post_patch_width = latent_width // p_w
+
+                rotary_emb = current_model.rope(latent_model_input)
+                rotary_emb = torch.cat(rotary_emb, dim=0)
+                timestep = timestep.flatten()
+
+                temb, timestep_proj, encoder_hidden_states, _ = current_model.condition_embedder(
+                    timestep, prompt_embeds, encoder_hidden_states_image=None, timestep_seq_len=None
+                )
+
+                if self.do_classifier_free_guidance:
+                    _, _, encoder_hidden_states_neg, _ = current_model.condition_embedder(
+                        timestep,
+                        negative_prompt_embeds,
+                        encoder_hidden_states_image=None,
+                        timestep_seq_len=None,
+                    )
+
+                timestep_proj = timestep_proj.unflatten(1, (6, -1))
+                inputs_aic = {
+                    "hidden_states": latents.detach().numpy(),
+                    "encoder_hidden_states": encoder_hidden_states.detach().numpy(),
+                    "rotary_emb": rotary_emb.detach().numpy(),
+                    "temb": temb.detach().numpy(),
+                    "timestep_proj": timestep_proj.detach().numpy(),
+                    "tsp": model_type.detach().numpy(),
+                }
+
+                if self.do_classifier_free_guidance:
+                    inputs_aic2 = {
+                        "hidden_states": latents.detach().numpy(),
+                        "encoder_hidden_states": encoder_hidden_states_neg.detach().numpy(),
+                        "rotary_emb": rotary_emb.detach().numpy(),
+                        "temb": temb.detach().numpy(),
+                        "timestep_proj": timestep_proj.detach().numpy(),
+                        "tsp": model_type.detach().numpy(),
+                    }
+
+                with current_model.cache_context("cond"):
+                    start_transformer_step_time = time.perf_counter()
+                    outputs = self.transformer.qpc_session.run(inputs_aic)
+                    end_transformer_step_time = time.perf_counter()
+                    transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
+                    noise_pred = self._reshape_noise_prediction(
+                        outputs,
+                        batch_size,
+                        post_patch_num_frames,
+                        post_patch_height,
+                        post_patch_width,
+                        p_t,
+                        p_h,
+                        p_w,
+                    )
+
+                if self.do_classifier_free_guidance:
+                    with current_model.cache_context("uncond"):
+                        start_transformer_step_time = time.perf_counter()
+                        outputs = self.transformer.qpc_session.run(inputs_aic2)
+                        end_transformer_step_time = time.perf_counter()
+                        transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
+                        noise_uncond = self._reshape_noise_prediction(
+                            outputs,
+                            batch_size,
+                            post_patch_num_frames,
+                            post_patch_height,
+                            post_patch_width,
+                            p_t,
+                            p_h,
+                            p_w,
+                        )
+                        noise_pred = noise_uncond + current_guidance_scale * (noise_pred - noise_uncond)
+
+                latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+
+                if callback_on_step_end is not None:
+                    callback_kwargs = {k: locals()[k] for k in callback_on_step_end_tensor_inputs}
+                    callback_outputs = callback_on_step_end(self, i, t, callback_kwargs)
+                    latents = callback_outputs.pop("latents", latents)
+                    prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
+                    negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
+
+                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
+                    progress_bar.update()
+
+        return latents, transformer_perf
+
+    def _run_denoise_loop_non_unified(
+        self,
+        latents: torch.Tensor,
+        timesteps: torch.Tensor,
+        batch_size: int,
+        guidance_scale: float,
+        guidance_scale_2: float,
+        boundary_timestep: Optional[float],
+        transformer_dtype: torch.dtype,
+        prompt_embeds: torch.Tensor,
+        negative_prompt_embeds: Optional[torch.Tensor],
+        mask: torch.Tensor,
+        num_inference_steps: int,
+        num_warmup_steps: int,
+        callback_on_step_end: Optional[Callable],
+        callback_on_step_end_tensor_inputs: List[str],
+    ):
+        transformer_perf = []
+        with self.model.progress_bar(total=num_inference_steps) as progress_bar:
+            for i, t in enumerate(timesteps):
+                if self._interrupt:
+                    continue
+
+                self._current_timestep = t
+
+                if boundary_timestep is None or t >= boundary_timestep:
+                    current_transformer_module = self.transformer_high
+                    current_guidance_scale = guidance_scale
+                else:
+                    current_transformer_module = self.transformer_low
+                    current_guidance_scale = guidance_scale_2
+                current_model = current_transformer_module.model
+
+                latent_model_input = latents.to(transformer_dtype)
+                if self.model.config.expand_timesteps:
+                    temp_ts = (mask[0][0][:, ::2, ::2] * t).flatten()
+                    timestep = temp_ts.unsqueeze(0).expand(latents.shape[0], -1)
+                else:
+                    timestep = t.expand(latents.shape[0])
+
+                _, _, latent_frames, latent_height, latent_width = latents.shape
+                p_t, p_h, p_w = current_model.config.patch_size
+                post_patch_num_frames = latent_frames // p_t
+                post_patch_height = latent_height // p_h
+                post_patch_width = latent_width // p_w
+
+                rotary_emb = current_model.rope(latent_model_input)
+                rotary_emb = torch.cat(rotary_emb, dim=0)
+                timestep = timestep.flatten()
+
+                temb, timestep_proj, encoder_hidden_states, _ = current_model.condition_embedder(
+                    timestep, prompt_embeds, encoder_hidden_states_image=None, timestep_seq_len=None
+                )
+
+                if self.do_classifier_free_guidance:
+                    _, _, encoder_hidden_states_neg, _ = current_model.condition_embedder(
+                        timestep,
+                        negative_prompt_embeds,
+                        encoder_hidden_states_image=None,
+                        timestep_seq_len=None,
+                    )
+
+                timestep_proj = timestep_proj.unflatten(1, (6, -1))
+                inputs_aic = {
+                    "hidden_states": latents.detach().numpy(),
+                    "encoder_hidden_states": encoder_hidden_states.detach().numpy(),
+                    "rotary_emb": rotary_emb.detach().numpy(),
+                    "temb": temb.detach().numpy(),
+                    "timestep_proj": timestep_proj.detach().numpy(),
+                }
+
+                if self.do_classifier_free_guidance:
+                    inputs_aic2 = {
+                        "hidden_states": latents.detach().numpy(),
+                        "encoder_hidden_states": encoder_hidden_states_neg.detach().numpy(),
+                        "rotary_emb": rotary_emb.detach().numpy(),
+                        "temb": temb.detach().numpy(),
+                        "timestep_proj": timestep_proj.detach().numpy(),
+                    }
+
+                with current_model.cache_context("cond"):
+                    start_transformer_step_time = time.perf_counter()
+                    outputs = current_transformer_module.qpc_session.run(inputs_aic)
+                    end_transformer_step_time = time.perf_counter()
+                    transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
+                    noise_pred = self._reshape_noise_prediction(
+                        outputs,
+                        batch_size,
+                        post_patch_num_frames,
+                        post_patch_height,
+                        post_patch_width,
+                        p_t,
+                        p_h,
+                        p_w,
+                    )
+
+                if self.do_classifier_free_guidance:
+                    with current_model.cache_context("uncond"):
+                        start_transformer_step_time = time.perf_counter()
+                        outputs = current_transformer_module.qpc_session.run(inputs_aic2)
+                        end_transformer_step_time = time.perf_counter()
+                        transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
+                        noise_uncond = self._reshape_noise_prediction(
+                            outputs,
+                            batch_size,
+                            post_patch_num_frames,
+                            post_patch_height,
+                            post_patch_width,
+                            p_t,
+                            p_h,
+                            p_w,
+                        )
+                        noise_pred = noise_uncond + current_guidance_scale * (noise_pred - noise_uncond)
+
+                latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+
+                if callback_on_step_end is not None:
+                    callback_kwargs = {k: locals()[k] for k in callback_on_step_end_tensor_inputs}
+                    callback_outputs = callback_on_step_end(self, i, t, callback_kwargs)
+                    latents = callback_outputs.pop("latents", latents)
+                    prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
+                    negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
+
+                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
+                    progress_bar.update()
+
+        return latents, transformer_perf
 
     def __call__(
         self,
@@ -519,7 +866,7 @@ class QEffWanPipeline:
         )
 
         # Convert embeddings to transformer dtype for compatibility
-        transformer_dtype = self.transformer.model.transformer_high.dtype
+        transformer_dtype = self._get_transformer_dtype()
         prompt_embeds = prompt_embeds.to(transformer_dtype)
         if negative_prompt_embeds is not None:
             negative_prompt_embeds = negative_prompt_embeds.to(transformer_dtype)
@@ -529,7 +876,7 @@ class QEffWanPipeline:
         timesteps = self.scheduler.timesteps
 
         # Step 5: Prepare initial latent variables for video generation
-        num_channels_latents = self.transformer.model.config.in_channels
+        num_channels_latents = self.model.transformer.config.in_channels
 
         latents = self.model.prepare_latents(
             batch_size * num_videos_per_prompt,
@@ -555,13 +902,7 @@ class QEffWanPipeline:
         else:
             boundary_timestep = None
 
-        # Step 7: Initialize QAIC inference session for transformer
-        if self.transformer.qpc_session is None:
-            self.transformer.qpc_session = QAICInferenceSession(
-                str(self.transformer.qpc_path), device_ids=self.transformer.device_ids
-            )
-
-        # Calculate compressed latent dimension for transformer buffer allocation
+        # Step 7: Initialize transformer sessions and buffers
         cl, _, _, _ = calculate_latent_dimensions_with_frames(
             height,
             width,
@@ -571,168 +912,28 @@ class QEffWanPipeline:
             self.patch_height,
             self.patch_width,
         )
-        # Allocate output buffer for QAIC inference
-        output_buffer = {
-            "output": np.random.rand(
-                batch_size,
-                cl,  # Compressed latent dimension
-                constants.WAN_DIT_OUT_CHANNELS,
-            ).astype(np.int32),
-        }
-        self.transformer.qpc_session.set_buffers(output_buffer)
-        transformer_perf = []
-
-        # Step 8: Denoising loop with dual-stage processing
-        with self.model.progress_bar(total=num_inference_steps) as progress_bar:
-            for i, t in enumerate(timesteps):
-                if self._interrupt:
-                    continue
-
-                self._current_timestep = t
-
-                # Determine which model to use based on boundary timestep
-                if boundary_timestep is None or t >= boundary_timestep:
-                    # High-noise stage
-                    current_model = self.transformer.model.transformer_high
-                    current_guidance_scale = guidance_scale
-                    model_type = torch.ones(1, dtype=torch.int64)  # High-noise model indicator
-                else:
-                    # Low-noise stage
-                    current_model = self.transformer.model.transformer_low
-                    current_guidance_scale = guidance_scale_2
-                    model_type = torch.ones(2, dtype=torch.int64)  # Low-noise model indicator
-
-                # Prepare latent input with proper dtype
-                latent_model_input = latents.to(transformer_dtype)
-
-                # Handle timestep expansion for temporal consistency
-                if self.model.config.expand_timesteps:
-                    # Expand timesteps spatially for better temporal modeling
-                    temp_ts = (mask[0][0][:, ::2, ::2] * t).flatten()
-                    timestep = temp_ts.unsqueeze(0).expand(latents.shape[0], -1)
-                else:
-                    # Standard timestep broadcasting
-                    timestep = t.expand(latents.shape[0])
-
-                # Extract dimensions for patch processing
-                batch_size, num_channels, latent_frames, latent_height, latent_width = latents.shape
-                p_t, p_h, p_w = current_model.config.patch_size
-                post_patch_num_frames = latent_frames // p_t
-                post_patch_height = latent_height // p_h
-                post_patch_width = latent_width // p_w
-
-                # Generate rotary position embeddings
-                rotary_emb = current_model.rope(latent_model_input)
-                rotary_emb = torch.cat(rotary_emb, dim=0)
-                ts_seq_len = None
-                timestep = timestep.flatten()
-
-                # Generate conditioning embeddings (time + text)
-                temb, timestep_proj, encoder_hidden_states, encoder_hidden_states_image = (
-                    current_model.condition_embedder(
-                        timestep, prompt_embeds, encoder_hidden_states_image=None, timestep_seq_len=ts_seq_len
-                    )
-                )
-
-                # Generate negative conditioning for classifier-free guidance
-                if self.do_classifier_free_guidance:
-                    temb, timestep_proj, encoder_hidden_states_neg, encoder_hidden_states_image = (
-                        current_model.condition_embedder(
-                            timestep,
-                            negative_prompt_embeds,
-                            encoder_hidden_states_image=None,
-                            timestep_seq_len=ts_seq_len,
-                        )
-                    )
-
-                # Reshape timestep projection for transformer input
-                timestep_proj = timestep_proj.unflatten(1, (6, -1))
-
-                # Prepare inputs for QAIC inference
-                inputs_aic = {
-                    "hidden_states": latents.detach().numpy(),
-                    "encoder_hidden_states": encoder_hidden_states.detach().numpy(),
-                    "rotary_emb": rotary_emb.detach().numpy(),
-                    "temb": temb.detach().numpy(),
-                    "timestep_proj": timestep_proj.detach().numpy(),
-                    "tsp": model_type.detach().numpy(),  # Transformer stage pointer
-                }
-
-                # Prepare negative inputs for classifier-free guidance
-                if self.do_classifier_free_guidance:
-                    inputs_aic2 = {
-                        "hidden_states": latents.detach().numpy(),
-                        "encoder_hidden_states": encoder_hidden_states_neg.detach().numpy(),
-                        "rotary_emb": rotary_emb.detach().numpy(),
-                        "temb": temb.detach().numpy(),
-                        "timestep_proj": timestep_proj.detach().numpy(),
-                    }
-
-                # Run conditional prediction with caching context
-                with current_model.cache_context("cond"):
-                    # QAIC inference for conditional prediction
-                    start_transformer_step_time = time.perf_counter()
-                    outputs = self.transformer.qpc_session.run(inputs_aic)
-                    end_transformer_step_time = time.perf_counter()
-                    transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
-                    print(f"DIT {i} time {end_transformer_step_time - start_transformer_step_time:.2f} seconds")
-
-                    # Process transformer output
-                    hidden_states = torch.tensor(outputs["output"])
-
-                    # Reshape output from patches back to video format
-                    hidden_states = hidden_states.reshape(
-                        batch_size, post_patch_num_frames, post_patch_height, post_patch_width, p_t, p_h, p_w, -1
-                    )
-
-                    # Permute dimensions to reconstruct video tensor
-                    hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
-                    noise_pred = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
-
-                # Run unconditional prediction for classifier-free guidance
-                if self.do_classifier_free_guidance:  # Note: CFG is False for WAN Lightning
-                    with current_model.cache_context("uncond"):
-                        # QAIC inference for unconditional prediction
-                        start_transformer_step_time = time.perf_counter()
-                        outputs = self.transformer.qpc_session.run(inputs_aic2)
-                        end_transformer_step_time = time.perf_counter()
-                        transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
-
-                        # Process unconditional output
-                        hidden_states = torch.tensor(outputs["output"])
-
-                        # Reshape unconditional output
-                        hidden_states = hidden_states.reshape(
-                            batch_size, post_patch_num_frames, post_patch_height, post_patch_width, p_t, p_h, p_w, -1
-                        )
-
-                        hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
-                        noise_uncond = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
-
-                        # Apply classifier-free guidance
-                        noise_pred = noise_uncond + current_guidance_scale * (noise_pred - noise_uncond)
-
-                # Update latents using scheduler (x_t -> x_t-1)
-                latents = self.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
-
-                # Execute callback if provided
-                if callback_on_step_end is not None:
-                    callback_kwargs = {}
-                    for k in callback_on_step_end_tensor_inputs:
-                        callback_kwargs[k] = locals()[k]
-                    callback_outputs = callback_on_step_end(self, i, t, callback_kwargs)
-
-                    latents = callback_outputs.pop("latents", latents)
-                    prompt_embeds = callback_outputs.pop("prompt_embeds", prompt_embeds)
-                    negative_prompt_embeds = callback_outputs.pop("negative_prompt_embeds", negative_prompt_embeds)
-
-                # Update progress bar
-                if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % self.scheduler.order == 0):
-                    progress_bar.update()
+        self._prepare_transformer_sessions(batch_size, cl)
+        latents, transformer_perf = self._denoise_impl(
+            latents=latents,
+            timesteps=timesteps,
+            batch_size=batch_size,
+            guidance_scale=guidance_scale,
+            guidance_scale_2=self._guidance_scale_2,
+            boundary_timestep=boundary_timestep,
+            transformer_dtype=transformer_dtype,
+            prompt_embeds=prompt_embeds,
+            negative_prompt_embeds=negative_prompt_embeds,
+            mask=mask,
+            num_inference_steps=num_inference_steps,
+            num_warmup_steps=num_warmup_steps,
+            callback_on_step_end=callback_on_step_end,
+            callback_on_step_end_tensor_inputs=callback_on_step_end_tensor_inputs,
+        )
 
         self._current_timestep = None
 
         # Step 9: Decode latents to video
+        vae_decoder_perf = 0.0
         if not output_type == "latent":
             # Prepare latents for VAE decoding
             latents = latents.to(self.vae_decoder.model.dtype)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 ---
 
 *Latest news* :fire: <br>
+- [04/2026] Added WAN non-unified execution support in `QEffWanPipeline` with separate `transformer_high` and `transformer_low` modules
+- [04/2026] Added first-block-cache support for WAN non-unified mode and FLUX (`QEffWanPipeline`, `QEffFluxPipeline`)
 - [12/2025] Enabled [disaggregated serving](examples/disagg_serving) for GPT-OSS model
 - [12/2025] Added support for wav2vec2 Audio Model [facebook/wav2vec2-base-960h](https://huggingface.co/facebook/wav2vec2-base-960h)
 - [12/2025] Added support for diffuser video generation model [WAN 2.2 Model Card](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B-Diffusers)

--- a/docs/source/diffuser_classes.md
+++ b/docs/source/diffuser_classes.md
@@ -64,6 +64,36 @@
 (QEffWanPipeline)=
 ### `QEffWanPipeline`
 
+WAN supports two execution architectures:
+
+- `use_unified=True` (default): one unified transformer module.
+- `use_unified=False`: separate `transformer_high` and `transformer_low` modules.
+
+First-block-cache is currently supported only for non-unified WAN:
+
+```python
+from QEfficient import QEffWanPipeline
+
+pipeline = QEffWanPipeline.from_pretrained(
+    "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+    use_unified=False,
+    enable_first_block_cache=True,
+    first_block_cache_downsample_factor=4,
+)
+
+output = pipeline(
+    prompt="A cat playing in a sunny garden",
+    cache_threshold_high=0.1,
+    cache_threshold_low=0.065,
+)
+```
+
+See examples:
+
+- `examples/diffusers/wan/wan_lightning.py`
+- `examples/diffusers/wan/wan_lightning_custom.py`
+- `examples/diffusers/wan/wan_first_block_cache.py`
+
 ```{eval-rst}
 .. autoclass:: QEfficient.diffusers.pipelines.wan.pipeline_wan.QEffWanPipeline
    :members:
@@ -82,6 +112,31 @@
 
 (QEffFluxPipeline)=
 ### `QEffFluxPipeline`
+
+FLUX supports optional first-block-cache via runtime monkey patching:
+
+```python
+from QEfficient import QEffFluxPipeline
+
+pipeline = QEffFluxPipeline.from_pretrained(
+    "black-forest-labs/FLUX.1-schnell",
+    enable_first_block_cache=True,
+    first_block_cache_downsample_factor=4,
+)
+
+output = pipeline(
+    prompt="A laughing girl",
+    cache_threshold=0.1,
+)
+```
+
+When `enable_first_block_cache=False`, the pipeline follows baseline behavior and ignores `cache_threshold`.
+
+See examples:
+
+- `examples/diffusers/flux/flux_1_schnell.py`
+- `examples/diffusers/flux/flux_1_shnell_custom.py`
+- `examples/diffusers/flux/flux_1_schnell_first_block_cache.py`
 
 ```{eval-rst}
 .. autoclass:: QEfficient.diffusers.pipelines.flux.pipeline_flux.QEffFluxPipeline

--- a/docs/source/introduction.md
+++ b/docs/source/introduction.md
@@ -23,6 +23,8 @@ For other models, there is comprehensive documentation to inspire upon the chang
 ***Latest news*** : <br>
 
 - [coming soon] Support for more popular [models](models_coming_soon)<br>
+- [04/2026] Added WAN non-unified execution support in `QEffWanPipeline` with separate `transformer_high` and `transformer_low` modules
+- [04/2026] Added first-block-cache support for WAN non-unified mode and FLUX (`QEffWanPipeline`, `QEffFluxPipeline`)
 - [12/2025] Enabled [disaggregated serving](https://github.com/quic/efficient-transformers/tree/main/examples/disagg_serving) for GPT-OSS model
 - [12/2025] Added support for wav2vec2 Audio Model [facebook/wav2vec2-base-960h](https://huggingface.co/facebook/wav2vec2-base-960h)
 - [12/2025] Added support for diffuser video generation model [WAN 2.2 Model Card](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B-Diffusers)

--- a/docs/source/validate.md
+++ b/docs/source/validate.md
@@ -125,7 +125,17 @@ If the `kv_offload` is set to `True` it runs in dual QPC and if its set to `Fals
 
 | Architecture | Model Family | Representative Models                                                                 | vLLM Support |
 |--------------|--------------|----------------------------------------------------------------------------------------|--------------|
-| **FluxPipeline**  | FLUX.1     | [black-forest-labs/FLUX.1-schnell](https://huggingface.co/stabilityai/stable-diffusion-2-1) |          |
+| **FluxPipeline**  | FLUX.1     | [black-forest-labs/FLUX.1-schnell](https://huggingface.co/black-forest-labs/FLUX.1-schnell) |          |
+
+Supported modes:
+
+- Baseline FLUX pipeline.
+- FLUX first-block-cache mode (`enable_first_block_cache=True`) with call-time `cache_threshold`.
+
+Reference examples:
+
+- [flux_1_schnell.py](https://github.com/quic/efficient-transformers/blob/main/examples/diffusers/flux/flux_1_schnell.py)
+- [flux_1_schnell_first_block_cache.py](https://github.com/quic/efficient-transformers/blob/main/examples/diffusers/flux/flux_1_schnell_first_block_cache.py)
 
 ### Video Generation Models
 #### Text to Video Generation Models
@@ -134,6 +144,19 @@ If the `kv_offload` is set to `True` it runs in dual QPC and if its set to `Fals
 | Architecture | Model Family | Representative Models                                                                 | vLLM Support |
 |--------------|--------------|----------------------------------------------------------------------------------------|--------------|
 | **WanPipeline**  | Wan2.2     | [Wan-AI/Wan2.2-T2V-A14B-Diffusers](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B-Diffusers) |         |
+
+Supported modes:
+
+- Unified WAN (`use_unified=True`): single transformer module.
+- Non-unified WAN (`use_unified=False`): separate high/low transformer modules.
+- Non-unified first-block-cache (`use_unified=False`, `enable_first_block_cache=True`) with
+  `cache_threshold_high` and `cache_threshold_low`.
+
+Reference examples:
+
+- [wan_lightning.py](https://github.com/quic/efficient-transformers/blob/main/examples/diffusers/wan/wan_lightning.py)
+- [wan_lightning_custom.py](https://github.com/quic/efficient-transformers/blob/main/examples/diffusers/wan/wan_lightning_custom.py)
+- [wan_first_block_cache.py](https://github.com/quic/efficient-transformers/blob/main/examples/diffusers/wan/wan_first_block_cache.py)
 
 #### Image to Video Generation Models
 **QEff Auto Class:** `QEffWanImageToVideoPipeline`

--- a/examples/diffusers/flux/README.md
+++ b/examples/diffusers/flux/README.md
@@ -10,6 +10,7 @@ FLUX.1-schnell is a fast, distilled version of the FLUX.1 text-to-image model op
 
 - **`flux_1_schnell.py`** - Basic example showing simple image generation
 - **`flux_1_shnell_custom.py`** - Advanced example with customization options
+- **`flux_1_schnell_first_block_cache.py`** - FLUX.1-schnell with patch-based first-block-cache enabled
 - **`flux_config.json`** - Configuration file for pipeline modules
 
 ## Quick Start
@@ -46,6 +47,31 @@ Run the basic example:
 ```bash
 python flux_1_schnell.py
 ```
+
+## First-Block-Cache Usage
+
+Use the first-block-cache path when you want retained-state based speedups during denoising:
+
+```python
+from QEfficient import QEffFluxPipeline
+
+pipeline = QEffFluxPipeline.from_pretrained(
+    "black-forest-labs/FLUX.1-schnell",
+    enable_first_block_cache=True,
+    # Downsample factor used on first-block residuals before similarity check.
+    first_block_cache_downsample_factor=4,
+)
+
+output = pipeline(
+    prompt="A laughing girl",
+    cache_threshold=0.1,
+)
+```
+
+Notes:
+- `enable_first_block_cache=False` keeps baseline behavior unchanged.
+- `cache_threshold` is used only when cache is enabled.
+- `first_block_cache_downsample_factor` must divide transformer hidden size.
 
 ## Advanced Customization
 

--- a/examples/diffusers/flux/flux_1_schnell_first_block_cache.py
+++ b/examples/diffusers/flux/flux_1_schnell_first_block_cache.py
@@ -1,0 +1,38 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+"""
+FLUX.1-schnell first-block-cache example.
+"""
+
+import torch
+
+from QEfficient import QEffFluxPipeline
+
+pipeline = QEffFluxPipeline.from_pretrained(
+    "black-forest-labs/FLUX.1-schnell",
+    enable_first_block_cache=True,
+    # Hidden-dimension downsampling used for first-block residual similarity check.
+    first_block_cache_downsample_factor=4,
+)
+
+output = pipeline(
+    prompt="A laughing girl",
+    custom_config_path="examples/diffusers/flux/flux_config.json",
+    height=256,
+    width=256,
+    guidance_scale=0.0,
+    num_inference_steps=40,
+    max_sequence_length=256,
+    generator=torch.Generator("cpu").manual_seed(42),
+    parallel_compile=True,
+    use_onnx_subfunctions=False,
+    cache_threshold=0.045,
+)
+
+image = output.images[0]
+image.save("girl_laughing_first_block_cache.png")
+print(output)

--- a/examples/diffusers/flux/flux_1_schnell_first_block_cache.py
+++ b/examples/diffusers/flux/flux_1_schnell_first_block_cache.py
@@ -29,7 +29,6 @@ output = pipeline(
     max_sequence_length=256,
     generator=torch.Generator("cpu").manual_seed(42),
     parallel_compile=True,
-    use_onnx_subfunctions=False,
     cache_threshold=0.045,
 )
 

--- a/examples/diffusers/wan/README.md
+++ b/examples/diffusers/wan/README.md
@@ -9,7 +9,9 @@ WAN 2.2 is a text-to-video diffusion model that uses dual-stage processing for h
 ## Files
 
 - **`wan_lightning.py`** - Complete example with Lightning LoRA for fast video generation
+- **`wan_first_block_cache.py`** - Non-unified WAN with patch-based first-block-cache enabled
 - **`wan_config.json`** - Contains default compilation config for transformer, vae modules.
+- **`wan_non_unified_config.json`** - Non-unified module config (`transformer_high`, `transformer_low`, `vae_decoder`)
 
 ## Quick Start
 

--- a/examples/diffusers/wan/wan_first_block_cache.py
+++ b/examples/diffusers/wan/wan_first_block_cache.py
@@ -1,0 +1,59 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+import torch
+from diffusers.utils import export_to_video
+
+from QEfficient import QEffWanPipeline
+
+# Non-unified WAN + first-block-cache (patch-based activation at load time).
+pipeline = QEffWanPipeline.from_pretrained(
+    "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
+    use_unified=False,
+    enable_first_block_cache=True,
+    # Hidden-dimension downsampling used for first-block residual similarity check.
+    first_block_cache_downsample_factor=4,
+)
+
+# ============================================================================
+# OPTIONAL: REDUCE MODEL LAYERS FOR FASTER INFERENCE
+# ============================================================================
+# pipeline.transformer_high.model.config["num_layers"] = 2
+# pipeline.transformer_low.model.config["num_layers"] = 2
+#
+# high_blocks = pipeline.transformer_high.model.blocks
+# pipeline.transformer_high.model.blocks = torch.nn.ModuleList(
+#     [high_blocks[i] for i in range(0, pipeline.transformer_high.model.config["num_layers"])]
+# )
+#
+# low_blocks = pipeline.transformer_low.model.blocks
+# pipeline.transformer_low.model.blocks = torch.nn.ModuleList(
+#     [low_blocks[i] for i in range(0, pipeline.transformer_low.model.config["num_layers"])]
+# )
+
+prompt = "Two anthropomorphic cats in comfy boxing gear and bright gloves fight intensely on a spotlighted stage."
+negative_prompt = "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
+
+output = pipeline(
+    prompt=prompt,
+    negative_prompt=negative_prompt,
+    num_frames=81,
+    guidance_scale=4.0,
+    guidance_scale_2=3.0,
+    num_inference_steps=40,
+    generator=torch.Generator().manual_seed(42),
+    custom_config_path="examples/diffusers/wan/wan_non_unified_config.json",
+    height=96,
+    width=160,
+    use_onnx_subfunctions=False,
+    parallel_compile=True,
+    cache_threshold_high=0.1,
+    cache_threshold_low=0.065,
+)
+
+frames = output.images[0]
+export_to_video(frames, "wan_first_block_cache.mp4", fps=16)
+print(output)

--- a/examples/diffusers/wan/wan_first_block_cache.py
+++ b/examples/diffusers/wan/wan_first_block_cache.py
@@ -48,7 +48,6 @@ output = pipeline(
     custom_config_path="examples/diffusers/wan/wan_non_unified_config.json",
     height=96,
     width=160,
-    use_onnx_subfunctions=False,
     parallel_compile=True,
     cache_threshold_high=0.1,
     cache_threshold_low=0.065,

--- a/examples/diffusers/wan/wan_lightning_custom.py
+++ b/examples/diffusers/wan/wan_lightning_custom.py
@@ -33,6 +33,8 @@ from QEfficient import QEffWanPipeline
 
 # Option 1: Basic initialization with default parameters
 pipeline = QEffWanPipeline.from_pretrained("Wan-AI/Wan2.2-T2V-A14B-Diffusers")
+# Option 2: Non-unified mode (separate high/low transformers)
+# pipeline = QEffWanPipeline.from_pretrained("Wan-AI/Wan2.2-T2V-A14B-Diffusers", use_unified=False)
 
 # ============================================================================
 # LORA ADAPTER LOADING FOR LIGHTNING MODEL

--- a/examples/diffusers/wan/wan_non_unified_config.json
+++ b/examples/diffusers/wan/wan_non_unified_config.json
@@ -1,0 +1,73 @@
+{
+  "description": "Default configuration for Wan pipeline in non-unified mode with separate transformer_high and transformer_low modules",
+  "modules": {
+    "transformer_high": {
+      "specializations": {
+        "batch_size": "1",
+        "num_channels": "16",
+        "steps": "1",
+        "sequence_length": "512"
+      },
+      "compilation": {
+        "onnx_path": null,
+        "compile_dir": null,
+        "mdp_ts_num_devices": 16,
+        "mxfp6_matmul": true,
+        "convert_to_fp16": true,
+        "compile_only": true,
+        "aic_num_cores": 16,
+        "mos": 1,
+        "mdts_mos": 1
+      },
+      "execute": {
+        "device_ids": null,
+        "qpc_path": null
+      }
+    },
+    "transformer_low": {
+      "specializations": {
+        "batch_size": "1",
+        "num_channels": "16",
+        "steps": "1",
+        "sequence_length": "512"
+      },
+      "compilation": {
+        "onnx_path": null,
+        "compile_dir": null,
+        "mdp_ts_num_devices": 16,
+        "mxfp6_matmul": true,
+        "convert_to_fp16": true,
+        "compile_only": true,
+        "aic_num_cores": 16,
+        "mos": 1,
+        "mdts_mos": 1
+      },
+      "execute": {
+        "device_ids": null,
+        "qpc_path": null
+      }
+    },
+    "vae_decoder": {
+      "specializations": {
+        "batch_size": 1,
+        "num_channels": 16
+      },
+      "compilation": {
+        "onnx_path": null,
+        "compile_dir": null,
+        "mdp_ts_num_devices": 8,
+        "mxfp6_matmul": false,
+        "convert_to_fp16": true,
+        "aic_num_cores": 16,
+        "aic-enable-depth-first": true,
+        "compile_only": true,
+        "mos": 1,
+        "mdts_mos": 1
+      },
+      "execute": {
+        "device_ids": null,
+        "qpc_path": null
+      }
+    }
+  }
+}

--- a/tests/diffusers/test_flux.py
+++ b/tests/diffusers/test_flux.py
@@ -60,6 +60,7 @@ def flux_pipeline_call_with_mad_validation(
     custom_config_path: Optional[str] = None,
     use_onnx_subfunctions: bool = False,
     parallel_compile: bool = False,
+    cache_threshold: Optional[float] = None,
     mad_tolerances: Dict[str, float] = None,
 ):
     """
@@ -168,6 +169,16 @@ def flux_pipeline_call_with_mad_validation(
         "output": np.zeros((batch_size, cl, pipeline.transformer.model.config.in_channels), dtype=np.float32),
     }
     pipeline.transformer.qpc_session.set_buffers(output_buffer)
+    if getattr(pipeline, "enable_first_block_cache", False):
+        pipeline.transformer.qpc_session.skip_buffers(
+            [
+                tensor_name
+                for tensor_name in (
+                    pipeline.transformer.qpc_session.input_names + pipeline.transformer.qpc_session.output_names
+                )
+                if tensor_name.startswith("prev_") or tensor_name.endswith("_RetainedState")
+            ]
+        )
 
     transformer_perf = []
     pipeline.scheduler.set_begin_index(0)
@@ -218,6 +229,9 @@ def flux_pipeline_call_with_mad_validation(
                 "adaln_single_emb": adaln_single_emb.detach().numpy(),
                 "adaln_out": adaln_out.detach().numpy(),
             }
+            if getattr(pipeline, "enable_first_block_cache", False):
+                stage_cache_threshold = 0.0 if cache_threshold is None else cache_threshold
+                inputs_aic["cache_threshold"] = np.array(stage_cache_threshold, dtype=np.float32)
 
             # MAD Validation for Transformer - PyTorch reference inference
             noise_pred_torch = pytorch_pipeline.transformer(
@@ -313,9 +327,8 @@ def flux_pipeline_call_with_mad_validation(
     )
 
 
-@pytest.fixture(scope="session")
-def flux_pipeline():
-    """Setup Flux test pipelines with random-initialized (dummy) weights."""
+def _build_flux_pipeline(enable_first_block_cache: bool = False):
+    """Build Flux test pipelines with random-initialized (dummy) weights."""
     torch.manual_seed(TEST_SEED)
     np.random.seed(TEST_SEED)
 
@@ -363,14 +376,29 @@ def flux_pipeline():
     # Use QEff wrapper on a copy of the random-init reference model.
     import copy
 
-    pipeline = QEffFluxPipeline(copy.deepcopy(pytorch_pipeline))
+    pipeline = QEffFluxPipeline(
+        copy.deepcopy(pytorch_pipeline),
+        enable_first_block_cache=enable_first_block_cache,
+    )
     return pipeline, pytorch_pipeline
 
 
-@pytest.mark.flux
-@pytest.mark.diffusion_models
-@pytest.mark.on_qaic
-def test_flux_pipeline(flux_pipeline):
+@pytest.fixture(scope="session")
+def flux_pipeline():
+    return _build_flux_pipeline(enable_first_block_cache=False)
+
+
+@pytest.fixture(scope="session")
+def flux_pipeline_first_block_cache():
+    return _build_flux_pipeline(enable_first_block_cache=True)
+
+
+def _run_flux_pipeline_test_case(
+    flux_pipeline_data,
+    config,
+    test_label: str,
+    pipeline_call_overrides: Optional[Dict[str, Any]] = None,
+):
     """
     Comprehensive Flux pipeline test that follows the exact same flow as pipeline_flux.py:
     - 256x256 resolution - 2 transformer layers
@@ -379,12 +407,11 @@ def test_flux_pipeline(flux_pipeline):
     - Export/compilation checks
     - Returns QEffPipelineOutput with performance metrics
     """
-    pipeline, pytorch_pipeline = flux_pipeline
-    config = INITIAL_TEST_CONFIG
+    pipeline, pytorch_pipeline = flux_pipeline_data
 
     # Print test header
     DiffusersTestUtils.print_test_header(
-        f"FLUX PIPELINE TEST - {config['model_setup']['height']}x{config['model_setup']['width']} Resolution, {config['model_setup']['num_transformer_layers']} Layers",
+        test_label,
         config,
     )
 
@@ -399,6 +426,7 @@ def test_flux_pipeline(flux_pipeline):
     start_time = time.time()
 
     try:
+        pipeline_call_overrides = pipeline_call_overrides or {}
         # Run the pipeline with integrated MAD validation (follows exact pipeline flow)
         result = flux_pipeline_call_with_mad_validation(
             pipeline,
@@ -415,6 +443,7 @@ def test_flux_pipeline(flux_pipeline):
             use_onnx_subfunctions=config["pipeline_params"]["use_onnx_subfunctions"],
             parallel_compile=True,
             return_dict=True,
+            **pipeline_call_overrides,
         )
 
         execution_time = time.time() - start_time
@@ -467,6 +496,37 @@ def test_flux_pipeline(flux_pipeline):
     except Exception as e:
         print(f"\nTEST FAILED: {e}")
         raise
+
+
+@pytest.mark.flux
+@pytest.mark.diffusion_models
+@pytest.mark.on_qaic
+def test_flux_pipeline(flux_pipeline):
+    _run_flux_pipeline_test_case(
+        flux_pipeline,
+        INITIAL_TEST_CONFIG,
+        (
+            f"FLUX PIPELINE TEST - {INITIAL_TEST_CONFIG['model_setup']['height']}x"
+            f"{INITIAL_TEST_CONFIG['model_setup']['width']} Resolution, "
+            f"{INITIAL_TEST_CONFIG['model_setup']['num_transformer_layers']} Layers"
+        ),
+    )
+
+
+@pytest.mark.flux
+@pytest.mark.diffusion_models
+@pytest.mark.on_qaic
+def test_flux_pipeline_first_block_cache(flux_pipeline_first_block_cache):
+    _run_flux_pipeline_test_case(
+        flux_pipeline_first_block_cache,
+        INITIAL_TEST_CONFIG,
+        (
+            f"FLUX PIPELINE FIRST-BLOCK-CACHE TEST - {INITIAL_TEST_CONFIG['model_setup']['height']}x"
+            f"{INITIAL_TEST_CONFIG['model_setup']['width']} Resolution, "
+            f"{INITIAL_TEST_CONFIG['model_setup']['num_transformer_layers']} Layers"
+        ),
+        pipeline_call_overrides={"cache_threshold": 0.0},
+    )
 
 
 if __name__ == "__main__":

--- a/tests/diffusers/test_wan.py
+++ b/tests/diffusers/test_wan.py
@@ -64,6 +64,8 @@ def wan_pipeline_call_with_mad_validation(
     custom_config_path: Optional[str] = None,
     use_onnx_subfunctions: bool = False,
     parallel_compile: bool = True,
+    cache_threshold_high: Optional[float] = None,
+    cache_threshold_low: Optional[float] = None,
     mad_tolerances: Dict[str, float] = None,
 ):
     """
@@ -214,6 +216,27 @@ def wan_pipeline_call_with_mad_validation(
             )
         pipeline.transformer_high.qpc_session.set_buffers(output_buffer)
         pipeline.transformer_low.qpc_session.set_buffers(output_buffer)
+        if getattr(pipeline, "enable_first_block_cache", False):
+            pipeline.transformer_high.qpc_session.skip_buffers(
+                [
+                    tensor_name
+                    for tensor_name in (
+                        pipeline.transformer_high.qpc_session.input_names
+                        + pipeline.transformer_high.qpc_session.output_names
+                    )
+                    if tensor_name.startswith("prev_") or tensor_name.endswith("_RetainedState")
+                ]
+            )
+            pipeline.transformer_low.qpc_session.skip_buffers(
+                [
+                    tensor_name
+                    for tensor_name in (
+                        pipeline.transformer_low.qpc_session.input_names
+                        + pipeline.transformer_low.qpc_session.output_names
+                    )
+                    if tensor_name.startswith("prev_") or tensor_name.endswith("_RetainedState")
+                ]
+            )
     transformer_perf = []
 
     # Step 8: Denoising loop with transformer MAD validation
@@ -223,6 +246,7 @@ def wan_pipeline_call_with_mad_validation(
         boundary_timestep = None
 
     num_warmup_steps = len(timesteps) - num_inference_steps * pipeline.scheduler.order
+    low_stage_counter = 0
 
     with pipeline.model.progress_bar(total=num_inference_steps) as progress_bar:
         for i, t in enumerate(timesteps):
@@ -254,6 +278,7 @@ def wan_pipeline_call_with_mad_validation(
                     current_model = pipeline.transformer_low.model
                     current_qpc_session = pipeline.transformer_low.qpc_session
                     model_type = None
+                    low_stage_counter += 1
 
             latent_model_input = latents.to(transformer_dtype)
             if pipeline.model.config.expand_timesteps:
@@ -292,6 +317,13 @@ def wan_pipeline_call_with_mad_validation(
             }
             if model_type is not None:
                 inputs_aic["tsp"] = model_type.detach().numpy()
+            if getattr(pipeline, "enable_first_block_cache", False):
+                if boundary_timestep is None or t >= boundary_timestep:
+                    stage_cache_threshold = 0.0 if cache_threshold_high is None else cache_threshold_high
+                else:
+                    low_threshold = 0.0 if cache_threshold_low is None else cache_threshold_low
+                    stage_cache_threshold = 0.0 if low_stage_counter < 3 else low_threshold
+                inputs_aic["cache_threshold"] = np.array(stage_cache_threshold, dtype=np.float32)
 
             # PyTorch reference inference (standard WAN transformer has different signature)
             noise_pred_torch = pytorch_current_model(
@@ -394,7 +426,7 @@ def wan_pipeline_call_with_mad_validation(
     )
 
 
-def _build_wan_pipeline(use_unified: bool = True):
+def _build_wan_pipeline(use_unified: bool = True, enable_first_block_cache: bool = False):
     """Build the WAN pipeline with random weights/ dummy config."""
     torch.manual_seed(TEST_SEED)
     np.random.seed(TEST_SEED)
@@ -447,7 +479,11 @@ def _build_wan_pipeline(use_unified: bool = True):
     text_encoder.eval()
 
     pytorch_pipeline_copy = copy.deepcopy(pytorch_pipeline)
-    pipeline = QEffWanPipeline(pytorch_pipeline_copy, use_unified=use_unified)
+    pipeline = QEffWanPipeline(
+        pytorch_pipeline_copy,
+        use_unified=use_unified,
+        enable_first_block_cache=enable_first_block_cache,
+    )
 
     return pipeline, pytorch_pipeline
 
@@ -460,6 +496,11 @@ def wan_pipeline():
 @pytest.fixture(scope="session")
 def wan_pipeline_non_unified():
     return _build_wan_pipeline(use_unified=False)
+
+
+@pytest.fixture(scope="session")
+def wan_pipeline_non_unified_first_block_cache():
+    return _build_wan_pipeline(use_unified=False, enable_first_block_cache=True)
 
 
 @pytest.mark.diffusion_models
@@ -486,11 +527,28 @@ def test_wan_pipeline_non_unified(wan_pipeline_non_unified):
     )
 
 
+@pytest.mark.diffusion_models
+@pytest.mark.on_qaic
+@pytest.mark.wan
+def test_wan_pipeline_non_unified_first_block_cache(wan_pipeline_non_unified_first_block_cache):
+    _run_wan_pipeline_test_case(
+        wan_pipeline_non_unified_first_block_cache,
+        NON_UNIFIED_TEST_CONFIG,
+        NON_UNIFIED_CONFIG_PATH,
+        "WAN PIPELINE NON-UNIFIED FIRST-BLOCK-CACHE TEST",
+        pipeline_call_overrides={
+            "cache_threshold_high": 0.0,
+            "cache_threshold_low": 0.0,
+        },
+    )
+
+
 def _run_wan_pipeline_test_case(
     wan_pipeline_data,
     config,
     compile_config_path: str,
     test_label: str,
+    pipeline_call_overrides: Optional[Dict[str, Any]] = None,
 ):
     """
     Comprehensive WAN pipeline test case runner that focuses on transformer validation:
@@ -521,6 +579,7 @@ def _run_wan_pipeline_test_case(
     start_time = time.time()
 
     try:
+        pipeline_call_overrides = pipeline_call_overrides or {}
         # Run the pipeline with integrated MAD validation
         result = wan_pipeline_call_with_mad_validation(
             pipeline,
@@ -539,6 +598,7 @@ def _run_wan_pipeline_test_case(
             use_onnx_subfunctions=config["pipeline_params"]["use_onnx_subfunctions"],
             parallel_compile=True,
             return_dict=True,
+            **pipeline_call_overrides,
         )
 
         execution_time = time.time() - start_time

--- a/tests/diffusers/test_wan.py
+++ b/tests/diffusers/test_wan.py
@@ -33,7 +33,9 @@ from tests.diffusers.diffusers_utils import DiffusersTestUtils, MADValidator
 
 # Test Configuration for 48 x 64 resolution with 1 layer
 CONFIG_PATH = "tests/diffusers/wan_test_config.json"
+NON_UNIFIED_CONFIG_PATH = "tests/diffusers/wan_test_non_unified_config.json"
 INITIAL_TEST_CONFIG = load_json(CONFIG_PATH)
+NON_UNIFIED_TEST_CONFIG = load_json(NON_UNIFIED_CONFIG_PATH)
 TEST_SEED = 42
 
 
@@ -161,7 +163,10 @@ def wan_pipeline_call_with_mad_validation(
         device=device,
     )
 
-    transformer_dtype = pipeline.transformer.model.transformer_high.dtype
+    if pipeline.use_unified:
+        transformer_dtype = pipeline.transformer.model.transformer_high.dtype
+    else:
+        transformer_dtype = pipeline.transformer_high.model.dtype
     prompt_embeds = prompt_embeds.to(transformer_dtype)
     pytorch_prompt_embeds = pytorch_prompt_embeds.to(transformer_dtype)
     if negative_prompt_embeds is not None:
@@ -171,9 +176,10 @@ def wan_pipeline_call_with_mad_validation(
     # Step 5: Prepare timesteps
     pipeline.scheduler.set_timesteps(num_inference_steps, device=device)
     timesteps = pipeline.scheduler.timesteps
+    reference_scheduler = copy.deepcopy(pipeline.scheduler)
 
     # Step 6: Prepare latent variables
-    num_channels_latents = pipeline.transformer.model.config.in_channels
+    num_channels_latents = pipeline.model.transformer.config.in_channels
     latents = pipeline.model.prepare_latents(
         batch_size * num_videos_per_prompt,
         num_channels_latents,
@@ -187,20 +193,27 @@ def wan_pipeline_call_with_mad_validation(
     )
 
     mask = torch.ones(latents.shape, dtype=torch.float32, device=device)
+    latents_torch = latents.clone()
 
-    # Step 7: Setup transformer inference session
-    if pipeline.transformer.qpc_session is None:
-        pipeline.transformer.qpc_session = QAICInferenceSession(
-            str(pipeline.transformer.qpc_path), device_ids=pipeline.transformer.device_ids
-        )
-
-    output_buffer = {
-        "output": np.zeros(
-            (batch_size, pipeline.cl, constants.WAN_DIT_OUT_CHANNELS),
-            dtype=np.int32,
-        ),
-    }
-    pipeline.transformer.qpc_session.set_buffers(output_buffer)
+    # Step 7: Setup transformer inference session(s)
+    output_buffer = {"output": np.zeros((batch_size, pipeline.cl, constants.WAN_DIT_OUT_CHANNELS), dtype=np.int32)}
+    if pipeline.use_unified:
+        if pipeline.transformer.qpc_session is None:
+            pipeline.transformer.qpc_session = QAICInferenceSession(
+                str(pipeline.transformer.qpc_path), device_ids=pipeline.transformer.device_ids
+            )
+        pipeline.transformer.qpc_session.set_buffers(output_buffer)
+    else:
+        if pipeline.transformer_high.qpc_session is None:
+            pipeline.transformer_high.qpc_session = QAICInferenceSession(
+                str(pipeline.transformer_high.qpc_path), device_ids=pipeline.transformer_high.device_ids
+            )
+        if pipeline.transformer_low.qpc_session is None:
+            pipeline.transformer_low.qpc_session = QAICInferenceSession(
+                str(pipeline.transformer_low.qpc_path), device_ids=pipeline.transformer_low.device_ids
+            )
+        pipeline.transformer_high.qpc_session.set_buffers(output_buffer)
+        pipeline.transformer_low.qpc_session.set_buffers(output_buffer)
     transformer_perf = []
 
     # Step 8: Denoising loop with transformer MAD validation
@@ -221,16 +234,26 @@ def wan_pipeline_call_with_mad_validation(
             # Determine which transformer to use (high or low noise)
             if boundary_timestep is None or t >= boundary_timestep:
                 # High-noise stage
-                current_model = pipeline.transformer.model.transformer_high
                 pytorch_current_model = pytorch_pipeline.transformer
-                model_type = torch.ones(1, dtype=torch.int64)
-                model_name = "transformer_high"
+                if pipeline.use_unified:
+                    current_model = pipeline.transformer.model.transformer_high
+                    current_qpc_session = pipeline.transformer.qpc_session
+                    model_type = torch.ones(1, dtype=torch.int64)
+                else:
+                    current_model = pipeline.transformer_high.model
+                    current_qpc_session = pipeline.transformer_high.qpc_session
+                    model_type = None
             else:
                 # Low-noise stage
-                current_model = pipeline.transformer.model.transformer_low
                 pytorch_current_model = pytorch_pipeline.transformer_2
-                model_type = torch.ones(2, dtype=torch.int64)
-                model_name = "transformer_low"
+                if pipeline.use_unified:
+                    current_model = pipeline.transformer.model.transformer_low
+                    current_qpc_session = pipeline.transformer.qpc_session
+                    model_type = torch.ones(2, dtype=torch.int64)
+                else:
+                    current_model = pipeline.transformer_low.model
+                    current_qpc_session = pipeline.transformer_low.qpc_session
+                    model_type = None
 
             latent_model_input = latents.to(transformer_dtype)
             if pipeline.model.config.expand_timesteps:
@@ -266,14 +289,15 @@ def wan_pipeline_call_with_mad_validation(
                 "rotary_emb": rotary_emb.detach().numpy(),
                 "temb": temb.detach().numpy(),
                 "timestep_proj": timestep_proj.detach().numpy(),
-                "tsp": model_type.detach().numpy(),
             }
+            if model_type is not None:
+                inputs_aic["tsp"] = model_type.detach().numpy()
 
             # PyTorch reference inference (standard WAN transformer has different signature)
             noise_pred_torch = pytorch_current_model(
-                hidden_states=latent_model_input,
+                hidden_states=latents_torch.to(transformer_dtype),
                 timestep=timestep,
-                encoder_hidden_states=prompt_embeds,
+                encoder_hidden_states=pytorch_prompt_embeds,
                 attention_kwargs=attention_kwargs,
                 return_dict=False,
             )[0]
@@ -281,7 +305,7 @@ def wan_pipeline_call_with_mad_validation(
             # QAIC inference
             with current_model.cache_context("cond"):
                 start_transformer_step_time = time.time()
-                outputs = pipeline.transformer.qpc_session.run(inputs_aic)
+                outputs = current_qpc_session.run(inputs_aic)
                 end_transformer_step_time = time.time()
                 transformer_perf.append(end_transformer_step_time - start_transformer_step_time)
 
@@ -292,23 +316,27 @@ def wan_pipeline_call_with_mad_validation(
                 hidden_states = hidden_states.permute(0, 7, 1, 4, 2, 5, 3, 6)
                 noise_pred = hidden_states.flatten(6, 7).flatten(4, 5).flatten(2, 3)
 
-            # Transformer MAD validation
-            print(f" Performing MAD validation for {model_name} at step {i}...")
-            mad_validator.validate_module_mad(
-                noise_pred_torch.detach().cpu().numpy(),
-                noise_pred.detach().cpu().numpy(),
-                model_name,
-                f"step {i} (t={t.item():.1f})",
-            )
-
             # Update latents using scheduler
             latents = pipeline.scheduler.step(noise_pred, t, latents, return_dict=False)[0]
+            latents_torch = reference_scheduler.step(noise_pred_torch, t, latents_torch, return_dict=False)[0]
 
             # Update progress bar
             if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % pipeline.scheduler.order == 0):
                 progress_bar.update()
 
-    pipeline.transformer.qpc_session.deactivate()  # deactivate transformer qpc session
+    print(" Performing MAD validation for transformer final latent output...")
+    mad_validator.validate_module_mad(
+        latents_torch.detach().cpu().numpy(),
+        latents.detach().cpu().numpy(),
+        "transformer",
+        f"final latents after {num_inference_steps} steps",
+    )
+
+    if pipeline.use_unified:
+        pipeline.transformer.qpc_session.deactivate()  # deactivate transformer qpc session
+    else:
+        pipeline.transformer_high.qpc_session.deactivate()
+        pipeline.transformer_low.qpc_session.deactivate()
     # Step 9: Decode latents to video QAIC VAE decoder
     latents = latents.to(pipeline.vae_decoder.model.dtype)
     latents_mean = (
@@ -366,8 +394,7 @@ def wan_pipeline_call_with_mad_validation(
     )
 
 
-@pytest.fixture(scope="session")
-def wan_pipeline():
+def _build_wan_pipeline(use_unified: bool = True):
     """Build the WAN pipeline with random weights/ dummy config."""
     torch.manual_seed(TEST_SEED)
     np.random.seed(TEST_SEED)
@@ -420,29 +447,64 @@ def wan_pipeline():
     text_encoder.eval()
 
     pytorch_pipeline_copy = copy.deepcopy(pytorch_pipeline)
-    pipeline = QEffWanPipeline(pytorch_pipeline_copy)
+    pipeline = QEffWanPipeline(pytorch_pipeline_copy, use_unified=use_unified)
 
     return pipeline, pytorch_pipeline
+
+
+@pytest.fixture(scope="session")
+def wan_pipeline():
+    return _build_wan_pipeline(use_unified=True)
+
+
+@pytest.fixture(scope="session")
+def wan_pipeline_non_unified():
+    return _build_wan_pipeline(use_unified=False)
 
 
 @pytest.mark.diffusion_models
 @pytest.mark.on_qaic
 @pytest.mark.wan
 def test_wan_pipeline(wan_pipeline):
+    _run_wan_pipeline_test_case(
+        wan_pipeline,
+        INITIAL_TEST_CONFIG,
+        CONFIG_PATH,
+        "WAN PIPELINE TEST",
+    )
+
+
+@pytest.mark.diffusion_models
+@pytest.mark.on_qaic
+@pytest.mark.wan
+def test_wan_pipeline_non_unified(wan_pipeline_non_unified):
+    _run_wan_pipeline_test_case(
+        wan_pipeline_non_unified,
+        NON_UNIFIED_TEST_CONFIG,
+        NON_UNIFIED_CONFIG_PATH,
+        "WAN PIPELINE NON-UNIFIED TEST",
+    )
+
+
+def _run_wan_pipeline_test_case(
+    wan_pipeline_data,
+    config,
+    compile_config_path: str,
+    test_label: str,
+):
     """
-    Comprehensive WAN pipeline test that focuses on transformer validation:
+    Comprehensive WAN pipeline test case runner that focuses on transformer validation:
     - 45p - 48x64 resolution - 2 transformer layers total (1 high + 1 low)
     - MAD validation for transformer modules only
     - Functional video generation test
     - Export/compilation checks for transformer and VAE decoder
     - Returns QEffPipelineOutput with performance metrics
     """
-    pipeline, pytorch_pipeline = wan_pipeline
-    config = INITIAL_TEST_CONFIG
+    pipeline, pytorch_pipeline = wan_pipeline_data
 
     # Print test header
     DiffusersTestUtils.print_test_header(
-        f"WAN PIPELINE TEST - {config['model_setup']['height']}x{config['model_setup']['width']} Resolution, {config['model_setup']['num_frames']} Frames, 2 Layers Total",
+        f"{test_label} - {config['model_setup']['height']}x{config['model_setup']['width']} Resolution, {config['model_setup']['num_frames']} Frames, 2 Layers Total",
         config,
     )
 
@@ -471,7 +533,7 @@ def test_wan_pipeline(wan_pipeline):
             guidance_scale_2=guidance_scale_2,
             num_inference_steps=num_inference_steps,
             max_sequence_length=max_sequence_length,
-            custom_config_path=CONFIG_PATH,
+            custom_config_path=compile_config_path,
             generator=generator,
             mad_tolerances=config["mad_validation"]["tolerances"],
             use_onnx_subfunctions=config["pipeline_params"]["use_onnx_subfunctions"],
@@ -523,16 +585,20 @@ def test_wan_pipeline(wan_pipeline):
             print(result)
 
         if config["validation_checks"]["onnx_export"]:
-            # Check if transformer ONNX file exists
             print("\n ONNX Export Validation:")
-            if hasattr(pipeline.transformer, "onnx_path") and pipeline.transformer.onnx_path:
+            if pipeline.use_unified:
                 DiffusersTestUtils.check_file_exists(str(pipeline.transformer.onnx_path), "transformer ONNX")
+            else:
+                DiffusersTestUtils.check_file_exists(str(pipeline.transformer_high.onnx_path), "transformer_high ONNX")
+                DiffusersTestUtils.check_file_exists(str(pipeline.transformer_low.onnx_path), "transformer_low ONNX")
 
         if config["validation_checks"]["compilation"]:
-            # Check if transformer QPC file exists
             print("\n Compilation Validation:")
-            if hasattr(pipeline.transformer, "qpc_path") and pipeline.transformer.qpc_path:
+            if pipeline.use_unified:
                 DiffusersTestUtils.check_file_exists(str(pipeline.transformer.qpc_path), "transformer QPC")
+            else:
+                DiffusersTestUtils.check_file_exists(str(pipeline.transformer_high.qpc_path), "transformer_high QPC")
+                DiffusersTestUtils.check_file_exists(str(pipeline.transformer_low.qpc_path), "transformer_low QPC")
 
         # Print test summary
         print(f"\nTotal execution time: {execution_time:.4f}s")

--- a/tests/diffusers/wan_test_non_unified_config.json
+++ b/tests/diffusers/wan_test_non_unified_config.json
@@ -30,29 +30,43 @@
                             "compilation": true
                         },
     "modules": {
-        "transformer": {
-          "specializations": [
-                              {
-                                  "batch_size": "1",
-                                  "num_channels": "16",
-                                  "steps": "1",
-                                  "sequence_length": "512",
-                                  "model_type": 1
-                              },
-                              {
-                                  "batch_size": "1",
-                                  "num_channels": "16",
-                                  "steps": "1",
-                                  "sequence_length": "512",
-                                  "model_type": 2
-                              }
-                          ],
+        "transformer_high": {
+          "specializations": {
+                              "batch_size": "1",
+                              "num_channels": "16",
+                              "steps": "1",
+                              "sequence_length": "512"
+                          },
           "compilation":  {
                                 "onnx_path": null,
                                 "compile_dir": null,
                                 "mdp_ts_num_devices": 1,
                                 "mxfp6_matmul": true,
                                 "convert_to_fp16": true,
+                                "compile_only":true,
+                                "aic_num_cores": 16,
+                                "mos": 1,
+                                "mdts_mos": 1
+                            },
+          "execute":     {
+                                "device_ids": null,
+                                "qpc_path" : null
+                          }
+        },
+        "transformer_low": {
+          "specializations": {
+                              "batch_size": "1",
+                              "num_channels": "16",
+                              "steps": "1",
+                              "sequence_length": "512"
+                          },
+          "compilation":  {
+                                "onnx_path": null,
+                                "compile_dir": null,
+                                "mdp_ts_num_devices": 1,
+                                "mxfp6_matmul": true,
+                                "convert_to_fp16": true,
+                                "compile_only":true,
                                 "aic_num_cores": 16,
                                 "mos": 1,
                                 "mdts_mos": 1
@@ -73,6 +87,7 @@
                 "mdp_ts_num_devices": 1,
                 "mxfp6_matmul": false,
                 "convert_to_fp16": true,
+                "compile_only": true,
                 "aic_num_cores": 16,
                 "mos": 1,
                 "mdts_mos": 1

--- a/tests/diffusers/wan_test_non_unified_config.json
+++ b/tests/diffusers/wan_test_non_unified_config.json
@@ -30,23 +30,36 @@
                             "compilation": true
                         },
     "modules": {
-        "transformer": {
-          "specializations": [
-                              {
-                                  "batch_size": "1",
-                                  "num_channels": "16",
-                                  "steps": "1",
-                                  "sequence_length": "512",
-                                  "model_type": 1
-                              },
-                              {
-                                  "batch_size": "1",
-                                  "num_channels": "16",
-                                  "steps": "1",
-                                  "sequence_length": "512",
-                                  "model_type": 2
-                              }
-                          ],
+        "transformer_high": {
+          "specializations": {
+                              "batch_size": "1",
+                              "num_channels": "16",
+                              "steps": "1",
+                              "sequence_length": "512"
+                          },
+          "compilation":  {
+                                "onnx_path": null,
+                                "compile_dir": null,
+                                "mdp_ts_num_devices": 1,
+                                "mxfp6_matmul": true,
+                                "convert_to_fp16": true,
+                                "compile_only":true,
+                                "aic_num_cores": 16,
+                                "mos": 1,
+                                "mdts_mos": 1
+                            },
+          "execute":     {
+                                "device_ids": null,
+                                "qpc_path" : null
+                          }
+        },
+        "transformer_low": {
+          "specializations": {
+                              "batch_size": "1",
+                              "num_channels": "16",
+                              "steps": "1",
+                              "sequence_length": "512"
+                          },
           "compilation":  {
                                 "onnx_path": null,
                                 "compile_dir": null,

--- a/tests/transformers/models/audio_models/test_audio_embedding_models.py
+++ b/tests/transformers/models/audio_models/test_audio_embedding_models.py
@@ -139,7 +139,6 @@ def check_ctc_pytorch_vs_kv_vs_ort_vs_ai100(
     qnn_config: Optional[str] = None,
     compare_results: Optional[bool] = False,
 ):
-
     replace_transformers_quantizers()
     model_config = {"model_name": model_name}
     model_config["n_layer"] = n_layer
@@ -200,7 +199,6 @@ def check_ctc_pytorch_vs_kv_vs_ort_vs_ai100(
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models)
 def test_full_ctc_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     torch.manual_seed(42)
     check_ctc_pytorch_vs_kv_vs_ort_vs_ai100(
         model_name=model_name, compare_results=True, manual_cleanup=manual_cleanup, num_devices=4
@@ -211,7 +209,6 @@ def test_full_ctc_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models)
 def test_few_ctc_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     torch.manual_seed(42)
     check_ctc_pytorch_vs_kv_vs_ort_vs_ai100(model_name=model_name, n_layer=4, manual_cleanup=manual_cleanup)
 

--- a/tests/transformers/models/audio_models/test_speech_seq2seq_models.py
+++ b/tests/transformers/models/audio_models/test_speech_seq2seq_models.py
@@ -374,7 +374,6 @@ def check_seq2seq_pytorch_vs_kv_vs_ort_vs_ai100(
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models)
 def test_full_seq2seq_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     torch.manual_seed(42)
     check_seq2seq_pytorch_vs_kv_vs_ort_vs_ai100(
         model_name=model_name, compare_results=True, manual_cleanup=manual_cleanup, num_devices=4
@@ -385,7 +384,6 @@ def test_full_seq2seq_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models)
 def test_few_seq2seq_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     torch.manual_seed(42)
     check_seq2seq_pytorch_vs_kv_vs_ort_vs_ai100(model_name=model_name, n_layer=4, manual_cleanup=manual_cleanup)
 

--- a/tests/transformers/models/causal_lm_models/check_causal_models.py
+++ b/tests/transformers/models/causal_lm_models/check_causal_models.py
@@ -57,7 +57,6 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
     retain_full_kv: Optional[bool] = None,
     compare_results: bool = False,
 ):
-
     torch.manual_seed(42)
     replace_transformers_quantizers()
     model_hf = load_hf_causal_lm_model(model_name, num_hidden_layers=n_layer, config=config)

--- a/tests/transformers/models/causal_lm_models/test_causal_lm_blocking_hqkv.py
+++ b/tests/transformers/models/causal_lm_models/test_causal_lm_blocking_hqkv.py
@@ -31,7 +31,6 @@ model_config_dict = {model["model_name"]: model for model in blockedKV_models}
 @pytest.mark.on_qaic
 @pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
 def test_full_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     HEAD_BLOCK_SIZE = 8
     NUM_KV_BLOCKS = 2
     NUM_Q_BLOCKS = 2
@@ -77,7 +76,6 @@ def test_full_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manu
 @pytest.mark.on_qaic
 @pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
 def test_few_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     HEAD_BLOCK_SIZE = 8
     NUM_KV_BLOCKS = 2
     NUM_Q_BLOCKS = 2
@@ -123,7 +121,6 @@ def test_few_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manua
 @pytest.mark.on_qaic
 @pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
 def test_dummy_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     HEAD_BLOCK_SIZE = 8
     NUM_KV_BLOCKS = 2
     NUM_Q_BLOCKS = 2
@@ -178,7 +175,6 @@ def test_dummy_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, man
 @pytest.mark.on_qaic
 @pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
 def test_full_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cleanup):
-
     HEAD_BLOCK_SIZE = 8
     NUM_KV_BLOCKS = 2
     NUM_Q_BLOCKS = 2
@@ -244,7 +240,6 @@ def test_full_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, m
 @pytest.mark.on_qaic
 @pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
 def test_few_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cleanup):
-
     HEAD_BLOCK_SIZE = 8
     NUM_KV_BLOCKS = 2
     NUM_Q_BLOCKS = 2
@@ -310,7 +305,6 @@ def test_few_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, ma
 @pytest.mark.on_qaic
 @pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
 def test_dummy_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cleanup):
-
     HEAD_BLOCK_SIZE = 8
     NUM_KV_BLOCKS = 2
     NUM_Q_BLOCKS = 2

--- a/tests/transformers/models/causal_lm_models/test_causal_lm_models.py
+++ b/tests/transformers/models/causal_lm_models/test_causal_lm_models.py
@@ -33,7 +33,6 @@ model_config_dict = {model["model_name"]: model for model in causal_lm_models}
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_causal)
 def test_full_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     if model_name in ModelConfig.FULL_MODEL_TESTS_TO_SKIP:
         pytest.skip(f"Skipping full model test for {model_name} due to resource constraints.")
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
@@ -55,7 +54,6 @@ def test_few_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup)
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_causal)
 def test_dummy_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     custom_config = model_config_dict[model_name]
     hf_config = AutoConfig.from_pretrained(
         model_name,
@@ -89,7 +87,6 @@ def test_full_causal_lm_pytorch_vs_ort_vs_ai100_cb(model_name, manual_cleanup):
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_causal)
 def test_few_causal_lm_pytorch_vs_ort_vs_ai100_cb(model_name, manual_cleanup):
-
     n_layer = get_custom_n_layers(model_name)
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         model_name=model_name,
@@ -104,7 +101,6 @@ def test_few_causal_lm_pytorch_vs_ort_vs_ai100_cb(model_name, manual_cleanup):
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_causal)
 def test_dummy_causal_lm_pytorch_vs_ort_vs_ai100_cb(model_name, manual_cleanup):
-
     custom_config = model_config_dict[model_name]
     hf_config = AutoConfig.from_pretrained(
         model_name,

--- a/tests/transformers/models/causal_lm_models/test_causal_lm_pl1.py
+++ b/tests/transformers/models/causal_lm_models/test_causal_lm_pl1.py
@@ -32,7 +32,6 @@ model_config_dict = {model["model_name"]: model for model in causal_pl1_models}
 @pytest.mark.parametrize("model_name", test_models_pl1)
 @pytest.mark.parametrize("retain_full_kv", [True, False])
 def test_full_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1(model_name, retain_full_kv, manual_cleanup):
-
     if model_name == "gpt2" and retain_full_kv:
         pytest.skip("Skipping test for gpt2 with retain_full_kv=True as it is not supported.")
 
@@ -52,7 +51,6 @@ def test_full_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1(model_name, retain_ful
 @pytest.mark.parametrize("model_name", test_models_pl1)
 @pytest.mark.parametrize("retain_full_kv", [True, False])
 def test_few_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1(model_name, retain_full_kv, manual_cleanup):
-
     if model_name == "gpt2" and retain_full_kv:
         pytest.skip("Skipping test for gpt2 with retain_full_kv=True as it is not supported.")
     torch.manual_seed(42)
@@ -71,7 +69,6 @@ def test_few_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1(model_name, retain_full
 @pytest.mark.parametrize("model_name", test_models_pl1)
 @pytest.mark.parametrize("retain_full_kv", [True, False])
 def test_dummy_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1(model_name, retain_full_kv, manual_cleanup):
-
     if model_name == "gpt2" and retain_full_kv:
         pytest.skip("Skipping test for gpt2 with retain_full_kv=True as it is not supported.")
 
@@ -97,7 +94,6 @@ def test_dummy_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1(model_name, retain_fu
 @pytest.mark.parametrize("model_name", test_models_pl1)
 @pytest.mark.parametrize("retain_full_kv", [True, False])
 def test_full_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1_CB(model_name, retain_full_kv, manual_cleanup):
-
     if model_name == "gpt2" and retain_full_kv:
         pytest.skip("Skipping test for gpt2 with retain_full_kv=True as it is not supported.")
     torch.manual_seed(42)
@@ -117,7 +113,6 @@ def test_full_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1_CB(model_name, retain_
 @pytest.mark.parametrize("model_name", test_models_pl1)
 @pytest.mark.parametrize("retain_full_kv", [True, False])
 def test_few_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1_CB(model_name, retain_full_kv, manual_cleanup):
-
     if model_name == "gpt2" and retain_full_kv:
         pytest.skip("Skipping test for gpt2 with retain_full_kv=True as it is not supported.")
     torch.manual_seed(42)
@@ -137,7 +132,6 @@ def test_few_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1_CB(model_name, retain_f
 @pytest.mark.parametrize("model_name", test_models_pl1)
 @pytest.mark.parametrize("retain_full_kv", [True, False])
 def test_dummy_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100_pl1_CB(model_name, retain_full_kv, manual_cleanup):
-
     if model_name == "gpt2" and retain_full_kv:
         pytest.skip("Skipping test for gpt2 with retain_full_kv=True as it is not supported.")
 

--- a/tests/transformers/models/causal_lm_models/test_causal_tlm_models.py
+++ b/tests/transformers/models/causal_lm_models/test_causal_tlm_models.py
@@ -32,7 +32,6 @@ model_config_dict = {model["model_name"]: model for model in spd_models}
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_spd)
 def test_full_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         model_name=model_name,
         num_speculative_tokens=Constants.NUM_SPECULATIVE_TOKENS,
@@ -46,7 +45,6 @@ def test_full_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanu
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_spd)
 def test_few_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     n_layer = get_custom_n_layers(model_name)
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         model_name=model_name,
@@ -61,7 +59,6 @@ def test_few_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_spd)
 def test_dummy_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
-
     custom_config = model_config_dict[model_name]
     hf_config = AutoConfig.from_pretrained(
         model_name,
@@ -81,7 +78,6 @@ def test_dummy_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_clean
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_spd)
 def test_full_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cleanup):
-
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         model_name=model_name,
         num_speculative_tokens=Constants.NUM_SPECULATIVE_TOKENS,
@@ -96,7 +92,6 @@ def test_full_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cle
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_spd)
 def test_few_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cleanup):
-
     n_layer = get_custom_n_layers(model_name)
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         model_name=model_name,
@@ -112,7 +107,6 @@ def test_few_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_clea
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_spd)
 def test_dummy_causal_tlm_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cleanup):
-
     custom_config = model_config_dict[model_name]
     hf_config = AutoConfig.from_pretrained(
         model_name,

--- a/tests/transformers/models/causal_lm_models/test_fp16_causal_lm.py
+++ b/tests/transformers/models/causal_lm_models/test_fp16_causal_lm.py
@@ -127,7 +127,6 @@ def check_causal_lm_pytorch_vs_kv_vs_ai100(
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models)
 def test_full_fp16_causal_lm_pytorch_vs_kv_vs_ai100(model_name, manual_cleanup):
-
     torch.manual_seed(42)
     check_causal_lm_pytorch_vs_kv_vs_ai100(
         model_name=model_name, torch_dtype=torch.float16, manual_cleanup=manual_cleanup
@@ -139,7 +138,6 @@ def test_full_fp16_causal_lm_pytorch_vs_kv_vs_ai100(model_name, manual_cleanup):
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models)
 def test_few_fp16_causal_lm_pytorch_vs_kv_vs_ai100(model_name, manual_cleanup):
-
     torch.manual_seed(42)
     n_layer = get_custom_n_layers(model_name)
     check_causal_lm_pytorch_vs_kv_vs_ai100(
@@ -152,7 +150,6 @@ def test_few_fp16_causal_lm_pytorch_vs_kv_vs_ai100(model_name, manual_cleanup):
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models)
 def test_dummy_fp16_causal_lm_pytorch_vs_kv_vs_ai100(model_name, manual_cleanup):
-
     torch.manual_seed(42)
     custom_config = model_config_dict[model_name]
     hf_config = AutoConfig.from_pretrained(

--- a/tests/transformers/models/image_text_to_text/test_custom_dtype.py
+++ b/tests/transformers/models/image_text_to_text/test_custom_dtype.py
@@ -41,7 +41,6 @@ NEW_GENERATION_TOKENS = 10
 def test_full_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100_custom_dtype(
     model_name, kv_offload, torch_dtype, manual_cleanup
 ):
-
     if model_name in ModelConfig.SKIPPED_MODELS:
         pytest.skip("Test skipped for this model due to some issues.")
     if model_name in ModelConfig.DUAL_QPC_MODELS and not kv_offload:
@@ -65,7 +64,6 @@ def test_full_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100_custom_dtype(
 def test_few_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100_custom_dtype(
     model_name, kv_offload, torch_dtype, manual_cleanup
 ):
-
     if model_name in ModelConfig.SKIPPED_MODELS:
         pytest.skip("Test skipped for this model due to some issues.")
     if model_name in ModelConfig.DUAL_QPC_MODELS and not kv_offload:

--- a/tests/transformers/subfunction/test_causal_lm_blocking_subfunction.py
+++ b/tests/transformers/subfunction/test_causal_lm_blocking_subfunction.py
@@ -64,7 +64,6 @@ def check_blockedKV_onnx_function_count_with_subfunction(
 @pytest.mark.feature
 @pytest.mark.parametrize("model_name", test_models_blockedKV)
 def test_full_blockedKV_onnx_function_count_with_subfunction(model_name, manual_cleanup):
-
     # Keep model small for test runtime, and avoid CB path (not needed for function count).
     check_blockedKV_onnx_function_count_with_subfunction(model_name, manual_cleanup=manual_cleanup)
 
@@ -73,7 +72,6 @@ def test_full_blockedKV_onnx_function_count_with_subfunction(model_name, manual_
 @pytest.mark.feature
 @pytest.mark.parametrize("model_name", test_models_blockedKV)
 def test_few_blockedKV_onnx_function_count_with_subfunction(model_name, manual_cleanup):
-
     # Keep model small for test runtime, and avoid CB path (not needed for function count).
     n_layer = get_custom_n_layers(model_name)
 
@@ -84,7 +82,6 @@ def test_few_blockedKV_onnx_function_count_with_subfunction(model_name, manual_c
 @pytest.mark.feature
 @pytest.mark.parametrize("model_name", test_models_blockedKV)
 def test_dummy_blockedKV_onnx_function_count_with_subfunction(model_name, manual_cleanup):
-
     # Keep model small for test runtime, and avoid CB path (not needed for function count).
     hf_config = AutoConfig.from_pretrained(
         model_name,

--- a/tests/transformers/subfunction/test_subfunction_vlm.py
+++ b/tests/transformers/subfunction/test_subfunction_vlm.py
@@ -50,7 +50,6 @@ def check_image_text_to_text_subfunction_core(
     num_devices: int = 1,
     config: Optional[AutoConfig] = None,
 ):
-
     img_size = model_config_dict[model_name]["img_size"]
     img_url = model_config_dict[model_name]["img_url"]
     query = model_config_dict[model_name]["text_prompt"]
@@ -117,7 +116,6 @@ def check_image_text_to_text_subfunction_core(
 @pytest.mark.parametrize("model_name", test_mm_models)
 @pytest.mark.parametrize("kv_offload", [True])
 def test_full_image_text_to_text_subfunction(model_name, kv_offload, manual_cleanup):
-
     torch.manual_seed(42)
     check_image_text_to_text_subfunction_core(model_name, kv_offload=kv_offload, manual_cleanup=manual_cleanup)
 
@@ -127,7 +125,6 @@ def test_full_image_text_to_text_subfunction(model_name, kv_offload, manual_clea
 @pytest.mark.parametrize("model_name", test_mm_models)
 @pytest.mark.parametrize("kv_offload", [True])
 def test_few_image_text_to_text_subfunction(model_name, kv_offload, manual_cleanup):
-
     torch.manual_seed(42)
     check_image_text_to_text_subfunction_core(
         model_name,
@@ -142,7 +139,6 @@ def test_few_image_text_to_text_subfunction(model_name, kv_offload, manual_clean
 @pytest.mark.parametrize("model_name", test_mm_models)
 @pytest.mark.parametrize("kv_offload", [True])
 def test_dummy_image_text_to_text_subfunction(model_name, kv_offload, manual_cleanup):
-
     torch.manual_seed(42)
     hf_config = AutoConfig.from_pretrained(
         model_name, trust_remote_code=True, **model_config_dict[model_name].get("additional_params", {})

--- a/tests/unit_test/utils/test_flux_first_block_cache_blocking.py
+++ b/tests/unit_test/utils/test_flux_first_block_cache_blocking.py
@@ -1,0 +1,360 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+"""
+CPU-only unit tests for FLUX first-block-cache with attention blocking configs.
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+from QEfficient.diffusers.first_block_cache.flux import enable_flux_first_block_cache
+from QEfficient.diffusers.models.modeling_utils import compute_blocked_attention, get_attention_blocking_config
+
+
+class _FluxNormOut(nn.Module):
+    def forward(self, hidden_states: torch.Tensor, adaln_out: torch.Tensor) -> torch.Tensor:
+        del adaln_out
+        return hidden_states
+
+
+class _BlockingAwareFluxBlock(nn.Module):
+    def __init__(self, residual_scale: float):
+        super().__init__()
+        self.residual_scale = residual_scale
+        self.last_config = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        image_rotary_emb: torch.Tensor,
+        joint_attention_kwargs=None,
+    ):
+        del temb, image_rotary_emb, joint_attention_kwargs
+
+        mode, head_block_size, num_kv_blocks, num_q_blocks = get_attention_blocking_config()
+        self.last_config = (mode, head_block_size, num_kv_blocks, num_q_blocks)
+
+        bs, cl, hidden_size = hidden_states.shape
+        num_heads = 2
+        head_dim = hidden_size // num_heads
+        q = hidden_states.view(bs, cl, num_heads, head_dim).permute(0, 2, 1, 3).contiguous()
+        k = q
+        v = q
+        blocked = compute_blocked_attention(
+            q=q,
+            k=k,
+            v=v,
+            head_block_size=head_block_size or num_heads,
+            num_kv_blocks=num_kv_blocks or 1,
+            num_q_blocks=num_q_blocks or 1,
+            blocking_mode=mode,
+        )
+        blocked = blocked.permute(0, 2, 1, 3).reshape(bs, cl, hidden_size)
+        return encoder_hidden_states, hidden_states + self.residual_scale * blocked
+
+
+class _DummyFluxModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.inner_dim = 8
+        self.config = {"num_attention_heads": 2, "attention_head_dim": 4}
+        self.x_embedder = nn.Identity()
+        self.context_embedder = nn.Identity()
+        self.transformer_blocks = nn.ModuleList(
+            [
+                _BlockingAwareFluxBlock(0.30),
+                _BlockingAwareFluxBlock(0.20),
+                _BlockingAwareFluxBlock(0.10),
+            ]
+        )
+        self.single_transformer_blocks = nn.ModuleList(
+            [
+                _BlockingAwareFluxBlock(0.07),
+                _BlockingAwareFluxBlock(0.05),
+            ]
+        )
+        self.norm_out = _FluxNormOut()
+        self.proj_out = nn.Identity()
+
+    def pos_embed(self, ids: torch.Tensor) -> torch.Tensor:
+        return torch.zeros(ids.shape[0], 1)
+
+    def forward(self, **kwargs):
+        return Transformer2DModelOutput(sample=kwargs["hidden_states"])
+
+
+class _DummyTransformerWrapper:
+    def __init__(self):
+        self.model = _DummyFluxModel()
+        self.hash_params = {}
+        self.compile_kwargs = None
+
+    def get_onnx_params(self):
+        return {"hidden_states": torch.randn(1, 6, 8)}, {"hidden_states": {0: "batch_size", 1: "cl"}}, ["sample"]
+
+    def _compile(self, **kwargs):
+        self.compile_kwargs = kwargs
+        return "compiled"
+
+    def compile(self, *args, **kwargs):
+        return self._compile(*args, **kwargs)
+
+
+def _set_blocking_env(monkeypatch, mode: str, head_block_size: int = 2, num_kv_blocks: int = 2, num_q_blocks: int = 2):
+    monkeypatch.setenv("ATTENTION_BLOCKING_MODE", mode)
+    monkeypatch.setenv("head_block_size", str(head_block_size))
+    monkeypatch.setenv("num_kv_blocks", str(num_kv_blocks))
+    monkeypatch.setenv("num_q_blocks", str(num_q_blocks))
+
+
+def _make_forward_inputs():
+    torch.manual_seed(13)
+    hidden_states = torch.randn(1, 6, 8)
+    encoder_hidden_states = torch.randn(1, 4, 8)
+    timestep = torch.tensor([1], dtype=torch.long)
+    img_ids = torch.zeros(6, 1)
+    txt_ids = torch.zeros(4, 1)
+    adaln_emb = torch.zeros(3, 1)
+    adaln_single_emb = torch.zeros(2, 1)
+    adaln_out = torch.zeros(1)
+    return hidden_states, encoder_hidden_states, timestep, img_ids, txt_ids, adaln_emb, adaln_single_emb, adaln_out
+
+
+def _manual_cache_intermediates(
+    model,
+    hidden_states,
+    encoder_hidden_states,
+    img_ids,
+    txt_ids,
+    adaln_emb,
+    adaln_single_emb,
+):
+    hidden_states = model.x_embedder(hidden_states)
+    encoder_hidden_states = model.context_embedder(encoder_hidden_states)
+    ids = torch.cat((txt_ids, img_ids), dim=0)
+    image_rotary_emb = model.pos_embed(ids)
+
+    original_hidden_states = hidden_states
+    encoder_hidden_states, hidden_states = model.transformer_blocks[0](
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        temb=adaln_emb[0],
+        image_rotary_emb=image_rotary_emb,
+        joint_attention_kwargs=None,
+    )
+    current_first_hidden_states_residuals = hidden_states - original_hidden_states
+
+    downsample_factor = model._qeff_first_block_cache_downsample_factor
+    downsampled_first_hidden_states_residuals = current_first_hidden_states_residuals[
+        ..., ::downsample_factor
+    ].contiguous()
+
+    remaining_hidden_states = hidden_states
+    remaining_encoder_hidden_states = encoder_hidden_states
+    for index_block, block in enumerate(model.transformer_blocks[1:], start=1):
+        remaining_encoder_hidden_states, remaining_hidden_states = block(
+            hidden_states=remaining_hidden_states,
+            encoder_hidden_states=remaining_encoder_hidden_states,
+            temb=adaln_emb[index_block],
+            image_rotary_emb=image_rotary_emb,
+            joint_attention_kwargs=None,
+        )
+
+    for index_block, block in enumerate(model.single_transformer_blocks):
+        remaining_encoder_hidden_states, remaining_hidden_states = block(
+            hidden_states=remaining_hidden_states,
+            encoder_hidden_states=remaining_encoder_hidden_states,
+            temb=adaln_single_emb[index_block],
+            image_rotary_emb=image_rotary_emb,
+            joint_attention_kwargs=None,
+        )
+
+    current_hidden_states_residuals = remaining_hidden_states - hidden_states
+    return hidden_states, downsampled_first_hidden_states_residuals, current_hidden_states_residuals
+
+
+@pytest.mark.diffusers
+@pytest.mark.parametrize("mode", ["default", "kv", "q", "qkv"])
+def test_flux_first_block_cache_runs_with_all_blocking_modes(mode, monkeypatch):
+    _set_blocking_env(monkeypatch, mode)
+    wrapper = _DummyTransformerWrapper()
+    enable_flux_first_block_cache(wrapper, downsample_factor=2)
+
+    hidden_states, encoder_hidden_states, timestep, img_ids, txt_ids, adaln_emb, adaln_single_emb, adaln_out = (
+        _make_forward_inputs()
+    )
+    _, expected_first_residuals, _ = _manual_cache_intermediates(
+        wrapper.model,
+        hidden_states,
+        encoder_hidden_states,
+        img_ids,
+        txt_ids,
+        adaln_emb,
+        adaln_single_emb,
+    )
+    prev_hidden_states_residuals = torch.randn(1, 6, 8)
+
+    output, retained_first, retained_hidden = wrapper.model(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        timestep=timestep,
+        img_ids=img_ids,
+        txt_ids=txt_ids,
+        adaln_emb=adaln_emb,
+        adaln_single_emb=adaln_single_emb,
+        adaln_out=adaln_out,
+        prev_first_hidden_states_residuals=expected_first_residuals,
+        prev_hidden_states_residuals=prev_hidden_states_residuals,
+        cache_threshold=1.0,
+    )
+
+    assert isinstance(output, Transformer2DModelOutput)
+    assert output.sample.shape == (1, 6, 8)
+    assert torch.isfinite(output.sample).all()
+    assert torch.allclose(retained_first, expected_first_residuals, atol=1e-6)
+    assert torch.allclose(retained_hidden, prev_hidden_states_residuals, atol=1e-6)
+    all_blocks = list(wrapper.model.transformer_blocks) + list(wrapper.model.single_transformer_blocks)
+    assert all(block.last_config[0] == mode for block in all_blocks)
+
+
+@pytest.mark.diffusers
+def test_flux_first_block_cache_qkv_hit_uses_prev_hidden_residuals(monkeypatch):
+    _set_blocking_env(monkeypatch, "qkv")
+    wrapper = _DummyTransformerWrapper()
+    enable_flux_first_block_cache(wrapper, downsample_factor=2)
+
+    hidden_states, encoder_hidden_states, timestep, img_ids, txt_ids, adaln_emb, adaln_single_emb, adaln_out = (
+        _make_forward_inputs()
+    )
+    first_hidden_states, first_residuals, _ = _manual_cache_intermediates(
+        wrapper.model,
+        hidden_states,
+        encoder_hidden_states,
+        img_ids,
+        txt_ids,
+        adaln_emb,
+        adaln_single_emb,
+    )
+    prev_hidden_states_residuals = torch.randn(1, 6, 8)
+
+    output, _, retained_hidden = wrapper.model(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        timestep=timestep,
+        img_ids=img_ids,
+        txt_ids=txt_ids,
+        adaln_emb=adaln_emb,
+        adaln_single_emb=adaln_single_emb,
+        adaln_out=adaln_out,
+        prev_first_hidden_states_residuals=first_residuals,
+        prev_hidden_states_residuals=prev_hidden_states_residuals,
+        cache_threshold=1.0,
+    )
+
+    assert torch.allclose(retained_hidden, prev_hidden_states_residuals, atol=1e-6)
+    assert torch.allclose(output.sample, first_hidden_states + prev_hidden_states_residuals, atol=1e-6)
+
+
+@pytest.mark.diffusers
+def test_flux_first_block_cache_kv_miss_uses_current_hidden_residuals(monkeypatch):
+    _set_blocking_env(monkeypatch, "kv")
+    wrapper = _DummyTransformerWrapper()
+    enable_flux_first_block_cache(wrapper, downsample_factor=2)
+
+    hidden_states, encoder_hidden_states, timestep, img_ids, txt_ids, adaln_emb, adaln_single_emb, adaln_out = (
+        _make_forward_inputs()
+    )
+    first_hidden_states, first_residuals, current_hidden_residuals = _manual_cache_intermediates(
+        wrapper.model,
+        hidden_states,
+        encoder_hidden_states,
+        img_ids,
+        txt_ids,
+        adaln_emb,
+        adaln_single_emb,
+    )
+    prev_first_residuals = first_residuals + 1.0
+    prev_hidden_states_residuals = torch.randn(1, 6, 8)
+
+    output, _, retained_hidden = wrapper.model(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        timestep=timestep,
+        img_ids=img_ids,
+        txt_ids=txt_ids,
+        adaln_emb=adaln_emb,
+        adaln_single_emb=adaln_single_emb,
+        adaln_out=adaln_out,
+        prev_first_hidden_states_residuals=prev_first_residuals,
+        prev_hidden_states_residuals=prev_hidden_states_residuals,
+        cache_threshold=0.0,
+    )
+
+    assert torch.allclose(retained_hidden, current_hidden_residuals, atol=1e-6)
+    assert torch.allclose(output.sample, first_hidden_states + current_hidden_residuals, atol=1e-6)
+
+
+@pytest.mark.diffusers
+def test_flux_first_block_cache_reads_blocking_env_config(monkeypatch):
+    _set_blocking_env(monkeypatch, "qkv", head_block_size=4, num_kv_blocks=3, num_q_blocks=5)
+    wrapper = _DummyTransformerWrapper()
+    enable_flux_first_block_cache(wrapper, downsample_factor=2)
+
+    hidden_states, encoder_hidden_states, timestep, img_ids, txt_ids, adaln_emb, adaln_single_emb, adaln_out = (
+        _make_forward_inputs()
+    )
+    _, first_residuals, _ = _manual_cache_intermediates(
+        wrapper.model,
+        hidden_states,
+        encoder_hidden_states,
+        img_ids,
+        txt_ids,
+        adaln_emb,
+        adaln_single_emb,
+    )
+
+    wrapper.model(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        timestep=timestep,
+        img_ids=img_ids,
+        txt_ids=txt_ids,
+        adaln_emb=adaln_emb,
+        adaln_single_emb=adaln_single_emb,
+        adaln_out=adaln_out,
+        prev_first_hidden_states_residuals=first_residuals,
+        prev_hidden_states_residuals=torch.zeros(1, 6, 8),
+        cache_threshold=1.0,
+    )
+
+    all_blocks = list(wrapper.model.transformer_blocks) + list(wrapper.model.single_transformer_blocks)
+    assert all(block.last_config == ("qkv", 4, 3, 5) for block in all_blocks)
+
+
+@pytest.mark.diffusers
+def test_flux_first_block_cache_patch_is_idempotent_with_blocking(monkeypatch):
+    _set_blocking_env(monkeypatch, "q")
+    wrapper = _DummyTransformerWrapper()
+    enable_flux_first_block_cache(wrapper, downsample_factor=2)
+
+    patched_forward = wrapper.model.forward
+    patched_get_onnx_params = wrapper.get_onnx_params
+    patched_compile = wrapper.compile
+    downsample_factor = wrapper.model._qeff_first_block_cache_downsample_factor
+    hash_params = dict(wrapper.hash_params)
+
+    enable_flux_first_block_cache(wrapper, downsample_factor=4)
+
+    assert wrapper.model.forward is patched_forward
+    assert wrapper.get_onnx_params is patched_get_onnx_params
+    assert wrapper.compile is patched_compile
+    assert wrapper.model._qeff_first_block_cache_downsample_factor == downsample_factor
+    assert wrapper.hash_params == hash_params

--- a/tests/unit_test/utils/test_flux_first_block_cache_blocking.py
+++ b/tests/unit_test/utils/test_flux_first_block_cache_blocking.py
@@ -137,6 +137,10 @@ def _manual_cache_intermediates(
     adaln_emb,
     adaln_single_emb,
 ):
+    downsample_factor = model._qeff_first_block_cache_downsample_factor
+    if downsample_factor <= 0:
+        raise ValueError(f"downsample_factor must be > 0, got {downsample_factor}")
+
     try:
         hidden_states = model.x_embedder(hidden_states)
         encoder_hidden_states = model.context_embedder(encoder_hidden_states)
@@ -152,20 +156,20 @@ def _manual_cache_intermediates(
             joint_attention_kwargs=None,
         )
         current_first_hidden_states_residuals = hidden_states - original_hidden_states
+    except (IndexError, RuntimeError, TypeError) as exc:
+        raise AssertionError(f"Failed to compute FLUX cache intermediates: {exc}") from exc
 
-        downsample_factor = model._qeff_first_block_cache_downsample_factor
-        if downsample_factor <= 0:
-            raise ValueError(f"downsample_factor must be > 0, got {downsample_factor}")
-        if current_first_hidden_states_residuals.shape[-1] % downsample_factor != 0:
-            raise ValueError(
-                "downsample_factor must divide hidden dimension exactly, "
-                f"got hidden_size={current_first_hidden_states_residuals.shape[-1]}, "
-                f"downsample_factor={downsample_factor}"
-            )
-        downsampled_first_hidden_states_residuals = current_first_hidden_states_residuals[
-            ..., ::downsample_factor
-        ].contiguous()
+    if current_first_hidden_states_residuals.shape[-1] % downsample_factor != 0:
+        raise ValueError(
+            "downsample_factor must divide hidden dimension exactly, "
+            f"got hidden_size={current_first_hidden_states_residuals.shape[-1]}, "
+            f"downsample_factor={downsample_factor}"
+        )
+    downsampled_first_hidden_states_residuals = current_first_hidden_states_residuals[
+        ..., ::downsample_factor
+    ].contiguous()
 
+    try:
         remaining_hidden_states = hidden_states
         remaining_encoder_hidden_states = encoder_hidden_states
         for index_block, block in enumerate(model.transformer_blocks[1:], start=1):
@@ -188,7 +192,7 @@ def _manual_cache_intermediates(
 
         current_hidden_states_residuals = remaining_hidden_states - hidden_states
         return hidden_states, downsampled_first_hidden_states_residuals, current_hidden_states_residuals
-    except (IndexError, RuntimeError, TypeError, ValueError) as exc:
+    except (IndexError, RuntimeError, TypeError) as exc:
         raise AssertionError(f"Failed to compute FLUX cache intermediates: {exc}") from exc
 
 

--- a/tests/unit_test/utils/test_flux_first_block_cache_blocking.py
+++ b/tests/unit_test/utils/test_flux_first_block_cache_blocking.py
@@ -137,48 +137,59 @@ def _manual_cache_intermediates(
     adaln_emb,
     adaln_single_emb,
 ):
-    hidden_states = model.x_embedder(hidden_states)
-    encoder_hidden_states = model.context_embedder(encoder_hidden_states)
-    ids = torch.cat((txt_ids, img_ids), dim=0)
-    image_rotary_emb = model.pos_embed(ids)
+    try:
+        hidden_states = model.x_embedder(hidden_states)
+        encoder_hidden_states = model.context_embedder(encoder_hidden_states)
+        ids = torch.cat((txt_ids, img_ids), dim=0)
+        image_rotary_emb = model.pos_embed(ids)
 
-    original_hidden_states = hidden_states
-    encoder_hidden_states, hidden_states = model.transformer_blocks[0](
-        hidden_states=hidden_states,
-        encoder_hidden_states=encoder_hidden_states,
-        temb=adaln_emb[0],
-        image_rotary_emb=image_rotary_emb,
-        joint_attention_kwargs=None,
-    )
-    current_first_hidden_states_residuals = hidden_states - original_hidden_states
-
-    downsample_factor = model._qeff_first_block_cache_downsample_factor
-    downsampled_first_hidden_states_residuals = current_first_hidden_states_residuals[
-        ..., ::downsample_factor
-    ].contiguous()
-
-    remaining_hidden_states = hidden_states
-    remaining_encoder_hidden_states = encoder_hidden_states
-    for index_block, block in enumerate(model.transformer_blocks[1:], start=1):
-        remaining_encoder_hidden_states, remaining_hidden_states = block(
-            hidden_states=remaining_hidden_states,
-            encoder_hidden_states=remaining_encoder_hidden_states,
-            temb=adaln_emb[index_block],
+        original_hidden_states = hidden_states
+        encoder_hidden_states, hidden_states = model.transformer_blocks[0](
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            temb=adaln_emb[0],
             image_rotary_emb=image_rotary_emb,
             joint_attention_kwargs=None,
         )
+        current_first_hidden_states_residuals = hidden_states - original_hidden_states
 
-    for index_block, block in enumerate(model.single_transformer_blocks):
-        remaining_encoder_hidden_states, remaining_hidden_states = block(
-            hidden_states=remaining_hidden_states,
-            encoder_hidden_states=remaining_encoder_hidden_states,
-            temb=adaln_single_emb[index_block],
-            image_rotary_emb=image_rotary_emb,
-            joint_attention_kwargs=None,
-        )
+        downsample_factor = model._qeff_first_block_cache_downsample_factor
+        if downsample_factor <= 0:
+            raise ValueError(f"downsample_factor must be > 0, got {downsample_factor}")
+        if current_first_hidden_states_residuals.shape[-1] % downsample_factor != 0:
+            raise ValueError(
+                "downsample_factor must divide hidden dimension exactly, "
+                f"got hidden_size={current_first_hidden_states_residuals.shape[-1]}, "
+                f"downsample_factor={downsample_factor}"
+            )
+        downsampled_first_hidden_states_residuals = current_first_hidden_states_residuals[
+            ..., ::downsample_factor
+        ].contiguous()
 
-    current_hidden_states_residuals = remaining_hidden_states - hidden_states
-    return hidden_states, downsampled_first_hidden_states_residuals, current_hidden_states_residuals
+        remaining_hidden_states = hidden_states
+        remaining_encoder_hidden_states = encoder_hidden_states
+        for index_block, block in enumerate(model.transformer_blocks[1:], start=1):
+            remaining_encoder_hidden_states, remaining_hidden_states = block(
+                hidden_states=remaining_hidden_states,
+                encoder_hidden_states=remaining_encoder_hidden_states,
+                temb=adaln_emb[index_block],
+                image_rotary_emb=image_rotary_emb,
+                joint_attention_kwargs=None,
+            )
+
+        for index_block, block in enumerate(model.single_transformer_blocks):
+            remaining_encoder_hidden_states, remaining_hidden_states = block(
+                hidden_states=remaining_hidden_states,
+                encoder_hidden_states=remaining_encoder_hidden_states,
+                temb=adaln_single_emb[index_block],
+                image_rotary_emb=image_rotary_emb,
+                joint_attention_kwargs=None,
+            )
+
+        current_hidden_states_residuals = remaining_hidden_states - hidden_states
+        return hidden_states, downsampled_first_hidden_states_residuals, current_hidden_states_residuals
+    except (IndexError, RuntimeError, TypeError, ValueError) as exc:
+        raise AssertionError(f"Failed to compute FLUX cache intermediates: {exc}") from exc
 
 
 @pytest.mark.diffusers

--- a/tests/unit_test/utils/test_wan_first_block_cache_blocking.py
+++ b/tests/unit_test/utils/test_wan_first_block_cache_blocking.py
@@ -1,0 +1,265 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+"""
+CPU-only unit tests for WAN first-block-cache with attention blocking configs.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+from diffusers.models.modeling_outputs import Transformer2DModelOutput
+
+from QEfficient.diffusers.first_block_cache.wan import enable_wan_first_block_cache
+from QEfficient.diffusers.models.modeling_utils import compute_blocked_attention, get_attention_blocking_config
+
+
+class _BlockingAwareWanBlock(nn.Module):
+    def __init__(self, residual_scale: float):
+        super().__init__()
+        self.residual_scale = residual_scale
+        self.last_config = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        timestep_proj: torch.Tensor,
+        rotary_emb: torch.Tensor,
+    ) -> torch.Tensor:
+        del encoder_hidden_states, timestep_proj, rotary_emb
+
+        mode, head_block_size, num_kv_blocks, num_q_blocks = get_attention_blocking_config()
+        self.last_config = (mode, head_block_size, num_kv_blocks, num_q_blocks)
+
+        bs, cl, hidden_size = hidden_states.shape
+        num_heads = 2
+        head_dim = hidden_size // num_heads
+
+        q = hidden_states.view(bs, cl, num_heads, head_dim).permute(0, 2, 1, 3).contiguous()
+        k = q
+        v = q
+        blocked = compute_blocked_attention(
+            q=q,
+            k=k,
+            v=v,
+            head_block_size=head_block_size or num_heads,
+            num_kv_blocks=num_kv_blocks or 1,
+            num_q_blocks=num_q_blocks or 1,
+            blocking_mode=mode,
+        )
+        blocked = blocked.permute(0, 2, 1, 3).reshape(bs, cl, hidden_size)
+        return hidden_states + self.residual_scale * blocked
+
+
+class _DummyWanModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(hidden_size=8)
+        self.blocks = nn.ModuleList(
+            [
+                _BlockingAwareWanBlock(0.30),
+                _BlockingAwareWanBlock(0.20),
+                _BlockingAwareWanBlock(0.10),
+            ]
+        )
+        self.norm_out = nn.Identity()
+        self.proj_out = nn.Identity()
+        self.scale_shift_table = nn.Parameter(torch.zeros(2, 8), requires_grad=False)
+
+    def patch_embedding(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return hidden_states
+
+    def forward(self, **kwargs):
+        hidden_states = self.patch_embedding(kwargs["hidden_states"]).flatten(2).transpose(1, 2)
+        return Transformer2DModelOutput(sample=hidden_states)
+
+
+class _DummyTransformerWrapper:
+    def __init__(self):
+        self.model = _DummyWanModel()
+        self.hash_params = {}
+        self.compile_kwargs = None
+
+    def get_onnx_params(self):
+        return {"hidden_states": torch.randn(1, 8, 1, 2, 3)}, {"hidden_states": {0: "batch_size"}}, ["sample"]
+
+    def _compile(self, **kwargs):
+        self.compile_kwargs = kwargs
+        return "compiled"
+
+    def compile(self, *args, **kwargs):
+        return self._compile(*args, **kwargs)
+
+
+def _set_blocking_env(monkeypatch, mode: str, head_block_size: int = 2, num_kv_blocks: int = 2, num_q_blocks: int = 2):
+    monkeypatch.setenv("ATTENTION_BLOCKING_MODE", mode)
+    monkeypatch.setenv("head_block_size", str(head_block_size))
+    monkeypatch.setenv("num_kv_blocks", str(num_kv_blocks))
+    monkeypatch.setenv("num_q_blocks", str(num_q_blocks))
+
+
+def _make_forward_inputs():
+    torch.manual_seed(9)
+    hidden_states = torch.randn(1, 8, 1, 2, 3)
+    encoder_hidden_states = torch.randn(1, 4, 8)
+    rotary_emb = torch.randn(2, 1, 1, 1)
+    temb = torch.zeros(1, 8)
+    timestep_proj = torch.zeros(1, 6, 8)
+    return hidden_states, encoder_hidden_states, rotary_emb, temb, timestep_proj
+
+
+def _manual_cache_intermediates(model, hidden_states, encoder_hidden_states, rotary_emb, timestep_proj):
+    rotary_chunks = torch.split(rotary_emb, 1, dim=0)
+    flattened = model.patch_embedding(hidden_states).flatten(2).transpose(1, 2)
+
+    first_block_out = model.blocks[0](flattened, encoder_hidden_states, timestep_proj, rotary_chunks)
+    first_block_residual = first_block_out - flattened
+
+    downsample_factor = model._qeff_first_block_cache_downsample_factor
+    downsampled_first_block_residual = first_block_residual[..., ::downsample_factor].contiguous()
+
+    remain_hidden = first_block_out
+    for block in model.blocks[1:]:
+        remain_hidden = block(remain_hidden, encoder_hidden_states, timestep_proj, rotary_chunks)
+    current_remain_block_residual = remain_hidden - first_block_out
+
+    return first_block_out, downsampled_first_block_residual, current_remain_block_residual
+
+
+@pytest.mark.diffusers
+@pytest.mark.parametrize("mode", ["default", "kv", "q", "qkv"])
+def test_wan_first_block_cache_runs_with_all_blocking_modes(mode, monkeypatch):
+    _set_blocking_env(monkeypatch, mode)
+    wrapper = _DummyTransformerWrapper()
+    enable_wan_first_block_cache(wrapper, downsample_factor=2)
+
+    hidden_states, encoder_hidden_states, rotary_emb, temb, timestep_proj = _make_forward_inputs()
+    _, expected_first_residual, _ = _manual_cache_intermediates(
+        wrapper.model, hidden_states, encoder_hidden_states, rotary_emb, timestep_proj
+    )
+    prev_remain_residual = torch.randn(1, 6, 8)
+
+    output, retained_first, retained_remain = wrapper.model(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        rotary_emb=rotary_emb,
+        temb=temb,
+        timestep_proj=timestep_proj,
+        prev_first_block_residuals=expected_first_residual,
+        prev_remain_block_residuals=prev_remain_residual,
+        cache_threshold=1.0,
+    )
+
+    assert isinstance(output, Transformer2DModelOutput)
+    assert output.sample.shape == (1, 6, 8)
+    assert torch.isfinite(output.sample).all()
+    assert torch.allclose(retained_first, expected_first_residual, atol=1e-6)
+    assert torch.allclose(retained_remain, prev_remain_residual, atol=1e-6)
+    assert all(block.last_config[0] == mode for block in wrapper.model.blocks)
+
+
+@pytest.mark.diffusers
+def test_wan_first_block_cache_qkv_hit_uses_prev_remain_residual(monkeypatch):
+    _set_blocking_env(monkeypatch, "qkv")
+    wrapper = _DummyTransformerWrapper()
+    enable_wan_first_block_cache(wrapper, downsample_factor=2)
+
+    hidden_states, encoder_hidden_states, rotary_emb, temb, timestep_proj = _make_forward_inputs()
+    first_block_out, first_residual, _ = _manual_cache_intermediates(
+        wrapper.model, hidden_states, encoder_hidden_states, rotary_emb, timestep_proj
+    )
+    prev_remain_residual = torch.randn(1, 6, 8)
+
+    output, _, retained_remain = wrapper.model(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        rotary_emb=rotary_emb,
+        temb=temb,
+        timestep_proj=timestep_proj,
+        prev_first_block_residuals=first_residual,
+        prev_remain_block_residuals=prev_remain_residual,
+        cache_threshold=1.0,
+    )
+
+    assert torch.allclose(retained_remain, prev_remain_residual, atol=1e-6)
+    assert torch.allclose(output.sample, first_block_out + prev_remain_residual, atol=1e-6)
+
+
+@pytest.mark.diffusers
+def test_wan_first_block_cache_kv_miss_uses_current_remain_residual(monkeypatch):
+    _set_blocking_env(monkeypatch, "kv")
+    wrapper = _DummyTransformerWrapper()
+    enable_wan_first_block_cache(wrapper, downsample_factor=2)
+
+    hidden_states, encoder_hidden_states, rotary_emb, temb, timestep_proj = _make_forward_inputs()
+    first_block_out, first_residual, current_remain_residual = _manual_cache_intermediates(
+        wrapper.model, hidden_states, encoder_hidden_states, rotary_emb, timestep_proj
+    )
+    prev_first_residual = first_residual + 1.0
+    prev_remain_residual = torch.randn(1, 6, 8)
+
+    output, _, retained_remain = wrapper.model(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        rotary_emb=rotary_emb,
+        temb=temb,
+        timestep_proj=timestep_proj,
+        prev_first_block_residuals=prev_first_residual,
+        prev_remain_block_residuals=prev_remain_residual,
+        cache_threshold=0.0,
+    )
+
+    assert torch.allclose(retained_remain, current_remain_residual, atol=1e-6)
+    assert torch.allclose(output.sample, first_block_out + current_remain_residual, atol=1e-6)
+
+
+@pytest.mark.diffusers
+def test_wan_first_block_cache_reads_blocking_env_config(monkeypatch):
+    _set_blocking_env(monkeypatch, "qkv", head_block_size=4, num_kv_blocks=3, num_q_blocks=5)
+    wrapper = _DummyTransformerWrapper()
+    enable_wan_first_block_cache(wrapper, downsample_factor=2)
+
+    hidden_states, encoder_hidden_states, rotary_emb, temb, timestep_proj = _make_forward_inputs()
+    _, expected_first_residual, _ = _manual_cache_intermediates(
+        wrapper.model, hidden_states, encoder_hidden_states, rotary_emb, timestep_proj
+    )
+
+    wrapper.model(
+        hidden_states=hidden_states,
+        encoder_hidden_states=encoder_hidden_states,
+        rotary_emb=rotary_emb,
+        temb=temb,
+        timestep_proj=timestep_proj,
+        prev_first_block_residuals=expected_first_residual,
+        prev_remain_block_residuals=torch.zeros(1, 6, 8),
+        cache_threshold=1.0,
+    )
+
+    assert all(block.last_config == ("qkv", 4, 3, 5) for block in wrapper.model.blocks)
+
+
+@pytest.mark.diffusers
+def test_wan_first_block_cache_patch_is_idempotent_with_blocking(monkeypatch):
+    _set_blocking_env(monkeypatch, "q")
+    wrapper = _DummyTransformerWrapper()
+    enable_wan_first_block_cache(wrapper, downsample_factor=2)
+
+    patched_forward = wrapper.model.forward
+    patched_get_onnx_params = wrapper.get_onnx_params
+    patched_compile = wrapper.compile
+    downsample_factor = wrapper.model._qeff_first_block_cache_downsample_factor
+    hash_params = dict(wrapper.hash_params)
+
+    enable_wan_first_block_cache(wrapper, downsample_factor=4)
+
+    assert wrapper.model.forward is patched_forward
+    assert wrapper.get_onnx_params is patched_get_onnx_params
+    assert wrapper.compile is patched_compile
+    assert wrapper.model._qeff_first_block_cache_downsample_factor == downsample_factor
+    assert wrapper.hash_params == hash_params

--- a/tests/unit_test/utils/test_wan_first_block_cache_blocking.py
+++ b/tests/unit_test/utils/test_wan_first_block_cache_blocking.py
@@ -115,31 +115,35 @@ def _make_forward_inputs():
 
 
 def _manual_cache_intermediates(model, hidden_states, encoder_hidden_states, rotary_emb, timestep_proj):
+    downsample_factor = model._qeff_first_block_cache_downsample_factor
+    if downsample_factor <= 0:
+        raise ValueError(f"downsample_factor must be > 0, got {downsample_factor}")
+
     try:
         rotary_chunks = torch.split(rotary_emb, 1, dim=0)
         flattened = model.patch_embedding(hidden_states).flatten(2).transpose(1, 2)
 
         first_block_out = model.blocks[0](flattened, encoder_hidden_states, timestep_proj, rotary_chunks)
         first_block_residual = first_block_out - flattened
+    except (IndexError, RuntimeError, TypeError) as exc:
+        raise AssertionError(f"Failed to compute WAN cache intermediates: {exc}") from exc
 
-        downsample_factor = model._qeff_first_block_cache_downsample_factor
-        if downsample_factor <= 0:
-            raise ValueError(f"downsample_factor must be > 0, got {downsample_factor}")
-        if first_block_residual.shape[-1] % downsample_factor != 0:
-            raise ValueError(
-                "downsample_factor must divide hidden dimension exactly, "
-                f"got hidden_size={first_block_residual.shape[-1]}, downsample_factor={downsample_factor}"
-            )
+    if first_block_residual.shape[-1] % downsample_factor != 0:
+        raise ValueError(
+            "downsample_factor must divide hidden dimension exactly, "
+            f"got hidden_size={first_block_residual.shape[-1]}, downsample_factor={downsample_factor}"
+        )
 
-        downsampled_first_block_residual = first_block_residual[..., ::downsample_factor].contiguous()
+    downsampled_first_block_residual = first_block_residual[..., ::downsample_factor].contiguous()
 
+    try:
         remain_hidden = first_block_out
         for block in model.blocks[1:]:
             remain_hidden = block(remain_hidden, encoder_hidden_states, timestep_proj, rotary_chunks)
         current_remain_block_residual = remain_hidden - first_block_out
 
         return first_block_out, downsampled_first_block_residual, current_remain_block_residual
-    except (IndexError, RuntimeError, TypeError, ValueError) as exc:
+    except (IndexError, RuntimeError, TypeError) as exc:
         raise AssertionError(f"Failed to compute WAN cache intermediates: {exc}") from exc
 
 

--- a/tests/unit_test/utils/test_wan_first_block_cache_blocking.py
+++ b/tests/unit_test/utils/test_wan_first_block_cache_blocking.py
@@ -115,21 +115,32 @@ def _make_forward_inputs():
 
 
 def _manual_cache_intermediates(model, hidden_states, encoder_hidden_states, rotary_emb, timestep_proj):
-    rotary_chunks = torch.split(rotary_emb, 1, dim=0)
-    flattened = model.patch_embedding(hidden_states).flatten(2).transpose(1, 2)
+    try:
+        rotary_chunks = torch.split(rotary_emb, 1, dim=0)
+        flattened = model.patch_embedding(hidden_states).flatten(2).transpose(1, 2)
 
-    first_block_out = model.blocks[0](flattened, encoder_hidden_states, timestep_proj, rotary_chunks)
-    first_block_residual = first_block_out - flattened
+        first_block_out = model.blocks[0](flattened, encoder_hidden_states, timestep_proj, rotary_chunks)
+        first_block_residual = first_block_out - flattened
 
-    downsample_factor = model._qeff_first_block_cache_downsample_factor
-    downsampled_first_block_residual = first_block_residual[..., ::downsample_factor].contiguous()
+        downsample_factor = model._qeff_first_block_cache_downsample_factor
+        if downsample_factor <= 0:
+            raise ValueError(f"downsample_factor must be > 0, got {downsample_factor}")
+        if first_block_residual.shape[-1] % downsample_factor != 0:
+            raise ValueError(
+                "downsample_factor must divide hidden dimension exactly, "
+                f"got hidden_size={first_block_residual.shape[-1]}, downsample_factor={downsample_factor}"
+            )
 
-    remain_hidden = first_block_out
-    for block in model.blocks[1:]:
-        remain_hidden = block(remain_hidden, encoder_hidden_states, timestep_proj, rotary_chunks)
-    current_remain_block_residual = remain_hidden - first_block_out
+        downsampled_first_block_residual = first_block_residual[..., ::downsample_factor].contiguous()
 
-    return first_block_out, downsampled_first_block_residual, current_remain_block_residual
+        remain_hidden = first_block_out
+        for block in model.blocks[1:]:
+            remain_hidden = block(remain_hidden, encoder_hidden_states, timestep_proj, rotary_chunks)
+        current_remain_block_residual = remain_hidden - first_block_out
+
+        return first_block_out, downsampled_first_block_residual, current_remain_block_residual
+    except (IndexError, RuntimeError, TypeError, ValueError) as exc:
+        raise AssertionError(f"Failed to compute WAN cache intermediates: {exc}") from exc
 
 
 @pytest.mark.diffusers


### PR DESCRIPTION

# Wan-AI/Wan2.2-T2V-A14B-Diffusers


1. Added support of Non-unified Wan transformers ( as for 720p, unified approach was failing). This could be enabled using flag use_unified=False
2.  Added support of first-block caching for non-unified approach, which can be enabled using flag enable_first_block_cache. Caching is only enabled with non-unified approach. 
3. Added test for both non-unified and caching

Example-
```
pipeline = QEffWanPipeline.from_pretrained(
    "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
    use_unified=False,
    enable_first_block_cache=True,
    # Hidden-dimension downsampling used for first-block residual similarity check.
    first_block_cache_downsample_factor=4,
)
```
Result- 90p/16TS/81f

<img width="560" height="307" alt="image" src="https://github.com/user-attachments/assets/18997b0d-1ad3-473f-a609-5a8ae889d142" />


# black-forest-labs/FLUX.1-schnell

1. Enabled first block caching for flux
2. Caching can be enabled with flag `enable_first_block_cache`
3. Example-
```
pipeline = QEffFluxPipeline.from_pretrained(
    "black-forest-labs/FLUX.1-schnell",
    enable_first_block_cache=True,
    # Hidden-dimension downsampling used for first-block residual similarity check.
    first_block_cache_downsample_factor=4,
)

```
4. Result-
height/width=256
<img width="834" height="581" alt="image" src="https://github.com/user-attachments/assets/7c5ad891-5e42-4ccf-9efc-dd7f617fa3bb" />
