### PR TITLE
Enable ffn blocking for dense models with automatic blocking configurator

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -25,12 +25,16 @@ from QEfficient.base.onnx_transforms import (
     SplitTensorsTransform,
 )
 from QEfficient.base.pytorch_transforms import PytorchTransform
-from QEfficient.blocking.blocking_configurator import build_transformer_blocking_config_for_transform
+from QEfficient.blocking.blocking_configurator import (
+    build_transformer_blocking_config_for_transform,
+    check_ffn_block_config,
+)
 from QEfficient.compile.qnn_compiler import compile as qnn_compile
 from QEfficient.generation.cloud_infer import QAICInferenceSession
 from QEfficient.transformers.models.pytorch_transforms import (
     BlockingAttentionTransform,
     ReplicateKVHeadTransform,
+    BlockingFFNTransform,
 )
 from QEfficient.utils import (
     constants,
@@ -477,8 +481,15 @@ class QEFFBaseModel(ABC):
             blocking_config = None
 
         if blocking_config is not None:
-            self.model, _ = BlockingAttentionTransform.apply(self.model, attn_blocking_config=blocking_config)
-            self.hash_params["blocking_kwargs"] = blocking_config
+            if blocking_config.get("attention", None) is not None:
+                self.model, _ = BlockingAttentionTransform.apply(
+                    self.model, attn_blocking_config=blocking_config["attention"]
+                )
+                self.hash_params["attention_blocking_kwargs"] = blocking_config["attention"]
+
+            if blocking_config.get("ffn", None) is not None:
+                self.model, _ = BlockingFFNTransform.apply(self.model, ffn_blocking_config=blocking_config["ffn"])
+                self.hash_params["ffn_blocking_kwargs"] = blocking_config["ffn"]
 
     @dump_qconfig
     def _compile(
@@ -569,6 +580,27 @@ class QEFFBaseModel(ABC):
             )
 
             return self.qpc_path
+
+        if "mdts_mos" not in compiler_options and "mos" not in compiler_options:
+            ffn_cfg = self.hash_params.get("ffn_blocking_kwargs")
+            if ffn_cfg is not None:
+                model_cfg = self.config.text_config if hasattr(self.config, "text_config") else self.config
+
+                num_token_blocks = ffn_cfg.num_token_blocks or 1
+                num_weights_blocks = ffn_cfg.num_weight_blocks or 1
+
+                split_for_soc, split_for_nsp = check_ffn_block_config(
+                    num_token_blocks,
+                    num_weights_blocks,
+                    model_config=model_cfg,
+                    specializations=specializations,
+                    compile_config={"mdp_ts_num_devices": mdp_ts_num_devices, **compiler_options},
+                )
+
+                if split_for_soc == "activation":
+                    compiler_options["mdts_mos"] = 1
+                if split_for_nsp == "activation":
+                    compiler_options["mos"] = 1
 
         command = (
             constants.COMPILER

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -33,8 +33,8 @@ from QEfficient.compile.qnn_compiler import compile as qnn_compile
 from QEfficient.generation.cloud_infer import QAICInferenceSession
 from QEfficient.transformers.models.pytorch_transforms import (
     BlockingAttentionTransform,
-    ReplicateKVHeadTransform,
     BlockingFFNTransform,
+    ReplicateKVHeadTransform,
 )
 from QEfficient.utils import (
     constants,

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -582,16 +582,16 @@ class QEFFBaseModel(ABC):
             return self.qpc_path
 
         if "mdts_mos" not in compiler_options and "mos" not in compiler_options:
-            ffn_cfg = self.hash_params.get("ffn_blocking_kwargs")
+            ffn_cfg = self.hash_params.get("ffn_blocking_kwargs", None) if hasattr(self, "hash_params") else None
             if ffn_cfg is not None:
                 model_cfg = self.config.text_config if hasattr(self.config, "text_config") else self.config
 
                 num_token_blocks = ffn_cfg.num_token_blocks or 1
-                num_weights_blocks = ffn_cfg.num_weight_blocks or 1
+                num_weight_blocks = ffn_cfg.num_weight_blocks or 1
 
                 split_for_soc, split_for_nsp = check_ffn_block_config(
                     num_token_blocks,
-                    num_weights_blocks,
+                    num_weight_blocks,
                     model_config=model_cfg,
                     specializations=specializations,
                     compile_config={"mdp_ts_num_devices": mdp_ts_num_devices, **compiler_options},

--- a/QEfficient/blocking/blocked_ffn_forwards.py
+++ b/QEfficient/blocking/blocked_ffn_forwards.py
@@ -1,0 +1,201 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+def blocked_tokens_ffn_forward(
+    w1: nn.Module,
+    w2: nn.Module,
+    x: torch.Tensor,
+    num_token_blocks: int,
+    w3: Optional[nn.Module] = None,
+    activation_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+    **kwargs,
+) -> torch.Tensor:
+    """
+    Token blocking: Process tokens in blocks.
+    Pattern: For each token_block:
+        X = gate(token_block), Y = nonlinearity(X), Z = up(token_block), W = Y*Z
+        outputs.append(down(W))
+    Result: concatenate along token dimension
+    """
+    act = activation_fn if activation_fn is not None else F.silu
+
+    _, seq_len, _ = x.shape
+
+    token_block_size = math.ceil(seq_len / num_token_blocks)
+    outputs = []
+
+    for token_idx in range(num_token_blocks):
+        start_idx = token_idx * token_block_size
+        if token_idx == num_token_blocks - 1:
+            token_len_block = seq_len - start_idx
+        else:
+            token_len_block = token_block_size
+        end_idx = start_idx + token_len_block
+        token_block = x[:, start_idx:end_idx, :]
+
+        X = w1(token_block)
+        Y = act(X)
+        # gpt2 style mlp has w1 and w2 only while llama style mlp has w3 as well
+        if w3 is not None:
+            Z = w3(token_block)
+            W = Y * Z
+        else:
+            W = Y
+
+        output_block = w2(W)
+        outputs.append(output_block)
+
+    # Concatenate along token dimension
+    return torch.cat(outputs, dim=1)  # [BS, seqlen, dim]
+
+
+def blocked_weights_ffn_forward(
+    w1: nn.Module,
+    w2: nn.Module,
+    x: torch.Tensor,
+    num_weight_blocks: int,
+    w3: Optional[nn.Module] = None,
+    activation_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+    **kwargs,
+) -> torch.Tensor:
+    """
+    Weight blocking: Process intermediate hidden dimension in chunks to reduce peak intermediate size.
+
+    For each hidden_block:
+        X = linear(x, w1_block)
+        Y = silu(X)
+        Z = linear(x, w3_block)
+        W = Y * Z
+        result += linear(W, w2_block)
+    """
+    act = activation_fn if activation_fn is not None else F.silu
+
+    bs, seq_len, dim = x.shape
+    hidden_dim = w1.weight.shape[0]
+
+    weight_block_size = math.ceil(hidden_dim / num_weight_blocks)
+
+    for weight_idx in range(num_weight_blocks):
+        start_idx = weight_idx * weight_block_size
+        if weight_idx == num_weight_blocks - 1:
+            weight_len_block = hidden_dim - start_idx
+        else:
+            weight_len_block = weight_block_size
+        end_idx = start_idx + weight_len_block
+
+        # Extract weight blocks.
+        # w1/w3: [hidden_dim, dim], w2: [dim, hidden_dim]
+        w1_block = w1.weight[start_idx:end_idx, :]
+        if w3 is not None:
+            w3_block = w3.weight[start_idx:end_idx, :]
+        w2_block = w2.weight[:, start_idx:end_idx]
+
+        w1_bias = w1.bias[start_idx:end_idx] if w1.bias is not None else None
+        if w3 is not None:
+            w3_bias = w3.bias[start_idx:end_idx] if w3.bias is not None else None
+        w2_bias = w2.bias if (weight_idx == 0 and w2.bias is not None) else None
+
+        X = F.linear(x, w1_block, w1_bias)
+        Y = act(X)
+        # gpt2 style mlp has w1 and w2 only while llama style mlp has w3 as well
+        if w3 is not None:
+            Z = F.linear(x, w3_block, w3_bias)
+            W = Y * Z
+        else:
+            W = Y
+        if weight_idx == 0:
+            result_block = F.linear(W, w2_block, w2_bias)
+        else:
+            result_block += F.linear(W, w2_block, w2_bias)
+
+    return result_block
+
+
+def blocked_tokens_weights_ffn_forward(
+    w1: nn.Module,
+    w2: nn.Module,
+    x: torch.Tensor,
+    num_token_blocks: int,
+    num_weight_blocks: int,
+    w3: Optional[nn.Module] = None,
+    activation_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+    **kwargs,
+) -> torch.Tensor:
+    """
+    Both token and weight blocking: process tokens in blocks, and within each token block,
+    process intermediate hidden dimension in blocks.
+
+    w1/w3: [hidden_dim, dim], w2: [dim, hidden_dim]
+    """
+    act = activation_fn if activation_fn is not None else F.silu
+
+    bs, seq_len, dim = x.shape
+    hidden_dim = w1.weight.shape[0]
+
+    token_block_size = math.ceil(seq_len / num_token_blocks)
+    weight_block_size = math.ceil(hidden_dim / num_weight_blocks)
+    result = torch.zeros(bs, seq_len, dim, device=x.device, dtype=x.dtype)
+
+    outputs = []
+
+    for token_idx in range(num_token_blocks):
+        t_start = token_idx * token_block_size
+        if token_idx == num_token_blocks - 1:
+            token_len_block = seq_len - t_start
+        else:
+            token_len_block = token_block_size
+        t_end = t_start + token_len_block
+
+        token_block = x[:, t_start:t_end, :]
+
+        for weight_idx in range(num_weight_blocks):
+            w_start = weight_idx * weight_block_size
+            if weight_idx == num_weight_blocks - 1:
+                weight_len_block = hidden_dim - w_start
+            else:
+                weight_len_block = weight_block_size
+            w_end = w_start + weight_len_block
+
+            w1_block = w1.weight[w_start:w_end, :]
+            if w3 is not None:
+                w3_block = w3.weight[w_start:w_end, :]
+            w2_block = w2.weight[:, w_start:w_end]
+
+            w1_bias = w1.bias[w_start:w_end] if w1.bias is not None else None
+            if w3 is not None:
+                w3_bias = w3.bias[w_start:w_end] if w3.bias is not None else None
+            w2_bias = w2.bias if (weight_idx == 0 and w2.bias is not None) else None
+
+            X = F.linear(token_block, w1_block, w1_bias)
+            Y = act(X)
+            # gpt2 style mlp has w1 and w2 only while llama style mlp has w3 as well
+            if w3 is not None:
+                Z = F.linear(token_block, w3_block, w3_bias)
+                W = Y * Z
+            else:
+                W = Y
+
+            if weight_idx == 0:
+                result_block = F.linear(W, w2_block, w2_bias)
+            else:
+                result_block += F.linear(W, w2_block, w2_bias)
+
+        outputs.append(result_block)
+
+    result = torch.cat(outputs, dim=1)
+
+    return result

--- a/QEfficient/blocking/blocked_ffn_forwards.py
+++ b/QEfficient/blocking/blocked_ffn_forwards.py
@@ -88,6 +88,7 @@ def blocked_weights_ffn_forward(
     hidden_dim = w1.weight.shape[0]
 
     weight_block_size = math.ceil(hidden_dim / num_weight_blocks)
+    result_block = None  # Initialize before loop
 
     for weight_idx in range(num_weight_blocks):
         start_idx = weight_idx * weight_block_size
@@ -161,6 +162,7 @@ def blocked_tokens_weights_ffn_forward(
         t_end = t_start + token_len_block
 
         token_block = x[:, t_start:t_end, :]
+        result_block = None  # Initialize before loop
 
         for weight_idx in range(num_weight_blocks):
             w_start = weight_idx * weight_block_size

--- a/QEfficient/blocking/blocking_configurator.py
+++ b/QEfficient/blocking/blocking_configurator.py
@@ -445,7 +445,7 @@ def ffn_configurator(
                     best_config.update(
                         {
                             "num_token_blocks": num_token_blocks,
-                            "num_weights_block": num_weight_blocks,
+                            "num_weight_blocks": num_weight_blocks,
                             "split_for_soc": "weights",
                             "split_for_nsp": "weights",
                             "vtcm_footprint": max(footprints.values()),

--- a/QEfficient/blocking/blocking_configurator.py
+++ b/QEfficient/blocking/blocking_configurator.py
@@ -14,9 +14,10 @@ that can be fed model config + pipeline compile config to derive blocking settin
 from __future__ import annotations
 
 import math
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from QEfficient.blocking.attention_blocking import AttentionBlockingConfig, BlockingMode
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode
 from QEfficient.utils import get_attr_or_key, require_value
 from QEfficient.utils.constants import DEFAULT_NUM_HEADS, FP16_BYTES, KV_LORA_RANK, ROPE_DIM, VTCM_SIZE_THRESHOLD
 
@@ -70,6 +71,28 @@ def _resolve_effective_blocking_mode(attention_cfg: Dict[str, Any], requested_mo
     if num_kv_blocks > 1:
         return "kv"
     return ""
+
+
+def resolve_ffn_blocking_mode(ffn_cfg: Dict[str, Any], requested_mode: str) -> str:
+    """
+    Resolve effective FFN mode string ("", "t", "w", "tw") based on whether auto-config
+    actually selected >1 blocks for tokens/weights.
+
+    This mirrors `_resolve_effective_blocking_mode` for attention.
+    """
+    mode = (requested_mode or "").lower()
+    if mode == "":
+        return ""
+
+    num_token_blocks = int(ffn_cfg.get("num_token_blocks") or 1)
+    num_weights_blocks = int(ffn_cfg.get("num_weights_blocks") or 1)
+
+    effective = ""
+    if "t" in mode and num_token_blocks > 1:
+        effective += "t"
+    if "w" in mode and num_weights_blocks > 1:
+        effective += "w"
+    return effective
 
 
 def _get_valid_num_blocks(config: Dict, requested_key: str) -> int:
@@ -243,6 +266,250 @@ def attention_configurator(
     return best_config
 
 
+def check_ffn_block_config(
+    num_token_blocks: int,
+    num_weights_blocks: int,
+    *,
+    model_config: Any,
+    specializations: Optional[List[Dict[str, int]]],
+    compile_config: Dict[str, Any],
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Decide (split_for_soc, split_for_nsp) for a given FFN block configuration by running
+    the VTCM-threshold checks (same 3 strategies as `ffn_configurator`).
+
+    This keeps call-sites simple: they only need block counts + specialization + compile options,
+    and we derive the rest (bs/seq_len/dims/devices/dtype size) here.
+
+    Args:
+        num_token_blocks: number of token blocks (> 0)
+        num_weights_blocks: number of weight blocks (> 0)
+        model_config: model config object/dict (for VLMs, pass text_config)
+        specializations: specialization list; uses first entry for bs/seq_len
+        compile_config: compile options dict (expects `mdp_ts_num_devices`, `aic_num_cores`,
+            and dtype info via `data_bytes` or `convert_to_fp16`)
+
+    Returns:
+        (split_for_soc, split_for_nsp) where each is:
+          - "weights"     : shard weights across that dimension
+          - "activation"  : shard activations across that dimension
+          - None          : no strategy fits VTCM threshold for the given block sizes
+    """
+    if specializations is None or len(specializations) == 0:
+        return None, None
+
+    bs = get_attr_or_key(specializations[0], ("batch_size", "batch"))
+    seq_len = get_attr_or_key(specializations[0], ("cl", "seq_len", "sequence_length"))
+
+    d_model = get_attr_or_key(model_config, ("hidden_size", "d_model", "model_dim"))
+    intermediate = get_attr_or_key(model_config, ("intermediate_size", "ffn_dim", "mlp_dim"))
+
+    if bs is None or seq_len is None or d_model is None or intermediate is None:
+        return None, None
+
+    num_socs = int(compile_config.get("mdp_ts_num_devices", 1))
+    num_nsps = int(compile_config.get("aic_num_cores", 1))
+    data_bytes = _infer_data_bytes(compile_config)
+
+    sl_block = int(seq_len) / int(num_token_blocks)
+    i_block = int(intermediate) / int(num_weights_blocks)
+
+    # 1) split weights across all (soc*nsp)
+    footprints = _op_footprints(
+        bs=int(bs),
+        d_model=int(d_model),
+        data_bytes=int(data_bytes),
+        sl_block=sl_block,
+        i_block=i_block,
+        split_act=1,
+        split_w_up_gate=num_socs * num_nsps,
+        split_w_down=num_socs * num_nsps,
+    )
+    if all(v < VTCM_SIZE_THRESHOLD for v in footprints.values()):
+        return "weights", "weights"
+
+    # 2) split weights across NSP, activations across SOC
+    footprints = _op_footprints(
+        bs=int(bs),
+        d_model=int(d_model),
+        data_bytes=int(data_bytes),
+        sl_block=sl_block,
+        i_block=i_block,
+        split_act=num_socs,
+        split_w_up_gate=num_nsps,
+        split_w_down=num_nsps,
+    )
+    if all(v < VTCM_SIZE_THRESHOLD for v in footprints.values()):
+        return "activation", "weights"
+
+    # 3) split activations across all (soc*nsp)
+    footprints = _op_footprints(
+        bs=int(bs),
+        d_model=int(d_model),
+        data_bytes=int(data_bytes),
+        sl_block=sl_block,
+        i_block=i_block,
+        split_act=num_socs * num_nsps,
+        split_w_up_gate=1,
+        split_w_down=1,
+    )
+    if all(v < VTCM_SIZE_THRESHOLD for v in footprints.values()):
+        return "activation", "activation"
+
+    return None, None
+
+
+def _weights_vtcm(dim1: float, dim2: float, *, data_bytes: int, split_weights: int) -> float:
+    # weights tensor is [dim1, dim2], scaled by min(1, 32 / dim2)
+    w_size = dim1 * (dim2 / split_weights) * data_bytes
+    cache_factor = min(1.0, 32.0 / (dim2 / split_weights))
+    return w_size * cache_factor
+
+
+def _op_footprints(
+    *,
+    bs: int,
+    d_model: int,
+    data_bytes: int,
+    sl_block: float,
+    i_block: float,
+    split_act: int,
+    split_w_up_gate: int,
+    split_w_down: int,
+) -> Dict[str, float]:
+    # activations split on dim0 (token dimension)
+    t = (bs * sl_block) / split_act
+
+    # up/gate input: [t, d_model], output: [t, i_block]
+    up_in = t * d_model * data_bytes
+    up_out = t * i_block * data_bytes
+    up_w = _weights_vtcm(d_model, i_block, data_bytes=data_bytes, split_weights=split_w_up_gate)
+    up = up_in + up_out + up_w
+
+    gate_in = up_in
+    gate_out = up_out
+    gate_w = up_w
+    gate = gate_in + gate_out + gate_w
+
+    # down input: [t, i_block], output: [t, d_model]
+    down_in = t * i_block * data_bytes
+    down_out = t * d_model * data_bytes
+    down_w = _weights_vtcm(i_block, d_model, data_bytes=data_bytes, split_weights=split_w_down)
+    down = down_in + down_out + down_w
+
+    return {"up_proj": up, "gate_proj": gate, "down_proj": down}
+
+
+def ffn_configurator(
+    bs: int,
+    seq_len: int,
+    d_model: int,
+    intermediate: int,
+    num_socs: int,
+    num_nsps: int,
+    data_bytes: int,
+) -> Dict[str, Any]:
+    num_token_blocks_list = block_candidates_generator(seq_len)
+    num_weights_blocks_list = block_candidates_generator(intermediate)
+
+    best_config = {
+        "num_token_blocks": seq_len,
+        "num_weights_blocks": intermediate,
+        "split_for_soc": None,
+        "split_for_nsp": None,
+        "vtcm_footprint": None,
+    }
+
+    for num_token_blocks in num_token_blocks_list:
+        sl_block = seq_len / num_token_blocks
+
+        for num_weights_blocks in num_weights_blocks_list:
+            i_block = intermediate / num_weights_blocks
+
+            # Strategy 1: split weights across all (soc*nsp)
+            footprints = _op_footprints(
+                bs=bs,
+                d_model=d_model,
+                data_bytes=data_bytes,
+                sl_block=sl_block,
+                i_block=i_block,
+                split_act=1,
+                split_w_up_gate=num_socs * num_nsps,
+                split_w_down=num_socs * num_nsps,
+            )
+            if all(v < VTCM_SIZE_THRESHOLD for v in footprints.values()):
+                if (
+                    best_config["num_token_blocks"] * best_config["num_weights_blocks"]
+                    > num_token_blocks * num_weights_blocks
+                ):
+                    best_config.update(
+                        {
+                            "num_token_blocks": num_token_blocks,
+                            "num_weights_blocks": num_weights_blocks,
+                            "split_for_soc": "weights",
+                            "split_for_nsp": "weights",
+                            "vtcm_footprint": max(footprints.values()),
+                        }
+                    )
+                    break
+
+            # Strategy 2: split weights across NSP, activations across SOC
+            footprints = _op_footprints(
+                bs=bs,
+                d_model=d_model,
+                data_bytes=data_bytes,
+                sl_block=sl_block,
+                i_block=i_block,
+                split_act=num_socs,
+                split_w_up_gate=num_nsps,
+                split_w_down=num_nsps,
+            )
+            if all(v < VTCM_SIZE_THRESHOLD for v in footprints.values()):
+                if (
+                    best_config["num_token_blocks"] * best_config["num_weights_blocks"]
+                    > num_token_blocks * num_weights_blocks
+                ):
+                    best_config.update(
+                        {
+                            "num_token_blocks": num_token_blocks,
+                            "num_weights_blocks": num_weights_blocks,
+                            "split_for_soc": "activation",
+                            "split_for_nsp": "weights",
+                            "vtcm_footprint": max(footprints.values()),
+                        }
+                    )
+                    break
+
+            # Strategy 3: split activations across all (soc*nsp)
+            footprints = _op_footprints(
+                bs=bs,
+                d_model=d_model,
+                data_bytes=data_bytes,
+                sl_block=sl_block,
+                i_block=i_block,
+                split_act=num_socs * num_nsps,
+                split_w_up_gate=1,
+                split_w_down=1,
+            )
+            if all(v < VTCM_SIZE_THRESHOLD for v in footprints.values()):
+                if (
+                    best_config["num_token_blocks"] * best_config["num_weights_blocks"]
+                    > num_token_blocks * num_weights_blocks
+                ):
+                    best_config.update(
+                        {
+                            "num_token_blocks": num_token_blocks,
+                            "num_weights_blocks": num_weights_blocks,
+                            "split_for_soc": "activation",
+                            "split_for_nsp": "activation",
+                            "vtcm_footprint": max(footprints.values()),
+                        }
+                    )
+                    break
+
+    return best_config
+
+
 def build_transformer_blocking_config(
     model_config: Any,
     pipeline_config: Optional[Any] = None,
@@ -252,9 +519,9 @@ def build_transformer_blocking_config(
     seq_len: Optional[int] = None,
     bs: Optional[int] = 1,
     compile_config: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Any]:
+) -> AttentionBlockingConfig:
     """
-    Build blocking configuration based on model config + pipeline compile config.
+    Build attention blocking configuration based on model config + pipeline compile config.
     """
     if ctx_len is None:
         ctx_len = seq_len
@@ -302,6 +569,66 @@ def build_transformer_blocking_config(
     )
 
 
+def build_ffn_blocking_config(
+    model_config: Any,
+    pipeline_config: Optional[Any] = None,
+    module_name: str = "transformer",
+    blocking_mode: Optional[str] = None,
+    ctx_len: Optional[int] = None,
+    seq_len: Optional[int] = None,
+    bs: Optional[int] = 1,
+    compile_config: Optional[Dict[str, Any]] = None,
+) -> Tuple[FFNBlockingConfig, Dict[str, Any]]:
+    """
+    Auto-derive FFN blocking config (and any required compiler flags) from model + compile config.
+
+    Returns:
+        (FFNBlockingConfig, compiler_flags)
+    """
+    if ctx_len is None:
+        ctx_len = seq_len
+
+    if seq_len is None and ctx_len is None:
+        return FFNBlockingConfig(mode=FFNBlockingMode.NONE), {}
+
+    # we only block on text configs in the case of VLMs
+    if hasattr(model_config, "text_config"):
+        model_config = model_config.text_config
+
+    d_model = require_value(get_attr_or_key(model_config, ("hidden_size", "d_model", "model_dim")), "hidden size")
+    intermediate = require_value(
+        get_attr_or_key(model_config, ("intermediate_size", "ffn_dim", "mlp_dim")), "intermediate size"
+    )
+
+    num_socs = int(compile_config.get("mdp_ts_num_devices", 1))
+    num_nsps = int(compile_config.get("aic_num_cores", 1))
+    data_bytes = _infer_data_bytes(compile_config)
+
+    ffn_cfg = ffn_configurator(
+        bs=int(bs),
+        seq_len=int(seq_len),
+        d_model=int(d_model),
+        intermediate=int(intermediate),
+        num_socs=int(num_socs),
+        num_nsps=int(num_nsps),
+        data_bytes=int(data_bytes),
+    )
+
+    requested_mode = str(blocking_mode or "tw").lower()
+    effective_mode = resolve_ffn_blocking_mode(ffn_cfg, requested_mode)
+
+    ffn_blocking_config = FFNBlockingConfig(
+        mode=FFNBlockingMode(effective_mode) if effective_mode != "" else FFNBlockingMode.NONE
+    )
+
+    if "t" in effective_mode:
+        ffn_blocking_config.num_token_blocks = int(ffn_cfg["num_token_blocks"])
+    if "w" in effective_mode:
+        ffn_blocking_config.num_weights_blocks = int(ffn_cfg["num_weights_blocks"])
+
+    return ffn_blocking_config
+
+
 def build_transformer_blocking_config_for_transform(
     model_config: Any,
     ctx_len: Optional[int] = None,
@@ -317,6 +644,7 @@ def build_transformer_blocking_config_for_transform(
         blocking_mode = BlockingMode.HQKV
     enable_blocking = False if not qaic_config else qaic_config.get("enable_blocking", False)
 
+    # ---------------- Attention blocking ----------------
     if qaic_config is None and enable_blocking:
         blocking_config = build_transformer_blocking_config(
             model_config,
@@ -360,4 +688,38 @@ def build_transformer_blocking_config_for_transform(
         if qaic_config.get("skip_kv", False) and enable_blocking:
             blocking_config.skip_kv = qaic_config.get("skip_kv")
 
-    return blocking_config
+    # ---------------- FFN blocking ----------------
+    if qaic_config:
+        ffn_blocking_mode = FFNBlockingMode(qaic_config.get("ffn_blocking_mode", "tw"))
+    else:
+        ffn_blocking_mode = FFNBlockingMode.TW
+    enable_ffn_blocking = False if not qaic_config else qaic_config.get("enable_ffn_blocking", False)
+
+    if not enable_ffn_blocking:
+        ffn_blocking_config = None
+    else:
+        ffn_blocking_config = FFNBlockingConfig()
+        mode_from_config = ""
+
+        if qaic_config is not None:
+            if qaic_config.get("num_token_blocks", False) and enable_ffn_blocking and "t" in ffn_blocking_mode:
+                ffn_blocking_config.num_token_blocks = _get_valid_num_blocks(qaic_config, "num_token_blocks")
+                mode_from_config += "t"
+            if qaic_config.get("num_weight_blocks", False) and enable_ffn_blocking and "w" in ffn_blocking_mode:
+                ffn_blocking_config.num_weight_blocks = _get_valid_num_blocks(qaic_config, "num_weight_blocks")
+                mode_from_config += "w"
+            # check if qaic config did not provide any blocking details
+            if mode_from_config == "":
+                # Auto derive from constraints (and collect compiler flags)
+                ffn_blocking_config = build_ffn_blocking_config(
+                    model_config,
+                    blocking_mode=str(ffn_blocking_mode).lower(),
+                    ctx_len=ctx_len,
+                    seq_len=seq_len,
+                    bs=bs,
+                    compile_config={"mdp_ts_num_devices": num_devices, **compile_options},
+                )
+            else:
+                ffn_blocking_config.mode = FFNBlockingMode(mode_from_config)
+
+    return {"attention": blocking_config, "ffn": ffn_blocking_config}

--- a/QEfficient/blocking/blocking_configurator.py
+++ b/QEfficient/blocking/blocking_configurator.py
@@ -85,12 +85,12 @@ def resolve_ffn_blocking_mode(ffn_cfg: Dict[str, Any], requested_mode: str) -> s
         return ""
 
     num_token_blocks = int(ffn_cfg.get("num_token_blocks") or 1)
-    num_weights_blocks = int(ffn_cfg.get("num_weights_blocks") or 1)
+    num_weight_blocks = int(ffn_cfg.get("num_weight_blocks") or 1)
 
     effective = ""
     if "t" in mode and num_token_blocks > 1:
         effective += "t"
-    if "w" in mode and num_weights_blocks > 1:
+    if "w" in mode and num_weight_blocks > 1:
         effective += "w"
     return effective
 
@@ -268,7 +268,7 @@ def attention_configurator(
 
 def check_ffn_block_config(
     num_token_blocks: int,
-    num_weights_blocks: int,
+    num_weight_blocks: int,
     *,
     model_config: Any,
     specializations: Optional[List[Dict[str, int]]],
@@ -283,7 +283,7 @@ def check_ffn_block_config(
 
     Args:
         num_token_blocks: number of token blocks (> 0)
-        num_weights_blocks: number of weight blocks (> 0)
+        num_weight_blocks: number of weight blocks (> 0)
         model_config: model config object/dict (for VLMs, pass text_config)
         specializations: specialization list; uses first entry for bs/seq_len
         compile_config: compile options dict (expects `mdp_ts_num_devices`, `aic_num_cores`,
@@ -312,7 +312,7 @@ def check_ffn_block_config(
     data_bytes = _infer_data_bytes(compile_config)
 
     sl_block = int(seq_len) / int(num_token_blocks)
-    i_block = int(intermediate) / int(num_weights_blocks)
+    i_block = int(intermediate) / int(num_weight_blocks)
 
     # 1) split weights across all (soc*nsp)
     footprints = _op_footprints(
@@ -410,11 +410,11 @@ def ffn_configurator(
     data_bytes: int,
 ) -> Dict[str, Any]:
     num_token_blocks_list = block_candidates_generator(seq_len)
-    num_weights_blocks_list = block_candidates_generator(intermediate)
+    num_weight_blocks_list = block_candidates_generator(intermediate)
 
     best_config = {
         "num_token_blocks": seq_len,
-        "num_weights_blocks": intermediate,
+        "num_weight_blocks": intermediate,
         "split_for_soc": None,
         "split_for_nsp": None,
         "vtcm_footprint": None,
@@ -423,8 +423,8 @@ def ffn_configurator(
     for num_token_blocks in num_token_blocks_list:
         sl_block = seq_len / num_token_blocks
 
-        for num_weights_blocks in num_weights_blocks_list:
-            i_block = intermediate / num_weights_blocks
+        for num_weight_blocks in num_weight_blocks_list:
+            i_block = intermediate / num_weight_blocks
 
             # Strategy 1: split weights across all (soc*nsp)
             footprints = _op_footprints(
@@ -439,13 +439,13 @@ def ffn_configurator(
             )
             if all(v < VTCM_SIZE_THRESHOLD for v in footprints.values()):
                 if (
-                    best_config["num_token_blocks"] * best_config["num_weights_blocks"]
-                    > num_token_blocks * num_weights_blocks
+                    best_config["num_token_blocks"] * best_config["num_weight_blocks"]
+                    > num_token_blocks * num_weight_blocks
                 ):
                     best_config.update(
                         {
                             "num_token_blocks": num_token_blocks,
-                            "num_weights_blocks": num_weights_blocks,
+                            "num_weights_block": num_weight_blocks,
                             "split_for_soc": "weights",
                             "split_for_nsp": "weights",
                             "vtcm_footprint": max(footprints.values()),
@@ -466,13 +466,13 @@ def ffn_configurator(
             )
             if all(v < VTCM_SIZE_THRESHOLD for v in footprints.values()):
                 if (
-                    best_config["num_token_blocks"] * best_config["num_weights_blocks"]
-                    > num_token_blocks * num_weights_blocks
+                    best_config["num_token_blocks"] * best_config["num_weight_blocks"]
+                    > num_token_blocks * num_weight_blocks
                 ):
                     best_config.update(
                         {
                             "num_token_blocks": num_token_blocks,
-                            "num_weights_blocks": num_weights_blocks,
+                            "num_weight_blocks": num_weight_blocks,
                             "split_for_soc": "activation",
                             "split_for_nsp": "weights",
                             "vtcm_footprint": max(footprints.values()),
@@ -493,13 +493,13 @@ def ffn_configurator(
             )
             if all(v < VTCM_SIZE_THRESHOLD for v in footprints.values()):
                 if (
-                    best_config["num_token_blocks"] * best_config["num_weights_blocks"]
-                    > num_token_blocks * num_weights_blocks
+                    best_config["num_token_blocks"] * best_config["num_weight_blocks"]
+                    > num_token_blocks * num_weight_blocks
                 ):
                     best_config.update(
                         {
                             "num_token_blocks": num_token_blocks,
-                            "num_weights_blocks": num_weights_blocks,
+                            "num_weight_blocks": num_weight_blocks,
                             "split_for_soc": "activation",
                             "split_for_nsp": "activation",
                             "vtcm_footprint": max(footprints.values()),
@@ -624,7 +624,7 @@ def build_ffn_blocking_config(
     if "t" in effective_mode:
         ffn_blocking_config.num_token_blocks = int(ffn_cfg["num_token_blocks"])
     if "w" in effective_mode:
-        ffn_blocking_config.num_weights_blocks = int(ffn_cfg["num_weights_blocks"])
+        ffn_blocking_config.num_weight_blocks = int(ffn_cfg["num_weight_blocks"])
 
     return ffn_blocking_config
 

--- a/QEfficient/blocking/ffn_blocking.py
+++ b/QEfficient/blocking/ffn_blocking.py
@@ -1,0 +1,93 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+"""
+FFN blocking utilities.
+
+This mirrors the attention blocking structure:
+- A small dataclass config + enum describing the blocking mode.
+- A generic interface used by modeling code to dispatch to a blocked FFN forward.
+
+FFN blocking modes:
+- ""   : no blocking (default)
+- "t"  : token blocking (split seq_len into blocks, full hidden intermediate each block)
+- "w"  : weight blocking (split intermediate hidden dim into blocks, full seq_len)
+- "tw" : both token + weight blocking
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Dict, Optional
+
+import torch
+from torch import nn
+
+from QEfficient.blocking.blocked_ffn_forwards import (
+    blocked_tokens_ffn_forward,
+    blocked_tokens_weights_ffn_forward,
+    blocked_weights_ffn_forward,
+)
+
+
+class FFNBlockingMode(str, Enum):
+    NONE = ""
+    T = "t"
+    W = "w"
+    TW = "tw"
+
+
+@dataclass
+class FFNBlockingConfig:
+    mode: FFNBlockingMode = FFNBlockingMode.NONE
+    num_token_blocks: Optional[int] = None
+    num_weight_blocks: Optional[int] = None
+
+
+_STRATEGIES: Dict[FFNBlockingMode, Callable[..., torch.Tensor]] = {
+    FFNBlockingMode.T: blocked_tokens_ffn_forward,
+    FFNBlockingMode.W: blocked_weights_ffn_forward,
+    FFNBlockingMode.TW: blocked_tokens_weights_ffn_forward,
+}
+
+
+def generic_blocked_ffn_interface(
+    *,
+    w1: nn.Module,
+    w2: nn.Module,
+    x: torch.Tensor,
+    blocking_config: FFNBlockingConfig,
+    w3: Optional[nn.Module] = None,
+    dropout: Optional[float] = None,
+    activation_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
+    **kwargs,
+) -> torch.Tensor:
+    """
+    Generic interface used by modeling files to route through a selected FFN blocking strategy.
+    """
+    if blocking_config is None or blocking_config.mode in (None, FFNBlockingMode.NONE, ""):
+        act = activation_fn if activation_fn is not None else torch.nn.functional.silu
+        # llama style mlp has up_proj, down_proj and gate_proj
+        if w3 is not None:
+            return w2(act(w1(x)) * w3(x))
+        # gpt2 style mlp has gate_proj and down_proj
+        else:
+            return w2(act(w1(x)))
+
+    strategy = _STRATEGIES.get(blocking_config.mode)
+    if strategy is None:
+        raise ValueError(f"Unsupported FFN blocking mode: {blocking_config.mode}")
+
+    return strategy(
+        w1=w1,
+        w2=w2,
+        w3=w3,
+        x=x,
+        num_token_blocks=blocking_config.num_token_blocks,
+        num_weight_blocks=blocking_config.num_weight_blocks,
+        activation_fn=activation_fn,
+    )

--- a/QEfficient/transformers/models/gemma/modeling_gemma.py
+++ b/QEfficient/transformers/models/gemma/modeling_gemma.py
@@ -31,6 +31,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
@@ -235,7 +236,22 @@ class QEffGemmaDecoderLayer(GemmaDecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            hidden_states = generic_blocked_ffn_interface(
+                w1=self.mlp.gate_proj,
+                w2=self.mlp.down_proj,
+                w3=self.mlp.up_proj,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+                activation_fn=self.mlp.act_fn,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
         hidden_states = residual + hidden_states
 
         return hidden_states

--- a/QEfficient/transformers/models/gemma2/modeling_gemma2.py
+++ b/QEfficient/transformers/models/gemma2/modeling_gemma2.py
@@ -32,6 +32,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 
 # from transformers.utils import is_torchdynamo_compiling
@@ -247,7 +248,21 @@ class QEffGemma2DecoderLayer(Gemma2DecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.pre_feedforward_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            hidden_states = generic_blocked_ffn_interface(
+                w1=self.mlp.gate_proj,
+                w2=self.mlp.down_proj,
+                w3=self.mlp.up_proj,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
         hidden_states = self.post_feedforward_layernorm(hidden_states)
         hidden_states = residual + hidden_states
 

--- a/QEfficient/transformers/models/granite/modeling_granite.py
+++ b/QEfficient/transformers/models/granite/modeling_granite.py
@@ -31,6 +31,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
@@ -236,7 +237,21 @@ class QEffGraniteDecoderLayer(GraniteDecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            hidden_states = generic_blocked_ffn_interface(
+                w1=self.mlp.gate_proj,
+                w2=self.mlp.down_proj,
+                w3=self.mlp.up_proj,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
         hidden_states = residual + hidden_states * self.residual_multiplier  # main diff with Llama
 
         outputs = (hidden_states,)

--- a/QEfficient/transformers/models/llama/modeling_llama.py
+++ b/QEfficient/transformers/models/llama/modeling_llama.py
@@ -31,6 +31,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
@@ -225,7 +226,21 @@ class QEffLlamaDecoderLayer(LlamaDecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            hidden_states = generic_blocked_ffn_interface(
+                w1=self.mlp.gate_proj,
+                w2=self.mlp.down_proj,
+                w3=self.mlp.up_proj,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
         hidden_states = residual + hidden_states
 
         return hidden_states

--- a/QEfficient/transformers/models/mistral/modeling_mistral.py
+++ b/QEfficient/transformers/models/mistral/modeling_mistral.py
@@ -34,6 +34,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
@@ -249,7 +250,21 @@ class QEffMistralDecoderLayer(MistralDecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            hidden_states = generic_blocked_ffn_interface(
+                w1=self.mlp.gate_proj,
+                w2=self.mlp.down_proj,
+                w3=self.mlp.up_proj,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
         hidden_states = residual + hidden_states
 
         return hidden_states

--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -1159,3 +1159,29 @@ class BlockingAttentionTransform:
             elif module.__class__.__name__.endswith("Attention") and type(module) not in supported_attention_classes:
                 warnings.warn(f"Blocking is not yet supported for {type(module)}.")
         return model, transformed
+
+
+class BlockingFFNTransform:
+    """
+    Attach FFN blocking config to supported decoder layers.
+
+    Reference: QEffLlamaDecoderLayer.forward reads `self.ffn_blocking_config` and routes
+    through `generic_blocked_ffn_interface(...)` when enabled.
+    """
+
+    _skip_classes = {}
+
+    @classmethod
+    def apply(cls, model: nn.Module, ffn_blocking_config) -> Tuple[nn.Module, bool]:
+        transformed = False
+
+        for module in model.modules():
+            if type(module) in cls._skip_classes:
+                warnings.warn(f"FFN blocking is not yet supported for {type(module)}.")
+                continue
+
+            if module.__class__.__name__.endswith("DecoderLayer"):
+                module.ffn_blocking_config = ffn_blocking_config
+                transformed = True
+
+        return model, transformed

--- a/QEfficient/transformers/models/qwen2/modeling_qwen2.py
+++ b/QEfficient/transformers/models/qwen2/modeling_qwen2.py
@@ -34,6 +34,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
@@ -251,7 +252,21 @@ class QEffQwen2DecoderLayer(Qwen2DecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            hidden_states = generic_blocked_ffn_interface(
+                w1=self.mlp.gate_proj,
+                w2=self.mlp.down_proj,
+                w3=self.mlp.up_proj,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
         hidden_states = residual + hidden_states
 
         return hidden_states

--- a/QEfficient/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/QEfficient/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -36,6 +36,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 
 # from transformers import Qw
@@ -526,7 +527,21 @@ class QEffQwen2_5_VLDecoderLayer(Qwen2_5_VLDecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            hidden_states = generic_blocked_ffn_interface(
+                w1=self.mlp.gate_proj,
+                w2=self.mlp.down_proj,
+                w3=self.mlp.up_proj,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
         hidden_states = residual + hidden_states
 
         outputs = (hidden_states,)

--- a/QEfficient/transformers/models/qwen3/modeling_qwen3.py
+++ b/QEfficient/transformers/models/qwen3/modeling_qwen3.py
@@ -34,6 +34,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
@@ -253,7 +254,21 @@ class QEffQwen3DecoderLayer(Qwen3DecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            hidden_states = generic_blocked_ffn_interface(
+                w1=self.mlp.gate_proj,
+                w2=self.mlp.down_proj,
+                w3=self.mlp.up_proj,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
         hidden_states = residual + hidden_states
 
         return hidden_states

--- a/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -36,6 +36,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils import constants
@@ -501,8 +502,23 @@ class QEffQwen3VLTextDecoderLayer(Qwen3VLTextDecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states[0]
+
+        # Qwen3-VL text MLP returns a tuple; element 0 is the FFN output.
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            ffn_out = generic_blocked_ffn_interface(
+                w1=self.mlp.gate_proj,
+                w2=self.mlp.down_proj,
+                w3=self.mlp.up_proj,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+            )
+        else:
+            ffn_out = self.mlp(hidden_states)[0]
+
+        hidden_states = residual + ffn_out
 
         outputs = (hidden_states,)
 

--- a/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -503,12 +503,11 @@ class QEffQwen3VLTextDecoderLayer(Qwen3VLTextDecoderLayer):
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
 
-        # Qwen3-VL text MLP returns a tuple; element 0 is the FFN output.
         ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
         use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
 
         if use_ffn_blocking:
-            ffn_out = generic_blocked_ffn_interface(
+            hidden_states = generic_blocked_ffn_interface(
                 w1=self.mlp.gate_proj,
                 w2=self.mlp.down_proj,
                 w3=self.mlp.up_proj,
@@ -516,9 +515,9 @@ class QEffQwen3VLTextDecoderLayer(Qwen3VLTextDecoderLayer):
                 blocking_config=ffn_blocking_config,
             )
         else:
-            ffn_out = self.mlp(hidden_states)[0]
+            hidden_states = self.mlp(hidden_states)
 
-        hidden_states = residual + ffn_out
+        hidden_states = residual + hidden_states
 
         outputs = (hidden_states,)
 

--- a/QEfficient/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/QEfficient/transformers/models/starcoder2/modeling_starcoder2.py
@@ -31,6 +31,7 @@ from QEfficient.blocking.attention_blocking import (
     generic_blocked_attention_interface,
     past_key_value_update,
 )
+from QEfficient.blocking.ffn_blocking import FFNBlockingConfig, FFNBlockingMode, generic_blocked_ffn_interface
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
@@ -197,7 +198,22 @@ class QEFFStarcoder2DecoderLayer(Starcoder2DecoderLayer):
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
+
+        ffn_blocking_config = getattr(self, "ffn_blocking_config", FFNBlockingConfig())
+        use_ffn_blocking = ffn_blocking_config is not None and ffn_blocking_config.mode != FFNBlockingMode.NONE
+
+        if use_ffn_blocking:
+            hidden_states = generic_blocked_ffn_interface(
+                w1=self.mlp.c_fc,
+                w2=self.mlp.c_proj,
+                w3=None,
+                x=hidden_states,
+                blocking_config=ffn_blocking_config,
+                activation_fn=self.mlp.act,
+            )
+        else:
+            hidden_states = self.mlp(hidden_states)
+
         hidden_states = residual + hidden_states
 
         return hidden_states

--- a/tests/transformers/models/causal_lm_models/test_causal_lm_ffn_blocking.py
+++ b/tests/transformers/models/causal_lm_models/test_causal_lm_ffn_blocking.py
@@ -1,0 +1,498 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+import json
+import os
+
+import pytest
+from transformers import AutoConfig
+
+from QEfficient.utils.test_utils import ModelConfig
+
+from .check_causal_models import (
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100,
+    get_custom_n_layers,
+)
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "../../../configs/causal_model_configs.json")
+with open(CONFIG_PATH, "r") as f:
+    config_data = json.load(f)
+    blockedKV_models = config_data["blockedKV_causal_lm_models"]
+test_models_blockedKV = [model["model_name"] for model in blockedKV_models]
+model_config_dict = {model["model_name"]: model for model in blockedKV_models}
+
+
+@pytest.mark.full_layers
+@pytest.mark.llm_model
+@pytest.mark.on_qaic
+@pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
+def test_full_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
+    # Skip MoE models: FFN blocking covers dense FFNs, not MoE blocks.
+    hf_config = AutoConfig.from_pretrained(
+        model_name,
+        trust_remote_code=model_name in ModelConfig.EXTERNAL_MODELS,
+    )
+    if getattr(hf_config, "num_local_experts", 1) not in (None, 0, 1) or getattr(hf_config, "num_experts", 1) not in (
+        None,
+        0,
+        1,
+    ):
+        pytest.skip(f"Skipping MoE model {model_name} for FFN blocking test")
+
+    # FFN blocking sizes
+    NUM_TOKEN_BLOCKS = 2
+    NUM_WEIGHT_BLOCKS = 2
+
+    # Attention blocking sizes (for the combined case).
+    HEAD_BLOCK_SIZE = 8
+    NUM_KV_BLOCKS = 2
+    NUM_Q_BLOCKS = 2
+
+    # token-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="t", num_token_blocks=NUM_TOKEN_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, qaic_config=qaic_config, manual_cleanup=manual_cleanup, num_devices=4
+    )
+
+    # weight-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="w", num_weight_blocks=NUM_WEIGHT_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, qaic_config=qaic_config, manual_cleanup=manual_cleanup, num_devices=4
+    )
+
+    # token+weight FFN blocking
+    qaic_config = dict(
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, qaic_config=qaic_config, manual_cleanup=manual_cleanup, num_devices=4
+    )
+
+    # token+weight FFN blocking + HQKV attention blocking
+    qaic_config = dict(
+        enable_blocking=True,
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+        blocking_mode="hqkv",
+        head_block_size=HEAD_BLOCK_SIZE,
+        num_kv_blocks=NUM_KV_BLOCKS,
+        num_q_blocks=NUM_Q_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, qaic_config=qaic_config, manual_cleanup=manual_cleanup, num_devices=4
+    )
+
+
+@pytest.mark.few_layers
+@pytest.mark.llm_model
+@pytest.mark.on_qaic
+@pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
+def test_few_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
+    # Skip MoE models: FFN blocking covers dense FFNs, not MoE blocks.
+    hf_config = AutoConfig.from_pretrained(
+        model_name,
+        trust_remote_code=model_name in ModelConfig.EXTERNAL_MODELS,
+    )
+    if getattr(hf_config, "num_local_experts", 1) not in (None, 0, 1) or getattr(hf_config, "num_experts", 1) not in (
+        None,
+        0,
+        1,
+    ):
+        pytest.skip(f"Skipping MoE model {model_name} for FFN blocking test")
+
+    # FFN blocking sizes
+    NUM_TOKEN_BLOCKS = 2
+    NUM_WEIGHT_BLOCKS = 2
+
+    # Attention blocking sizes (for the combined case).
+    HEAD_BLOCK_SIZE = 8
+    NUM_KV_BLOCKS = 2
+    NUM_Q_BLOCKS = 2
+
+    n_layer = get_custom_n_layers(model_name)
+
+    # token-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="t", num_token_blocks=NUM_TOKEN_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, n_layer=n_layer, qaic_config=qaic_config, manual_cleanup=manual_cleanup
+    )
+
+    # weight-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="w", num_weight_blocks=NUM_WEIGHT_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, n_layer=n_layer, qaic_config=qaic_config, manual_cleanup=manual_cleanup
+    )
+
+    # token+weight FFN blocking
+    qaic_config = dict(
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, n_layer=n_layer, qaic_config=qaic_config, manual_cleanup=manual_cleanup
+    )
+
+    # token+weight FFN blocking + HQKV attention blocking
+    qaic_config = dict(
+        enable_blocking=True,
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+        blocking_mode="hqkv",
+        head_block_size=HEAD_BLOCK_SIZE,
+        num_kv_blocks=NUM_KV_BLOCKS,
+        num_q_blocks=NUM_Q_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, n_layer=n_layer, qaic_config=qaic_config, manual_cleanup=manual_cleanup
+    )
+
+
+@pytest.mark.dummy_layers
+@pytest.mark.llm_model
+@pytest.mark.on_qaic
+@pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
+def test_dummy_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
+    # Skip MoE models: FFN blocking covers dense FFNs, not MoE blocks.
+    hf_config = AutoConfig.from_pretrained(
+        model_name,
+        trust_remote_code=model_name in ModelConfig.EXTERNAL_MODELS,
+    )
+    if getattr(hf_config, "num_local_experts", 1) not in (None, 0, 1) or getattr(hf_config, "num_experts", 1) not in (
+        None,
+        0,
+        1,
+    ):
+        pytest.skip(f"Skipping MoE model {model_name} for FFN blocking test")
+
+    hf_config = AutoConfig.from_pretrained(
+        model_name,
+        trust_remote_code=model_name in ModelConfig.EXTERNAL_MODELS,
+        **model_config_dict[model_name].get("additional_params", {}),
+    )
+    n_layer = -1
+    if model_name in ModelConfig.QUANTIZED_MODELS:
+        n_layer = get_custom_n_layers(model_name)
+        hf_config = None
+
+    # FFN blocking sizes
+    NUM_TOKEN_BLOCKS = 2
+    NUM_WEIGHT_BLOCKS = 2
+
+    # Attention blocking sizes (for the combined case).
+    HEAD_BLOCK_SIZE = 8
+    NUM_KV_BLOCKS = 2
+    NUM_Q_BLOCKS = 2
+
+    n_layer = get_custom_n_layers(model_name)
+
+    # token-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="t", num_token_blocks=NUM_TOKEN_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, n_layer=n_layer, qaic_config=qaic_config, config=hf_config, manual_cleanup=manual_cleanup
+    )
+
+    # weight-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="w", num_weight_blocks=NUM_WEIGHT_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, n_layer=n_layer, qaic_config=qaic_config, config=hf_config, manual_cleanup=manual_cleanup
+    )
+
+    # token+weight FFN blocking
+    qaic_config = dict(
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, n_layer=n_layer, qaic_config=qaic_config, config=hf_config, manual_cleanup=manual_cleanup
+    )
+
+    # token+weight FFN blocking + HQKV attention blocking
+    qaic_config = dict(
+        enable_blocking=True,
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+        blocking_mode="hqkv",
+        head_block_size=HEAD_BLOCK_SIZE,
+        num_kv_blocks=NUM_KV_BLOCKS,
+        num_q_blocks=NUM_Q_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, n_layer=n_layer, qaic_config=qaic_config, config=hf_config, manual_cleanup=manual_cleanup
+    )
+
+
+@pytest.mark.full_layers
+@pytest.mark.llm_model
+@pytest.mark.on_qaic
+@pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
+def test_full_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cleanup):
+    # Skip MoE models: FFN blocking covers dense FFNs, not MoE blocks.
+    hf_config = AutoConfig.from_pretrained(
+        model_name,
+        trust_remote_code=model_name in ModelConfig.EXTERNAL_MODELS,
+    )
+    if getattr(hf_config, "num_local_experts", 1) not in (None, 0, 1) or getattr(hf_config, "num_experts", 1) not in (
+        None,
+        0,
+        1,
+    ):
+        pytest.skip(f"Skipping MoE model {model_name} for FFN blocking test")
+
+    # FFN blocking sizes
+    NUM_TOKEN_BLOCKS = 2
+    NUM_WEIGHT_BLOCKS = 2
+
+    # Attention blocking sizes (for the combined case).
+    HEAD_BLOCK_SIZE = 8
+    NUM_KV_BLOCKS = 2
+    NUM_Q_BLOCKS = 2
+
+    # token-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="t", num_token_blocks=NUM_TOKEN_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        qaic_config=qaic_config,
+        manual_cleanup=manual_cleanup,
+        continuous_batching=True,
+        num_devices=4,
+    )
+
+    # weight-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="w", num_weight_blocks=NUM_WEIGHT_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        qaic_config=qaic_config,
+        manual_cleanup=manual_cleanup,
+        continuous_batching=True,
+        num_devices=4,
+    )
+
+    # token+weight FFN blocking
+    qaic_config = dict(
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        qaic_config=qaic_config,
+        manual_cleanup=manual_cleanup,
+        continuous_batching=True,
+        num_devices=4,
+    )
+
+    # token+weight FFN blocking + HQKV attention blocking
+    qaic_config = dict(
+        enable_blocking=True,
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+        blocking_mode="hqkv",
+        head_block_size=HEAD_BLOCK_SIZE,
+        num_kv_blocks=NUM_KV_BLOCKS,
+        num_q_blocks=NUM_Q_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, qaic_config=qaic_config, manual_cleanup=manual_cleanup, num_devices=4
+    )
+
+
+@pytest.mark.few_layers
+@pytest.mark.llm_model
+@pytest.mark.on_qaic
+@pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
+def test_few_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cleanup):
+    # Skip MoE models: FFN blocking covers dense FFNs, not MoE blocks.
+    hf_config = AutoConfig.from_pretrained(
+        model_name,
+        trust_remote_code=model_name in ModelConfig.EXTERNAL_MODELS,
+    )
+    if getattr(hf_config, "num_local_experts", 1) not in (None, 0, 1) or getattr(hf_config, "num_experts", 1) not in (
+        None,
+        0,
+        1,
+    ):
+        pytest.skip(f"Skipping MoE model {model_name} for FFN blocking test")
+
+    # FFN blocking sizes
+    NUM_TOKEN_BLOCKS = 2
+    NUM_WEIGHT_BLOCKS = 2
+
+    # Attention blocking sizes (for the combined case).
+    HEAD_BLOCK_SIZE = 8
+    NUM_KV_BLOCKS = 2
+    NUM_Q_BLOCKS = 2
+
+    n_layer = get_custom_n_layers(model_name)
+
+    # token-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="t", num_token_blocks=NUM_TOKEN_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        n_layer=n_layer,
+        qaic_config=qaic_config,
+        continuous_batching=True,
+        manual_cleanup=manual_cleanup,
+    )
+
+    # weight-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="w", num_weight_blocks=NUM_WEIGHT_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        n_layer=n_layer,
+        qaic_config=qaic_config,
+        continuous_batching=True,
+        manual_cleanup=manual_cleanup,
+    )
+
+    # token+weight FFN blocking
+    qaic_config = dict(
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        n_layer=n_layer,
+        qaic_config=qaic_config,
+        continuous_batching=True,
+        manual_cleanup=manual_cleanup,
+    )
+
+    # token+weight FFN blocking + HQKV attention blocking
+    qaic_config = dict(
+        enable_blocking=True,
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+        blocking_mode="hqkv",
+        head_block_size=HEAD_BLOCK_SIZE,
+        num_kv_blocks=NUM_KV_BLOCKS,
+        num_q_blocks=NUM_Q_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        n_layer=n_layer,
+        qaic_config=qaic_config,
+        continuous_batching=True,
+        manual_cleanup=manual_cleanup,
+    )
+
+
+@pytest.mark.dummy_layers
+@pytest.mark.llm_model
+@pytest.mark.on_qaic
+@pytest.mark.parametrize("model_name", test_models_blockedKV[:1])
+def test_dummy_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100_CB(model_name, manual_cleanup):
+    # Skip MoE models: FFN blocking covers dense FFNs, not MoE blocks.
+    hf_config = AutoConfig.from_pretrained(
+        model_name,
+        trust_remote_code=model_name in ModelConfig.EXTERNAL_MODELS,
+    )
+    if getattr(hf_config, "num_local_experts", 1) not in (None, 0, 1) or getattr(hf_config, "num_experts", 1) not in (
+        None,
+        0,
+        1,
+    ):
+        pytest.skip(f"Skipping MoE model {model_name} for FFN blocking test")
+
+    hf_config = AutoConfig.from_pretrained(
+        model_name,
+        trust_remote_code=model_name in ModelConfig.EXTERNAL_MODELS,
+        **model_config_dict[model_name].get("additional_params", {}),
+    )
+    n_layer = -1
+    if model_name in ModelConfig.QUANTIZED_MODELS:
+        n_layer = get_custom_n_layers(model_name)
+        hf_config = None
+
+    # FFN blocking sizes
+    NUM_TOKEN_BLOCKS = 2
+    NUM_WEIGHT_BLOCKS = 2
+
+    # Attention blocking sizes (for the combined case).
+    HEAD_BLOCK_SIZE = 8
+    NUM_KV_BLOCKS = 2
+    NUM_Q_BLOCKS = 2
+
+    n_layer = get_custom_n_layers(model_name)
+
+    # token-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="t", num_token_blocks=NUM_TOKEN_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        n_layer=n_layer,
+        qaic_config=qaic_config,
+        config=hf_config,
+        continuous_batching=True,
+        manual_cleanup=manual_cleanup,
+    )
+
+    # weight-only FFN blocking
+    qaic_config = dict(enable_ffn_blocking=True, ffn_blocking_mode="w", num_weight_blocks=NUM_WEIGHT_BLOCKS)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        n_layer=n_layer,
+        qaic_config=qaic_config,
+        config=hf_config,
+        continuous_batching=True,
+        manual_cleanup=manual_cleanup,
+    )
+
+    # token+weight FFN blocking
+    qaic_config = dict(
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        n_layer=n_layer,
+        qaic_config=qaic_config,
+        config=hf_config,
+        continuous_batching=True,
+        manual_cleanup=manual_cleanup,
+    )
+
+    # token+weight FFN blocking + HQKV attention blocking
+    qaic_config = dict(
+        enable_blocking=True,
+        enable_ffn_blocking=True,
+        ffn_blocking_mode="tw",
+        num_token_blocks=NUM_TOKEN_BLOCKS,
+        num_weight_blocks=NUM_WEIGHT_BLOCKS,
+        blocking_mode="hqkv",
+        head_block_size=HEAD_BLOCK_SIZE,
+        num_kv_blocks=NUM_KV_BLOCKS,
+        num_q_blocks=NUM_Q_BLOCKS,
+    )
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        n_layer=n_layer,
+        qaic_config=qaic_config,
+        config=hf_config,
+        continuous_batching=True,
+        manual_cleanup=manual_cleanup,
+    )


### PR DESCRIPTION
**Summary**

- This PR introduces QEfficient ffn blocking for dense causal language models, adding token and weight blocking strategies for both MLPs with and without up projections. 

**Key Features**

- Token Blocking: Blocked compute over hidden_states sequence length
- Weight Blocking: Blocked compute over MLP weights
- Currently, Configurable via qaic_config (explicit or auto), adjust relevant compiler flags based on ffn blocking strategy as well. 
- Updated performance teams ffn blocking configurator to be calculation based instead of requiring the creation of dummy MLPs. 