### PR TITLE
Automatic Blocking Configurator Bugfix and Enabling skip_kv by default

### DIFF
--- a/QEfficient/blocking/attention_blocking.py
+++ b/QEfficient/blocking/attention_blocking.py
@@ -42,7 +42,7 @@ class AttentionBlockingConfig:
     num_kv_blocks: Optional[int] = None
     num_q_blocks: Optional[int] = None
     head_block_size: Optional[int] = None
-    skip_kv: Optional[bool] = False
+    skip_kv: Optional[bool] = True
     num_batch_blocks: Optional[int] = None
 
 

--- a/QEfficient/blocking/attention_blocking.py
+++ b/QEfficient/blocking/attention_blocking.py
@@ -32,6 +32,8 @@ class BlockingMode(str, Enum):
     Q = "q"
     H = "h"
     QKV = "qkv"
+    HQ = "hq"
+    HKV = "hkv"
     HQKV = "hqkv"
     BHQKV = "bhqkv"
 
@@ -55,6 +57,8 @@ _STRATEGIES: Dict[BlockingMode, Callable] = {
     BlockingMode.Q: blocked_q_attention_forward,
     BlockingMode.H: blocked_h_attention_forward,
     BlockingMode.QKV: blocked_qkv_attention_forward,
+    BlockingMode.HQ: blocked_hqkv_attention_forward,
+    BlockingMode.HKV: blocked_hqkv_attention_forward,
     BlockingMode.HQKV: blocked_hqkv_attention_forward,
     BlockingMode.BHQKV: blocked_bhqkv_attention_forward,
 }

--- a/QEfficient/blocking/blocking_configurator.py
+++ b/QEfficient/blocking/blocking_configurator.py
@@ -42,6 +42,10 @@ def _infer_data_bytes(compile_config: Dict[str, Any]) -> int:
 
 def _normalize_attention_mode(raw_mode: str) -> str:
     mode = raw_mode.lower()
+    if "h" in mode and ("q" in mode or "kv" in mode):
+        return "hqkv"
+    if "h" in mode:
+        return "h"
     if "q" in mode and "kv" in mode:
         return "qkv"
     if "kv" in mode:
