### PR TITLE
Fix: Add **kwargs to QEffLlama4VisionModel.forward() for transformers v4.57.3 compatibility

### DIFF
--- a/QEfficient/transformers/models/llama4/modeling_llama4.py
+++ b/QEfficient/transformers/models/llama4/modeling_llama4.py
@@ -221,6 +221,7 @@ class QEffLlama4VisionModel(Llama4VisionModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
+        **kwargs,
     ) -> Union[BaseModelOutput, Tuple[torch.Tensor, ...]]:
         r"""
 


### PR DESCRIPTION
## Problem
After the transformers v4.57.3 rebase (commit 7acb860), the following error occurs:
TypeError: QEffLlama4VisionModel.forward() got an unexpected keyword argument 'vision_feature_layer'

## Root Cause Analysis
1. In transformers v4.57.3,
Llama4ForConditionalGeneration.get_image_features()
now passes additional parameters (vision_feature_layer and
vision_feature_select_strategy)
   to the vision model's forward method via **kwargs.

2. The call chain:
- QEffLlama4EncoderWrapper.forward() calls self.model.get_image_features()
- get_image_features() (from transformers library) calls self.vision_model(**kwargs)
   - QEffLlama4VisionModel.forward() was not accepting **kwargs

3. Since QEffLlama4VisionModel overrides the forward() method but didn't accept **kwargs,
   it raised a TypeError when these unexpected arguments were passed.

## Solution
Added **kwargs parameter to QEffLlama4VisionModel.forward() method signature.
This allows the method to accept vision_feature_layer and vision_feature_select_strategy
parameters from the parent class's get_image_features() method, even though they're
not used in the QEff implementation.

## Impact
- Backward compatible change
- Fixes ONNX export failures for Llama4 vision models
- Maintains compatibility with transformers v4.57.3 API

Tested with: examples/image_text_to_text/models/llama4/single_image.py

Signed-off-by: sudheepm <sudheepm@qti.qualcomm.com>
Co-authored-by: sudheepm <sudheepm@qti.qualcomm.com>