### PR TITLE
Enable On Device Sampling for Qwen3ForCausalLM

### DIFF
--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -934,6 +934,7 @@ class SamplerTransform:
         QEffPhi3ForCausalLM,
         QEffQwen2ForCausalLM,
         QEffQwen_2_5_vl_DecoderWrapper,
+        QEffQwen3ForCausalLM,
     }
 
     @classmethod


### PR DESCRIPTION
Add `QEffQwen3ForCausalLM` in the list of supported architectures for `SamplerTransform` in order to enable On Device Sampling.