### PR TITLE
fix: improve weight offloading to handle plain tensor attrs and use to_empty()

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -136,18 +136,22 @@ class QEFFBaseModel(ABC):
         """Clear PyTorch model weights to reduce memory usage after ONNX export."""
         if offload_pt_weights and not self._is_weights_offloaded:
             try:
-                for param in self.model.parameters():
-                    if param.storage():
-                        param.storage().resize_(0)
-                for buffer in self.model.buffers():
-                    if buffer.storage():
-                        buffer.storage().resize_(0)
+                # Clear plain tensor attributes that are not registered as parameters
+                # or buffers (e.g. stacked expert weights in MoE models). These are not
+                # handled by to_empty().
+                param_data_ptrs = {p.data_ptr() for p in self.model.parameters()}
+                buf_data_ptrs = {b.data_ptr() for b in self.model.buffers()}
+                registered_ptrs = param_data_ptrs | buf_data_ptrs
+                for module in self.model.modules():
+                    for attr_name in list(vars(module).keys()):
+                        attr = getattr(module, attr_name, None)
+                        if isinstance(attr, torch.Tensor) and attr.data_ptr() not in registered_ptrs:
+                            setattr(module, attr_name, torch.empty(0, device="meta"))
 
-                meta_model = self.model.to("meta")
-                del self.model
+                # Move all parameters and buffers to meta device with empty storage.
+                self.model.to_empty(device="meta")
                 gc.collect()
 
-                self.model = meta_model
                 self._is_weights_offloaded = True
                 return True
             except Exception as e:

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -157,23 +157,6 @@ class QEFFBaseModel(ABC):
                         new_b = torch.empty(b.shape, dtype=b.dtype, device="meta")
                         torch.utils.swap_tensors(b, new_b)
 
-                # Drop storage from any remaining large non-meta tensor
-                # in the gc graph. This handles refs held by torch.onnx.export's
-                # trace cache and similar external retainers.
-                large_tensors = []
-                for o in gc.get_objects():
-                    if isinstance(o, torch.Tensor) and not o.is_meta:
-                        try:
-                            if o.numel() * o.element_size() >= 1024 * 1024:
-                                large_tensors.append(o)
-                        except Exception:
-                            pass
-                for t in large_tensors:
-                    try:
-                        with torch.no_grad():
-                            t.set_(torch.empty(0, dtype=t.dtype))
-                    except Exception:
-                        pass
                 gc.collect()
 
                 self._is_weights_offloaded = True

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -134,9 +134,7 @@ class QEFFBaseModel(ABC):
         """Clear PyTorch model weights to reduce memory usage after ONNX export."""
         if offload_pt_weights and not self._is_weights_offloaded:
             try:
-                # Clear plain tensor attributes that are not registered as parameters
-                # or buffers (e.g. stacked expert weights in MoE models). These are not
-                # handled by to_empty().
+                # Clear plain tensor attrs (not registered as params/buffers)
                 param_data_ptrs = {p.data_ptr() for p in self.model.parameters()}
                 buf_data_ptrs = {b.data_ptr() for b in self.model.buffers()}
                 registered_ptrs = param_data_ptrs | buf_data_ptrs
@@ -146,8 +144,36 @@ class QEFFBaseModel(ABC):
                         if isinstance(attr, torch.Tensor) and attr.data_ptr() not in registered_ptrs:
                             setattr(module, attr_name, torch.empty_like(attr, device="meta"))
 
-                # Move all parameters and buffers to meta device with empty storage.
-                self.model.to_empty(device="meta")
+                # Swap each parameter/buffer with a meta tensor of the same
+                # shape, in place — so external Parameter refs also become meta.
+                with torch.no_grad():
+                    for p in self.model.parameters():
+                        new_p = torch.nn.Parameter(
+                            torch.empty(p.shape, dtype=p.dtype, device="meta"),
+                            requires_grad=p.requires_grad,
+                        )
+                        torch.utils.swap_tensors(p, new_p)
+                    for b in self.model.buffers():
+                        new_b = torch.empty(b.shape, dtype=b.dtype, device="meta")
+                        torch.utils.swap_tensors(b, new_b)
+
+                # Drop storage from any remaining large non-meta tensor
+                # in the gc graph. This handles refs held by torch.onnx.export's
+                # trace cache and similar external retainers.
+                large_tensors = []
+                for o in gc.get_objects():
+                    if isinstance(o, torch.Tensor) and not o.is_meta:
+                        try:
+                            if o.numel() * o.element_size() >= 1024 * 1024:
+                                large_tensors.append(o)
+                        except Exception:
+                            pass
+                for t in large_tensors:
+                    try:
+                        with torch.no_grad():
+                            t.set_(torch.empty(0, dtype=t.dtype))
+                    except Exception:
+                        pass
                 gc.collect()
 
                 self._is_weights_offloaded = True

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -144,7 +144,7 @@ class QEFFBaseModel(ABC):
                     for attr_name in list(vars(module).keys()):
                         attr = getattr(module, attr_name, None)
                         if isinstance(attr, torch.Tensor) and attr.data_ptr() not in registered_ptrs:
-                            setattr(module, attr_name, torch.empty(0, device="meta"))
+                            setattr(module, attr_name, torch.empty_like(attr, device="meta"))
 
                 # Move all parameters and buffers to meta device with empty storage.
                 self.model.to_empty(device="meta")

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -134,18 +134,22 @@ class QEFFBaseModel(ABC):
         """Clear PyTorch model weights to reduce memory usage after ONNX export."""
         if offload_pt_weights and not self._is_weights_offloaded:
             try:
-                for param in self.model.parameters():
-                    if param.storage():
-                        param.storage().resize_(0)
-                for buffer in self.model.buffers():
-                    if buffer.storage():
-                        buffer.storage().resize_(0)
+                # Clear plain tensor attributes that are not registered as parameters
+                # or buffers (e.g. stacked expert weights in MoE models). These are not
+                # handled by to_empty().
+                param_data_ptrs = {p.data_ptr() for p in self.model.parameters()}
+                buf_data_ptrs = {b.data_ptr() for b in self.model.buffers()}
+                registered_ptrs = param_data_ptrs | buf_data_ptrs
+                for module in self.model.modules():
+                    for attr_name in list(vars(module).keys()):
+                        attr = getattr(module, attr_name, None)
+                        if isinstance(attr, torch.Tensor) and attr.data_ptr() not in registered_ptrs:
+                            setattr(module, attr_name, torch.empty(0, device="meta"))
 
-                meta_model = self.model.to("meta")
-                del self.model
+                # Move all parameters and buffers to meta device with empty storage.
+                self.model.to_empty(device="meta")
                 gc.collect()
 
-                self.model = meta_model
                 self._is_weights_offloaded = True
                 return True
             except Exception as e:

--- a/tests/unit_test/base/test_modeling_qeff_base.py
+++ b/tests/unit_test/base/test_modeling_qeff_base.py
@@ -12,6 +12,7 @@ Run with: pytest tests/unit_test/base/ -n auto -v
 """
 
 import pytest
+import torch
 from transformers import GPT2Config, GPT2LMHeadModel, LlamaConfig, LlamaForCausalLM
 
 from QEfficient.transformers.models.modeling_auto import QEFFAutoModelForCausalLM
@@ -163,20 +164,32 @@ class TestQEFFBaseModelWeightOffloading:
         qeff._model_offloaded_check()
 
     def test_offload_clears_parameter_storage(self):
-        """_offload_model_weights clears parameter storage."""
+        """_offload_model_weights moves all parameters and buffers to meta device."""
         model, cfg = make_tiny_gpt2()
         qeff = QEFFAutoModelForCausalLM(model)
-        # Check that parameters have storage before offloading
-        has_storage_before = any(p.storage() and p.storage().size() > 0 for p in qeff.model.parameters())
-        assert has_storage_before
+        # Check that parameters are NOT on meta before offloading
+        assert not any(p.is_meta for p in qeff.model.parameters())
 
         qeff._offload_model_weights(offload_pt_weights=True)
 
-        # After offloading, parameters should have no storage or be on meta device
-        has_storage_after = any(
-            p.storage() and p.storage().size() > 0 for p in qeff.model.parameters() if not p.is_meta
-        )
-        assert not has_storage_after
+        # After offloading, ALL parameters and buffers must be on meta device
+        assert all(p.is_meta for p in qeff.model.parameters())
+        assert all(b.is_meta for b in qeff.model.buffers())
+
+    def test_offload_clears_plain_tensor_attributes(self):
+        """_offload_model_weights clears plain tensor attributes (not params/buffers)."""
+        model, cfg = make_tiny_gpt2()
+        qeff = QEFFAutoModelForCausalLM(model)
+
+        # Attach a plain tensor attribute to a submodule (simulates MoE stacked weights)
+        first_child = next(iter(qeff.model.modules()))
+        first_child.extra_weight = torch.randn(8, 8)
+        assert not first_child.extra_weight.is_meta
+
+        qeff._offload_model_weights(offload_pt_weights=True)
+
+        # The plain tensor attribute should also be on meta device
+        assert first_child.extra_weight.is_meta
 
 
 @pytest.mark.cpu_only

--- a/tests/unit_test/base/test_modeling_qeff_base.py
+++ b/tests/unit_test/base/test_modeling_qeff_base.py
@@ -191,6 +191,33 @@ class TestQEFFBaseModelWeightOffloading:
         # The plain tensor attribute should also be on meta device
         assert first_child.extra_weight.is_meta
 
+    def test_offload_preserves_plain_tensor_shape_and_dtype(self):
+        """_offload_model_weights must keep shape/dtype of plain tensor attributes.
+
+        Regression guard: an earlier implementation replaced unregistered tensor
+        attributes with ``torch.empty(0, device="meta")``, which silently broke
+        downstream code that broadcasts against or copies into them (e.g. the
+        LoRA re-export path that calls ``module.lora_scalings.copy_(...)``).
+        Meta tensors carry no storage regardless of shape, so preserving shape
+        costs nothing and keeps shape-dependent code working.
+        """
+        model, _ = make_tiny_gpt2()
+        qeff = QEFFAutoModelForCausalLM(model)
+
+        first_child = next(iter(qeff.model.modules()))
+        first_child.extra_weight = torch.randn(3, 1, 1, 1, dtype=torch.float32)
+
+        qeff._offload_model_weights(offload_pt_weights=True)
+
+        assert first_child.extra_weight.is_meta
+        assert tuple(first_child.extra_weight.shape) == (3, 1, 1, 1)
+        assert first_child.extra_weight.dtype == torch.float32
+
+        # Shape-dependent ops downstream must still type-check; this raised
+        # ``RuntimeError: output with shape [0] doesn't match the broadcast
+        # shape [3, 1, 1, 0]`` under the broken implementation.
+        first_child.extra_weight.copy_(torch.ones(3, 1, 1, 1))
+
 
 @pytest.mark.cpu_only
 def _get_any_attn_blocking_config(model):


### PR DESCRIPTION
fix: improve weight offloading to handle plain tensor attrs and use to_empty()

Replace manual storage resizing with `to_empty(device="meta")` for
parameters/buffers and explicitly handle plain tensor attributes (e.g.
stacked expert weights in MoE models) that are not registered as
parameters or buffers. This ensures all tensors are properly moved to
the meta device, reducing memory usage after ONNX export.

Add unit tests for plain tensor attribute clearing 