@@ -295,7 +299,7 @@ def build_transformer_blocking_config(
     effective_mode = _resolve_effective_blocking_mode(attention_cfg, resolved_mode)
 
     return AttentionBlockingConfig(
-        mode=effective_mode,
+        mode=BlockingMode(effective_mode),
         num_kv_blocks=attention_cfg["num_kv_blocks"],
         num_q_blocks=attention_cfg["num_q_blocks"],
         head_block_size=attention_cfg["head_block_size"],

--- a/QEfficient/blocking/blocking_configurator.py
+++ b/QEfficient/blocking/blocking_configurator.py
@@ -42,8 +42,12 @@ def _infer_data_bytes(compile_config: Dict[str, Any]) -> int:
 
 def _normalize_attention_mode(raw_mode: str) -> str:
     mode = raw_mode.lower()
-    if "h" in mode and ("q" in mode or "kv" in mode):
+    if "h" in mode and "q" in mode and "kv" in mode:
         return "hqkv"
+    if "h" in mode and "q" in mode:
+        return "hq"
+    if "h" in mode and "kv" in mode:
+        return "hkv"
     if "h" in mode:
         return "h"
     if "q" in mode and "kv" in mode:
@@ -65,6 +69,10 @@ def _resolve_effective_blocking_mode(attention_cfg: Dict[str, Any], requested_mo
 
     if head_block_size > 1 and num_q_blocks == 1 and num_kv_blocks == 1:
         return "h"
+    if head_block_size > 1 and num_q_blocks > 1:
+        return "hq"
+    if head_block_size > 1 and num_kv_blocks > 1:
+        return "hkv"
     if head_block_size > 1:
         return "hqkv"
     if num_q_blocks > 1 and num_kv_blocks > 1:

--- a/tests/unit_test/base/test_modeling_qeff_base.py
+++ b/tests/unit_test/base/test_modeling_qeff_base.py
@@ -216,7 +216,7 @@ class TestQEFFBaseModelHashParams:
 class TestQEFFBaseModelTransformBlocking:
     """Tests for QEFFBaseModel.transform() attention blocking behavior."""
 
-    @pytest.mark.parametrize("blocking_mode", ["kv", "q", "qkv", "hqkv"])
+    @pytest.mark.parametrize("blocking_mode", ["kv", "q", "qkv", "hq", "hkv", "hqkv"])
     def test_transform_enable_blocking_runs_auto_configurator(self, blocking_mode):
         # Use a slightly larger head count here to make it possible for "h" mode to result in head blocking
         # when num_devices > 1.

--- a/tests/unit_test/base/test_modeling_qeff_base.py
+++ b/tests/unit_test/base/test_modeling_qeff_base.py
@@ -180,6 +180,14 @@ class TestQEFFBaseModelWeightOffloading:
 
 
 @pytest.mark.cpu_only
+def _get_any_attn_blocking_config(model):
+    for m in model.modules():
+        if hasattr(m, "attn_blocking_config"):
+            return m.attn_blocking_config
+    return None
+
+
+@pytest.mark.cpu_only
 class TestQEFFBaseModelHashParams:
     """Test hash_params initialization."""
 
@@ -202,6 +210,65 @@ class TestQEFFBaseModelHashParams:
         qeff = QEFFAutoModelForCausalLM(model, pretrained_model_name_or_path="test-model")
         assert "pretrained_model_name_or_path" in qeff.hash_params
         assert qeff.hash_params["pretrained_model_name_or_path"] == "test-model"
+
+
+@pytest.mark.cpu_only
+class TestQEFFBaseModelTransformBlocking:
+    """Tests for QEFFBaseModel.transform() attention blocking behavior."""
+
+    @pytest.mark.parametrize("blocking_mode", ["kv", "q", "qkv", "hqkv"])
+    def test_transform_enable_blocking_runs_auto_configurator(self, blocking_mode):
+        # Create a small llama; keep make_tiny_llama() unchanged per requirement.
+        # Use a slightly larger head count here to make it possible for "h" mode to result in head blocking
+        # when num_devices > 1.
+        cfg = LlamaConfig(
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            hidden_size=64,
+            intermediate_size=128,
+            vocab_size=VOCAB_SIZE,
+            max_position_embeddings=CTX_LEN,
+        )
+        model = LlamaForCausalLM(cfg).eval()
+        qeff = QEFFAutoModelForCausalLM(model)
+
+        high_cl = 131072
+        qaic_config = {
+            "enable_blocking": True,
+            "blocking_mode": blocking_mode,
+            # Do not specify num_kv_blocks/num_q_blocks/head_block_size, so auto configurator is used.
+        }
+
+        qeff.transform(
+            ctx_len=high_cl,
+            seq_len=high_cl,
+            bs=1,
+            num_devices=2,
+            qaic_config=qaic_config,
+            aic_num_cores=16,
+            convert_to_fp16=False,
+        )
+
+        cfg = _get_any_attn_blocking_config(qeff.model)
+        assert cfg is not None, (
+            "Expected BlockingAttentionTransform to attach attn_blocking_config to attention modules"
+        )
+
+        decided_mode = cfg.mode.value
+        requested_mode = blocking_mode
+
+        # If the configurator decides blocking is not needed, decided_mode can be "".
+        # Otherwise, the decided mode should be a substring of the requested mode.
+        assert decided_mode in requested_mode
+
+        # For each kind of blocking that was decided, ensure it actually enabled >1 blocks.
+        if "kv" in decided_mode:
+            assert cfg.num_kv_blocks is not None and cfg.num_kv_blocks > 1
+        if "q" in decided_mode:
+            assert cfg.num_q_blocks is not None and cfg.num_q_blocks > 1
+        if "h" in decided_mode:
+            assert cfg.head_block_size is not None and cfg.head_block_size > 1
 
 
 @pytest.mark.cpu_only

--- a/tests/unit_test/base/test_modeling_qeff_base.py
+++ b/tests/unit_test/base/test_modeling_qeff_base.py
@@ -218,7 +218,6 @@ class TestQEFFBaseModelTransformBlocking:
 
     @pytest.mark.parametrize("blocking_mode", ["kv", "q", "qkv", "hqkv"])
     def test_transform_enable_blocking_runs_auto_configurator(self, blocking_mode):
-        # Create a small llama; keep make_tiny_llama() unchanged per requirement.
         # Use a slightly larger head count here to make it possible for "h" mode to result in head blocking
         # when num_devices > 1.
         cfg = LlamaConfig(


### PR DESCRIPTION
Fixed a minor issue in automatic blocking configurator that would drop head blocking when requested. Added a unit test to validate blocking modes after automatic configuration to catch similar bugs in the future. 

Also set skip_kv to be true by default since that is optimal behavior. 