### PR TITLE
Added support of `QEffDiffusionPipeline` for Diffusers

### DIFF
--- a/QEfficient/__init__.py
+++ b/QEfficient/__init__.py
@@ -29,6 +29,7 @@ from QEfficient.base import (
     QEFFCommonLoader,
 )
 from QEfficient.compile.compile_helper import compile
+from QEfficient.diffusers.pipelines.pipeline_diffusion import QEffDiffusionPipeline
 from QEfficient.diffusers.pipelines.flux.pipeline_flux import QEffFluxPipeline
 from QEfficient.diffusers.pipelines.wan.pipeline_wan import QEffWanPipeline
 from QEfficient.diffusers.pipelines.wan.pipeline_wan_i2v import QEffWanImageToVideoPipeline
@@ -58,6 +59,7 @@ __all__ = [
     "QEFFAutoModelForSequenceClassification",
     "QEFFAutoModelForSpeechSeq2Seq",
     "QEFFCommonLoader",
+    "QEffDiffusionPipeline",
     "QEffFluxPipeline",
     "QEffWanPipeline",
     "QEffWanImageToVideoPipeline",

--- a/QEfficient/diffusers/pipelines/__init__.py
+++ b/QEfficient/diffusers/pipelines/__init__.py
@@ -4,3 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # ----------------------------------------------------------------------------
+
+from QEfficient.diffusers.pipelines.pipeline_diffusion import QEffDiffusionPipeline
+
+__all__ = ["QEffDiffusionPipeline"]

--- a/QEfficient/diffusers/pipelines/flux/pipeline_flux.py
+++ b/QEfficient/diffusers/pipelines/flux/pipeline_flux.py
@@ -5,13 +5,6 @@
 #
 # ----------------------------------------------------------------------------
 
-# TODO: Pipeline Architecture Improvements
-# 1. Introduce QEffDiffusionPipeline base class to provide unified export, compile,
-#    and inference APIs across all diffusion pipelines, promoting code reusability
-#    and consistent interface design.
-# 2. Implement persistent QPC session management strategy to retain/drop compiled model
-#    sessions in memory across all pipeline modules.
-
 import os
 import time
 from typing import Callable, Dict, List, Optional, Union
@@ -20,29 +13,24 @@ import numpy as np
 import torch
 from diffusers import FluxPipeline
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import retrieve_timesteps
-from tqdm import tqdm
 
 from QEfficient.diffusers.first_block_cache.flux import enable_flux_first_block_cache
+from QEfficient.diffusers.pipelines.pipeline_diffusion import QEffDiffusionPipeline
 from QEfficient.diffusers.pipelines.pipeline_module import (
     QEffFluxTransformerModel,
     QEffTextEncoder,
     QEffVAE,
 )
 from QEfficient.diffusers.pipelines.pipeline_utils import (
-    ONNX_SUBFUNCTION_MODULE,
     ModulePerf,
     QEffPipelineOutput,
     calculate_compressed_latent_dimension,
-    compile_modules_parallel,
-    compile_modules_sequential,
-    config_manager,
-    set_execute_params,
 )
 from QEfficient.generation.cloud_infer import QAICInferenceSession
 from QEfficient.utils.logging_utils import logger
 
 
-class QEffFluxPipeline:
+class QEffFluxPipeline(QEffDiffusionPipeline):
     """
     QEfficient-optimized Flux pipeline for high-performance text-to-image generation on Qualcomm AI hardware.
 
@@ -248,22 +236,10 @@ class QEffFluxPipeline:
             ... )
             >>> print(f"Models exported to: {export_path}")
         """
-        for module_name, module_obj in tqdm(self.modules.items(), desc="Exporting modules", unit="module"):
-            # Get ONNX export configuration for this module
-            example_inputs, dynamic_axes, output_names = module_obj.get_onnx_params()
-
-            export_params = {
-                "inputs": example_inputs,
-                "output_names": output_names,
-                "dynamic_axes": dynamic_axes,
-                "export_dir": export_dir,
-            }
-
-            if use_onnx_subfunctions and module_name in ONNX_SUBFUNCTION_MODULE:
-                export_params["use_onnx_subfunctions"] = True
-
-            if module_obj.qpc_path is None:
-                module_obj.export(**export_params)
+        self._export_modules(
+            export_dir=export_dir,
+            use_onnx_subfunctions=use_onnx_subfunctions,
+        )
 
     @staticmethod
     def get_default_config_path() -> str:
@@ -318,24 +294,6 @@ class QEffFluxPipeline:
             ...     width=512
             ... )
         """
-        # Load compilation configuration
-        config_manager(self, config_source=compile_config, use_onnx_subfunctions=use_onnx_subfunctions)
-
-        # Set device IDs, qpc path if precompiled qpc exist
-        set_execute_params(self)
-
-        # Ensure all modules are exported to ONNX before compilation
-        if any(
-            path is None
-            for path in [
-                self.text_encoder.onnx_path,
-                self.text_encoder_2.onnx_path,
-                self.transformer.onnx_path,
-                self.vae_decode.onnx_path,
-            ]
-        ):
-            self.export(use_onnx_subfunctions=use_onnx_subfunctions)
-
         # Calculate compressed latent dimension using utility function
         cl, latent_height, latent_width = calculate_compressed_latent_dimension(
             height, width, self.model.vae_scale_factor
@@ -350,11 +308,13 @@ class QEffFluxPipeline:
             },
         }
 
-        # Use generic utility functions for compilation
-        if parallel:
-            compile_modules_parallel(self.modules, self.custom_config, specialization_updates)
-        else:
-            compile_modules_sequential(self.modules, self.custom_config, specialization_updates)
+        self._compile_modules(
+            compile_config=compile_config,
+            parallel=parallel,
+            use_onnx_subfunctions=use_onnx_subfunctions,
+            specialization_updates=specialization_updates,
+            required_module_names=["text_encoder", "text_encoder_2", "transformer", "vae_decoder"],
+        )
 
     def _get_t5_prompt_embeds(
         self,

--- a/QEfficient/diffusers/pipelines/pipeline_diffusion.py
+++ b/QEfficient/diffusers/pipelines/pipeline_diffusion.py
@@ -1,0 +1,146 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# ----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+
+from diffusers import DiffusionPipeline
+from tqdm import tqdm
+
+from QEfficient.diffusers.pipelines.pipeline_utils import (
+    ONNX_SUBFUNCTION_MODULE,
+    compile_modules_parallel,
+    compile_modules_sequential,
+    config_manager,
+    set_execute_params,
+)
+
+
+class QEffDiffusionPipeline:
+    """
+    Generic QEfficient Diffusers pipeline facade.
+
+    This class provides:
+    1) an auto-dispatch `from_pretrained` factory that returns concrete child pipelines,
+    2) shared export/compile plumbing reused by model-specific child pipelines.
+    """
+
+    _HF_PIPELINE_TO_QEFF_CLASS: Dict[str, Tuple[str, str]] = {
+        "FluxPipeline": ("QEfficient.diffusers.pipelines.flux.pipeline_flux", "QEffFluxPipeline"),
+        "WanPipeline": ("QEfficient.diffusers.pipelines.wan.pipeline_wan", "QEffWanPipeline"),
+        "WanImageToVideoPipeline": (
+            "QEfficient.diffusers.pipelines.wan.pipeline_wan_i2v",
+            "QEffWanImageToVideoPipeline",
+        ),
+    }
+
+    @staticmethod
+    def _filter_kwargs_for_callable(func: Callable, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        sig = inspect.signature(func)
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in sig.parameters.values()):
+            return dict(kwargs)
+        return {k: v for k, v in kwargs.items() if k in sig.parameters}
+
+    @classmethod
+    def _resolve_qeff_pipeline_class(
+        cls, pretrained_model_name_or_path: Optional[Union[str, Any]], **kwargs
+    ) -> Type["QEffDiffusionPipeline"]:
+        load_cfg_kwargs = cls._filter_kwargs_for_callable(DiffusionPipeline.load_config, kwargs)
+        config = DiffusionPipeline.load_config(pretrained_model_name_or_path, **load_cfg_kwargs)
+        if isinstance(config, tuple):
+            config = config[0]
+        hf_pipeline_class_name = config.get("_class_name")
+        if not hf_pipeline_class_name:
+            raise ValueError("Unable to infer Hugging Face diffusion pipeline class from model config.")
+
+        mapped = cls._HF_PIPELINE_TO_QEFF_CLASS.get(hf_pipeline_class_name)
+        if not mapped:
+            supported = ", ".join(sorted(cls._HF_PIPELINE_TO_QEFF_CLASS.keys()))
+            raise NotImplementedError(
+                f"Unsupported diffusion pipeline '{hf_pipeline_class_name}'. Supported pipelines: {supported}"
+            )
+
+        module_path, class_name = mapped
+        module = importlib.import_module(module_path)
+        qeff_cls = getattr(module, class_name)
+        return qeff_cls
+
+    @classmethod
+    def register_pipeline(cls, hf_pipeline_class_name: str, module_path: str, class_name: str) -> None:
+        """
+        Register a new HF pipeline class -> QEff pipeline class mapping.
+        """
+        cls._HF_PIPELINE_TO_QEFF_CLASS[hf_pipeline_class_name] = (module_path, class_name)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: Optional[Union[str, Any]], *args, **kwargs):
+        """
+        Auto-dispatch to a concrete QEff diffusion pipeline.
+
+        Note:
+            Calling this method on QEffDiffusionPipeline always returns a concrete child object.
+        """
+        if cls is not QEffDiffusionPipeline:
+            raise NotImplementedError(f"{cls.__name__}.from_pretrained must be implemented by concrete child classes.")
+
+        qeff_cls = cls._resolve_qeff_pipeline_class(pretrained_model_name_or_path, **kwargs)
+        return qeff_cls.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+    def _export_modules(
+        self,
+        export_dir: Optional[str] = None,
+        use_onnx_subfunctions: bool = False,
+        skip_if_qpc_exists: bool = True,
+    ) -> None:
+        """
+        Shared module export loop for diffusion child pipelines.
+        """
+        for module_name, module_obj in tqdm(self.modules.items(), desc="Exporting modules", unit="module"):
+            example_inputs, dynamic_axes, output_names = module_obj.get_onnx_params()
+            export_params = {
+                "inputs": example_inputs,
+                "output_names": output_names,
+                "dynamic_axes": dynamic_axes,
+                "export_dir": export_dir,
+            }
+            if use_onnx_subfunctions and module_name in ONNX_SUBFUNCTION_MODULE:
+                export_params["use_onnx_subfunctions"] = True
+
+            if skip_if_qpc_exists and module_obj.qpc_path is not None:
+                continue
+            module_obj.export(**export_params)
+
+    def _compile_modules(
+        self,
+        *,
+        compile_config: Optional[str] = None,
+        parallel: bool = False,
+        use_onnx_subfunctions: bool = False,
+        specialization_updates: Optional[Dict[str, Any]] = None,
+        required_module_names: Optional[list[str]] = None,
+        pre_compile_hook: Optional[Callable[[], None]] = None,
+    ) -> None:
+        """
+        Shared module compile flow for diffusion child pipelines.
+        """
+        config_manager(self, config_source=compile_config, use_onnx_subfunctions=use_onnx_subfunctions)
+        set_execute_params(self)
+
+        required_module_names = required_module_names or list(self.modules.keys())
+        if any(getattr(self.modules[name], "onnx_path", None) is None for name in required_module_names):
+            self.export(use_onnx_subfunctions=use_onnx_subfunctions)
+
+        if pre_compile_hook is not None:
+            pre_compile_hook()
+
+        if parallel:
+            compile_modules_parallel(self.modules, self.custom_config, specialization_updates)
+        else:
+            compile_modules_sequential(self.modules, self.custom_config, specialization_updates)

--- a/QEfficient/diffusers/pipelines/wan/pipeline_wan.py
+++ b/QEfficient/diffusers/pipelines/wan/pipeline_wan.py
@@ -25,30 +25,25 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import numpy as np
 import torch
 from diffusers import WanPipeline
-from tqdm import tqdm
 
 from QEfficient.diffusers.first_block_cache.wan import (
     enable_wan_first_block_cache,
     run_wan_non_unified_first_block_cache_denoise,
 )
 from QEfficient.diffusers.models.transformers.transformer_wan import QEffWanUnifiedWrapper
+from QEfficient.diffusers.pipelines.pipeline_diffusion import QEffDiffusionPipeline
 from QEfficient.diffusers.pipelines.pipeline_module import QEffVAE, QEffWanTransformer, QEffWanUnifiedTransformer
 from QEfficient.diffusers.pipelines.pipeline_utils import (
-    ONNX_SUBFUNCTION_MODULE,
     ModulePerf,
     QEffPipelineOutput,
     calculate_latent_dimensions_with_frames,
-    compile_modules_parallel,
-    compile_modules_sequential,
-    config_manager,
-    set_execute_params,
 )
 from QEfficient.generation.cloud_infer import QAICInferenceSession
 from QEfficient.utils import constants
 from QEfficient.utils.logging_utils import logger
 
 
-class QEffWanPipeline:
+class QEffWanPipeline(QEffDiffusionPipeline):
     """
     QEfficient-optimized WAN pipeline for high-performance text-to-video generation on Qualcomm AI hardware.
 
@@ -303,25 +298,10 @@ class QEffWanPipeline:
             ... )
         """
 
-        # Export each module with video-specific parameters
-        for module_name, module_obj in tqdm(self.modules.items(), desc="Exporting modules", unit="module"):
-            # Get ONNX export configuration with video dimensions
-            example_inputs, dynamic_axes, output_names = module_obj.get_onnx_params()
-
-            # Prepare export parameters
-            export_params = {
-                "inputs": example_inputs,
-                "output_names": output_names,
-                "dynamic_axes": dynamic_axes,
-                "export_dir": export_dir,
-            }
-
-            # Enable ONNX subfunctions for supported modules if requested
-            if use_onnx_subfunctions and module_name in ONNX_SUBFUNCTION_MODULE:
-                export_params["use_onnx_subfunctions"] = True
-
-            if module_obj.qpc_path is None:
-                module_obj.export(**export_params)
+        self._export_modules(
+            export_dir=export_dir,
+            use_onnx_subfunctions=use_onnx_subfunctions,
+        )
 
     def get_default_config_path(self):
         """
@@ -381,17 +361,6 @@ class QEffWanPipeline:
             ...     num_frames=81
             ... )
         """
-        # Load compilation configuration
-        config_manager(self, config_source=compile_config, use_onnx_subfunctions=use_onnx_subfunctions)
-
-        # Set device IDs, qpc path if precompiled qpc exist
-        set_execute_params(self)
-
-        # Ensure all modules are exported to ONNX before compilation
-        onnx_paths = [module.onnx_path for module in self.modules.values()]
-        if any(path is None for path in onnx_paths):
-            self.export(use_onnx_subfunctions=use_onnx_subfunctions)
-
         # Configure pipeline dimensions and calculate compressed latent parameters
         cl, latent_height, latent_width, latent_frames = calculate_latent_dimensions_with_frames(
             height,
@@ -443,11 +412,12 @@ class QEffWanPipeline:
                 },
             }
 
-        # Use generic utility functions for compilation
-        if parallel:
-            compile_modules_parallel(self.modules, self.custom_config, specialization_updates)
-        else:
-            compile_modules_sequential(self.modules, self.custom_config, specialization_updates)
+        self._compile_modules(
+            compile_config=compile_config,
+            parallel=parallel,
+            use_onnx_subfunctions=use_onnx_subfunctions,
+            specialization_updates=specialization_updates,
+        )
 
     def _get_transformer_dtype(self) -> torch.dtype:
         if self.use_unified:

--- a/QEfficient/diffusers/pipelines/wan/pipeline_wan_i2v.py
+++ b/QEfficient/diffusers/pipelines/wan/pipeline_wan_i2v.py
@@ -24,19 +24,14 @@ import torch
 from diffusers import WanImageToVideoPipeline
 from diffusers.image_processor import PipelineImageInput
 from diffusers.utils.torch_utils import randn_tensor
-from tqdm import tqdm
 
 from QEfficient.diffusers.models.transformers.transformer_wan import QEffWanUnifiedWrapper
+from QEfficient.diffusers.pipelines.pipeline_diffusion import QEffDiffusionPipeline
 from QEfficient.diffusers.pipelines.pipeline_module import QEffVAE, QEffWanUnifiedTransformer
 from QEfficient.diffusers.pipelines.pipeline_utils import (
-    ONNX_SUBFUNCTION_MODULE,
     ModulePerf,
     QEffPipelineOutput,
     calculate_latent_dimensions_with_frames,
-    compile_modules_parallel,
-    compile_modules_sequential,
-    config_manager,
-    set_execute_params,
     update_npi_path,
 )
 from QEfficient.generation.cloud_infer import QAICInferenceSession
@@ -44,7 +39,7 @@ from QEfficient.utils import constants
 from QEfficient.utils.logging_utils import logger
 
 
-class QEffWanImageToVideoPipeline:
+class QEffWanImageToVideoPipeline(QEffDiffusionPipeline):
     """
     QEfficient-optimized WAN image-to-video pipeline for high-performance video generation on Qualcomm AI hardware.
 
@@ -246,24 +241,11 @@ class QEffWanImageToVideoPipeline:
             >>> print(f"Models exported to: {export_path}")
         """
 
-        # Export each module with corresponding parameters
-        for module_name, module_obj in tqdm(self.modules.items(), desc="Exporting modules", unit="module"):
-            # Get ONNX export configuration with video dimensions
-            example_inputs, dynamic_axes, output_names = module_obj.get_onnx_params()
-
-            # Prepare export parameters
-            export_params = {
-                "inputs": example_inputs,
-                "output_names": output_names,
-                "dynamic_axes": dynamic_axes,
-                "export_dir": export_dir,
-            }
-
-            # Enable ONNX subfunctions for supported modules if requested
-            if use_onnx_subfunctions and module_name in ONNX_SUBFUNCTION_MODULE:
-                export_params["use_onnx_subfunctions"] = True
-
-            module_obj.export(**export_params)
+        self._export_modules(
+            export_dir=export_dir,
+            use_onnx_subfunctions=use_onnx_subfunctions,
+            skip_if_qpc_exists=False,
+        )
 
     @staticmethod
     def get_default_config_path():
@@ -333,23 +315,6 @@ class QEffWanImageToVideoPipeline:
             ...     num_frames=81
             ... )
         """
-        # Load compilation configuration
-        config_manager(self, config_source=compile_config, use_onnx_subfunctions=use_onnx_subfunctions)
-
-        # Set device IDs, qpc path if precompiled qpc exist
-        set_execute_params(self)
-
-        # Ensure all modules are exported to ONNX before compilation
-        if any(
-            path is None
-            for path in [
-                self.vae_encoder.onnx_path,
-                self.transformer.onnx_path,
-                self.vae_decoder.onnx_path,
-            ]
-        ):
-            self.export(use_onnx_subfunctions=use_onnx_subfunctions)
-
         # Configure pipeline dimensions and calculate compressed latent parameters
         cl, latent_height, latent_width, latent_frames = calculate_latent_dimensions_with_frames(
             height,
@@ -360,10 +325,6 @@ class QEffWanImageToVideoPipeline:
             self.patch_height,
             self.patch_width,
         )
-
-        # # Update NPI path for vae encoder
-        vae_npi_full_path = self.get_vae_encoder_npi_path()
-        update_npi_path(self, vae_npi_full_path, module_name="vae_encoder")
 
         # Prepare dynamic specialization updates based on video dimensions
         specialization_updates = {
@@ -395,11 +356,18 @@ class QEffWanImageToVideoPipeline:
             },
         }
 
-        # Use generic utility functions for compilation
-        if parallel:
-            compile_modules_parallel(self.modules, self.custom_config, specialization_updates)
-        else:
-            compile_modules_sequential(self.modules, self.custom_config, specialization_updates)
+        def _update_vae_encoder_npi_path() -> None:
+            vae_npi_full_path = self.get_vae_encoder_npi_path()
+            update_npi_path(self, vae_npi_full_path, module_name="vae_encoder")
+
+        self._compile_modules(
+            compile_config=compile_config,
+            parallel=parallel,
+            use_onnx_subfunctions=use_onnx_subfunctions,
+            specialization_updates=specialization_updates,
+            required_module_names=["vae_encoder", "transformer", "vae_decoder"],
+            pre_compile_hook=_update_vae_encoder_npi_path,
+        )
 
     def prepare_latents(
         self,

--- a/examples/diffusers/flux/flux_1_schnell.py
+++ b/examples/diffusers/flux/flux_1_schnell.py
@@ -8,7 +8,7 @@
 """
 FLUX.1-schnell Image Generation Example
 
-This example demonstrates how to use the QEffFluxPipeline to generate images
+This example demonstrates how to use the generic QEffDiffusionPipeline to generate images
 using the FLUX.1-schnell model from Black Forest Labs. FLUX.1-schnell is a
 fast, distilled version of the FLUX.1 text-to-image model optimized for
 speed with minimal quality loss.
@@ -16,10 +16,11 @@ speed with minimal quality loss.
 
 import torch
 
-from QEfficient import QEffFluxPipeline
+from QEfficient import QEffDiffusionPipeline
 
-# Initialize the FLUX.1-schnell pipeline from pretrained weights
-pipeline = QEffFluxPipeline.from_pretrained("black-forest-labs/FLUX.1-schnell")
+# Initialize from pretrained weights via generic auto-dispatch
+# For this model id, it resolves to QEffFluxPipeline.
+pipeline = QEffDiffusionPipeline.from_pretrained("black-forest-labs/FLUX.1-schnell")
 
 # Generate an image from a text prompt
 # use_onnx_subfunctions=True enables ONNX-based optimizations for faster compilation

--- a/examples/diffusers/flux/flux_1_schnell_first_block_cache.py
+++ b/examples/diffusers/flux/flux_1_schnell_first_block_cache.py
@@ -10,9 +10,10 @@ FLUX.1-schnell first-block-cache example.
 
 import torch
 
-from QEfficient import QEffFluxPipeline
+from QEfficient import QEffDiffusionPipeline
 
-pipeline = QEffFluxPipeline.from_pretrained(
+# Auto-dispatch resolves this model id to QEffFluxPipeline.
+pipeline = QEffDiffusionPipeline.from_pretrained(
     "black-forest-labs/FLUX.1-schnell",
     enable_first_block_cache=True,
     # Hidden-dimension downsampling used for first-block residual similarity check.

--- a/examples/diffusers/flux/flux_1_shnell_custom.py
+++ b/examples/diffusers/flux/flux_1_shnell_custom.py
@@ -21,18 +21,19 @@ Use this example to learn how to fine-tune FLUX.1 for your specific needs.
 
 import torch
 
-from QEfficient import QEffFluxPipeline
+from QEfficient import QEffDiffusionPipeline
 
 # ============================================================================
 # PIPELINE INITIALIZATION WITH CUSTOM PARAMETERS
 # ============================================================================
 
 # Option 1: Basic initialization with default parameters
-pipeline = QEffFluxPipeline.from_pretrained("black-forest-labs/FLUX.1-schnell")
+# Auto-dispatch resolves this model id to QEffFluxPipeline.
+pipeline = QEffDiffusionPipeline.from_pretrained("black-forest-labs/FLUX.1-schnell")
 # Option 2: Advanced initialization with custom modules
 # Uncomment and modify to use your own custom components:
 #
-# pipeline = QEffFluxPipeline.from_pretrained(
+# pipeline = QEffDiffusionPipeline.from_pretrained(
 #     "black-forest-labs/FLUX.1-schnell",
 #     text_encoder=custom_text_encoder,      # Your custom CLIP text encoder
 #     transformer=custom_transformer,         # Your custom transformer model

--- a/examples/diffusers/wan/wan_first_block_cache.py
+++ b/examples/diffusers/wan/wan_first_block_cache.py
@@ -7,10 +7,11 @@
 import torch
 from diffusers.utils import export_to_video
 
-from QEfficient import QEffWanPipeline
+from QEfficient import QEffDiffusionPipeline
 
 # Non-unified WAN + first-block-cache (patch-based activation at load time).
-pipeline = QEffWanPipeline.from_pretrained(
+# Auto-dispatch resolves this model id to QEffWanPipeline.
+pipeline = QEffDiffusionPipeline.from_pretrained(
     "Wan-AI/Wan2.2-T2V-A14B-Diffusers",
     use_unified=False,
     enable_first_block_cache=True,

--- a/examples/diffusers/wan/wan_lightning.py
+++ b/examples/diffusers/wan/wan_lightning.py
@@ -10,10 +10,11 @@ from diffusers.loaders.lora_conversion_utils import _convert_non_diffusers_wan_l
 from diffusers.utils import export_to_video
 from huggingface_hub import hf_hub_download
 
-from QEfficient import QEffWanPipeline
+from QEfficient import QEffDiffusionPipeline
 
 # Load the pipeline
-pipeline = QEffWanPipeline.from_pretrained("Wan-AI/Wan2.2-T2V-A14B-Diffusers")
+# Auto-dispatch resolves this model id to QEffWanPipeline.
+pipeline = QEffDiffusionPipeline.from_pretrained("Wan-AI/Wan2.2-T2V-A14B-Diffusers")
 
 # Download the LoRAs
 high_noise_lora_path = hf_hub_download(

--- a/examples/diffusers/wan/wan_lightning_custom.py
+++ b/examples/diffusers/wan/wan_lightning_custom.py
@@ -25,16 +25,17 @@ from diffusers.loaders.lora_conversion_utils import _convert_non_diffusers_wan_l
 from diffusers.utils import export_to_video
 from huggingface_hub import hf_hub_download
 
-from QEfficient import QEffWanPipeline
+from QEfficient import QEffDiffusionPipeline
 
 # ============================================================================
 # PIPELINE INITIALIZATION WITH CUSTOM PARAMETERS
 # ============================================================================
 
 # Option 1: Basic initialization with default parameters
-pipeline = QEffWanPipeline.from_pretrained("Wan-AI/Wan2.2-T2V-A14B-Diffusers")
+# Auto-dispatch resolves this model id to QEffWanPipeline.
+pipeline = QEffDiffusionPipeline.from_pretrained("Wan-AI/Wan2.2-T2V-A14B-Diffusers")
 # Option 2: Non-unified mode (separate high/low transformers)
-# pipeline = QEffWanPipeline.from_pretrained("Wan-AI/Wan2.2-T2V-A14B-Diffusers", use_unified=False)
+# pipeline = QEffDiffusionPipeline.from_pretrained("Wan-AI/Wan2.2-T2V-A14B-Diffusers", use_unified=False)
 
 # ============================================================================
 # LORA ADAPTER LOADING FOR LIGHTNING MODEL

--- a/examples/diffusers/wan_i2v/wan_i2v_custom.py
+++ b/examples/diffusers/wan_i2v/wan_i2v_custom.py
@@ -28,14 +28,15 @@ from diffusers.loaders.lora_conversion_utils import _convert_non_diffusers_wan_l
 from diffusers.utils import export_to_video, load_image
 from huggingface_hub import hf_hub_download
 
-from QEfficient import QEffWanImageToVideoPipeline
+from QEfficient import QEffDiffusionPipeline
 
 # ============================================================================
 # PIPELINE INITIALIZATION WITH CUSTOM PARAMETERS
 # ============================================================================
 
 # Option 1: Basic initialization with default parameters
-pipeline = QEffWanImageToVideoPipeline.from_pretrained("Wan-AI/Wan2.2-I2V-A14B-Diffusers")
+# Auto-dispatch resolves this model id to QEffWanImageToVideoPipeline.
+pipeline = QEffDiffusionPipeline.from_pretrained("Wan-AI/Wan2.2-I2V-A14B-Diffusers")
 
 # ============================================================================
 # LORA ADAPTER LOADING FOR LIGHTNING MODEL

--- a/examples/diffusers/wan_i2v/wan_lightning_i2v.py
+++ b/examples/diffusers/wan_i2v/wan_lightning_i2v.py
@@ -11,10 +11,11 @@ from diffusers.loaders.lora_conversion_utils import _convert_non_diffusers_wan_l
 from diffusers.utils import export_to_video, load_image
 from huggingface_hub import hf_hub_download
 
-from QEfficient import QEffWanImageToVideoPipeline
+from QEfficient import QEffDiffusionPipeline
 
 # Load the pipeline
-pipeline = QEffWanImageToVideoPipeline.from_pretrained("Wan-AI/Wan2.2-I2V-A14B-Diffusers")
+# Auto-dispatch resolves this model id to QEffWanImageToVideoPipeline.
+pipeline = QEffDiffusionPipeline.from_pretrained("Wan-AI/Wan2.2-I2V-A14B-Diffusers")
 
 # Download the LoRAs
 high_noise_lora_path = hf_hub_download(

--- a/tests/unit_test/utils/test_diffusion_pipeline_infra.py
+++ b/tests/unit_test/utils/test_diffusion_pipeline_infra.py
@@ -1,0 +1,319 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+"""
+Unit tests for the generic diffusion pipeline infra.
+
+Coverage in this single file:
+1. Generic dispatch (`QEffDiffusionPipeline.from_pretrained`) returns concrete child classes.
+2. Error handling for unsupported or malformed HF pipeline config.
+3. `register_pipeline` extension path for new HF pipeline mappings.
+4. Child pipeline inheritance from `QEffDiffusionPipeline`.
+5. Shared `_export_modules` behavior:
+   - honors `skip_if_qpc_exists`
+   - enables ONNX subfunction flag only for supported modules
+6. Shared `_compile_modules` behavior:
+   - calls config + execute setup
+   - exports only when ONNX is missing
+   - runs optional pre-compile hook
+   - routes to sequential vs parallel compile path
+7. Example scripts use only generic `QEffDiffusionPipeline.from_pretrained(...)`.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+from diffusers import DiffusionPipeline
+
+from QEfficient import QEffDiffusionPipeline, QEffFluxPipeline, QEffWanImageToVideoPipeline, QEffWanPipeline
+from QEfficient.diffusers.pipelines.pipeline_utils import ONNX_SUBFUNCTION_MODULE
+
+pytestmark = pytest.mark.diffusers
+
+EXAMPLE_SCRIPTS = [
+    "examples/diffusers/flux/flux_1_schnell.py",
+    "examples/diffusers/flux/flux_1_schnell_first_block_cache.py",
+    "examples/diffusers/flux/flux_1_shnell_custom.py",
+    "examples/diffusers/wan/wan_first_block_cache.py",
+    "examples/diffusers/wan/wan_lightning.py",
+    "examples/diffusers/wan/wan_lightning_custom.py",
+    "examples/diffusers/wan_i2v/wan_i2v_custom.py",
+    "examples/diffusers/wan_i2v/wan_lightning_i2v.py",
+]
+
+
+def _patch_load_config(monkeypatch, hf_class_name):
+    def _fake_load_config(cls, pretrained_model_name_or_path, cache_dir=None):
+        return {"_class_name": hf_class_name}
+
+    monkeypatch.setattr(DiffusionPipeline, "load_config", classmethod(_fake_load_config))
+
+
+def _patch_child_factory(monkeypatch, qeff_cls):
+    captured = {}
+
+    def _fake_from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        captured["model_id"] = pretrained_model_name_or_path
+        captured["kwargs"] = kwargs
+        return cls.__new__(cls)
+
+    monkeypatch.setattr(qeff_cls, "from_pretrained", classmethod(_fake_from_pretrained))
+    return captured
+
+
+class _DummyModule:
+    def __init__(self, *, qpc_path: Optional[str] = None, onnx_path: Optional[str] = None):
+        self.qpc_path = qpc_path
+        self.onnx_path = onnx_path
+        self.export_calls = []
+
+    def get_onnx_params(self):
+        return ({"x": 1}, {"x": {0: "batch_size"}}, ["y"])
+
+    def export(self, **kwargs):
+        self.export_calls.append(kwargs)
+
+
+class _DummyPipeline(QEffDiffusionPipeline):
+    def __init__(self, modules: Dict[str, _DummyModule]):
+        self.modules = modules
+        self.custom_config = {"dummy": True}
+        self.export_calls = []
+
+    def export(self, use_onnx_subfunctions: bool = False):
+        self.export_calls.append(use_onnx_subfunctions)
+
+
+def test_qeff_diffusion_pipeline_returns_concrete_child_for_supported_models(monkeypatch):
+    """Factory should return the exact concrete child class for supported HF pipeline configs."""
+    for hf_class_name, qeff_cls in [
+        ("FluxPipeline", QEffFluxPipeline),
+        ("WanPipeline", QEffWanPipeline),
+        ("WanImageToVideoPipeline", QEffWanImageToVideoPipeline),
+    ]:
+        _patch_load_config(monkeypatch, hf_class_name)
+        captured = _patch_child_factory(monkeypatch, qeff_cls)
+
+        pipeline = QEffDiffusionPipeline.from_pretrained(
+            "dummy-model-id",
+            cache_dir="/tmp/hf-cache",
+            use_unified=False,
+        )
+
+        assert isinstance(pipeline, qeff_cls)
+        assert type(pipeline) is qeff_cls
+        assert captured["model_id"] == "dummy-model-id"
+        assert captured["kwargs"]["use_unified"] is False
+
+
+def test_qeff_diffusion_pipeline_forwards_kwargs_to_load_config_and_child(monkeypatch):
+    """`from_pretrained` should pass load-config kwargs and preserve child kwargs."""
+    seen = {}
+
+    def _fake_load_config(cls, pretrained_model_name_or_path, cache_dir=None):
+        seen["model_id"] = pretrained_model_name_or_path
+        seen["cache_dir"] = cache_dir
+        return {"_class_name": "FluxPipeline"}
+
+    monkeypatch.setattr(DiffusionPipeline, "load_config", classmethod(_fake_load_config))
+    captured = _patch_child_factory(monkeypatch, QEffFluxPipeline)
+
+    QEffDiffusionPipeline.from_pretrained(
+        "dummy-model-id",
+        cache_dir="/tmp/hf-cache",
+        use_unified=False,
+        enable_first_block_cache=True,
+    )
+
+    assert seen["model_id"] == "dummy-model-id"
+    assert seen["cache_dir"] == "/tmp/hf-cache"
+    assert captured["kwargs"]["use_unified"] is False
+    assert captured["kwargs"]["enable_first_block_cache"] is True
+
+
+def test_qeff_diffusion_pipeline_raises_for_unsupported_hf_pipeline(monkeypatch):
+    """Unsupported HF `_class_name` must fail fast."""
+    _patch_load_config(monkeypatch, "StableDiffusionPipeline")
+
+    with pytest.raises(NotImplementedError):
+        QEffDiffusionPipeline.from_pretrained("dummy-model-id")
+
+
+def test_qeff_diffusion_pipeline_raises_for_missing_hf_class_name(monkeypatch):
+    """Missing HF `_class_name` in config should raise clear ValueError."""
+
+    def _fake_load_config(cls, pretrained_model_name_or_path, cache_dir=None):
+        return {}
+
+    monkeypatch.setattr(DiffusionPipeline, "load_config", classmethod(_fake_load_config))
+
+    with pytest.raises(ValueError):
+        QEffDiffusionPipeline.from_pretrained("dummy-model-id")
+
+
+def test_qeff_diffusion_pipeline_register_pipeline_adds_new_mapping(monkeypatch):
+    """`register_pipeline` should make new HF class names dispatchable."""
+    _patch_load_config(monkeypatch, "DummyPipeline")
+    captured = _patch_child_factory(monkeypatch, QEffFluxPipeline)
+
+    mapping_key = "DummyPipeline"
+    original = QEffDiffusionPipeline._HF_PIPELINE_TO_QEFF_CLASS.get(mapping_key)
+    try:
+        QEffDiffusionPipeline.register_pipeline(
+            "DummyPipeline",
+            "QEfficient.diffusers.pipelines.flux.pipeline_flux",
+            "QEffFluxPipeline",
+        )
+        pipeline = QEffDiffusionPipeline.from_pretrained("dummy-model-id")
+        assert isinstance(pipeline, QEffFluxPipeline)
+        assert captured["model_id"] == "dummy-model-id"
+    finally:
+        if original is None:
+            QEffDiffusionPipeline._HF_PIPELINE_TO_QEFF_CLASS.pop(mapping_key, None)
+        else:
+            QEffDiffusionPipeline._HF_PIPELINE_TO_QEFF_CLASS[mapping_key] = original
+
+
+def test_qeff_child_pipelines_inherit_qeff_diffusion_pipeline():
+    """Concrete diffusion pipelines should inherit from the generic base."""
+    assert issubclass(QEffFluxPipeline, QEffDiffusionPipeline)
+    assert issubclass(QEffWanPipeline, QEffDiffusionPipeline)
+    assert issubclass(QEffWanImageToVideoPipeline, QEffDiffusionPipeline)
+
+
+def test_export_modules_respects_skip_qpc_and_subfunction_flag():
+    """Shared export should skip modules with precompiled QPC and set ONNX subfunction flag where supported."""
+    subfn_module_name = next(iter(ONNX_SUBFUNCTION_MODULE))
+    module_with_qpc = _DummyModule(qpc_path="/tmp/precompiled.qpc")
+    module_without_qpc = _DummyModule()
+
+    pipeline = _DummyPipeline(
+        {
+            subfn_module_name: module_without_qpc,
+            "module_with_qpc": module_with_qpc,
+        }
+    )
+
+    pipeline._export_modules(export_dir="/tmp/export", use_onnx_subfunctions=True, skip_if_qpc_exists=True)
+
+    assert len(module_without_qpc.export_calls) == 1
+    assert module_without_qpc.export_calls[0]["export_dir"] == "/tmp/export"
+    assert module_without_qpc.export_calls[0]["use_onnx_subfunctions"] is True
+    assert len(module_with_qpc.export_calls) == 0
+
+
+def test_export_modules_can_force_export_even_if_qpc_exists():
+    """Shared export should support forced export when requested."""
+    module_with_qpc = _DummyModule(qpc_path="/tmp/precompiled.qpc")
+    pipeline = _DummyPipeline({"module": module_with_qpc})
+
+    pipeline._export_modules(skip_if_qpc_exists=False)
+
+    assert len(module_with_qpc.export_calls) == 1
+
+
+def test_compile_modules_sequential_runs_config_export_hook_and_compile(monkeypatch):
+    """Sequential compile path should run setup, export-if-needed, pre-hook, then sequential compile."""
+    module = _DummyModule(onnx_path=None)
+    pipeline = _DummyPipeline({"module": module})
+    specialization_updates: Dict[str, Any] = {"module": {"height": 512}}
+    calls = {"config": [], "execute": 0, "seq": [], "par": [], "hook": 0}
+
+    def _mock_config_manager(self, config_source=None, use_onnx_subfunctions=False):
+        calls["config"].append((self, config_source, use_onnx_subfunctions))
+
+    def _mock_set_execute_params(self):
+        calls["execute"] += 1
+
+    def _mock_compile_modules_sequential(modules, custom_config, specs):
+        calls["seq"].append((modules, custom_config, specs))
+
+    def _mock_compile_modules_parallel(modules, custom_config, specs):
+        calls["par"].append((modules, custom_config, specs))
+
+    monkeypatch.setattr("QEfficient.diffusers.pipelines.pipeline_diffusion.config_manager", _mock_config_manager)
+    monkeypatch.setattr(
+        "QEfficient.diffusers.pipelines.pipeline_diffusion.set_execute_params", _mock_set_execute_params
+    )
+    monkeypatch.setattr(
+        "QEfficient.diffusers.pipelines.pipeline_diffusion.compile_modules_sequential",
+        _mock_compile_modules_sequential,
+    )
+    monkeypatch.setattr(
+        "QEfficient.diffusers.pipelines.pipeline_diffusion.compile_modules_parallel",
+        _mock_compile_modules_parallel,
+    )
+
+    def _hook():
+        calls["hook"] += 1
+
+    pipeline._compile_modules(
+        compile_config="cfg.json",
+        parallel=False,
+        use_onnx_subfunctions=True,
+        specialization_updates=specialization_updates,
+        required_module_names=["module"],
+        pre_compile_hook=_hook,
+    )
+
+    assert calls["config"] == [(pipeline, "cfg.json", True)]
+    assert calls["execute"] == 1
+    assert calls["hook"] == 1
+    assert pipeline.export_calls == [True]
+    assert len(calls["seq"]) == 1
+    assert calls["seq"][0] == (pipeline.modules, pipeline.custom_config, specialization_updates)
+    assert calls["par"] == []
+
+
+def test_compile_modules_parallel_skips_export_when_onnx_exists(monkeypatch):
+    """Parallel compile path should not call export when ONNX path already exists."""
+    module = _DummyModule(onnx_path="/tmp/model.onnx")
+    pipeline = _DummyPipeline({"module": module})
+    calls = {"seq": 0, "par": 0}
+
+    monkeypatch.setattr(
+        "QEfficient.diffusers.pipelines.pipeline_diffusion.config_manager", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "QEfficient.diffusers.pipelines.pipeline_diffusion.set_execute_params", lambda *args, **kwargs: None
+    )
+
+    def _mock_compile_modules_sequential(*args, **kwargs):
+        calls["seq"] += 1
+
+    def _mock_compile_modules_parallel(*args, **kwargs):
+        calls["par"] += 1
+
+    monkeypatch.setattr(
+        "QEfficient.diffusers.pipelines.pipeline_diffusion.compile_modules_sequential",
+        _mock_compile_modules_sequential,
+    )
+    monkeypatch.setattr(
+        "QEfficient.diffusers.pipelines.pipeline_diffusion.compile_modules_parallel",
+        _mock_compile_modules_parallel,
+    )
+
+    pipeline._compile_modules(parallel=True, specialization_updates={"module": {"width": 512}})
+
+    assert pipeline.export_calls == []
+    assert calls["par"] == 1
+    assert calls["seq"] == 0
+
+
+def test_diffusers_examples_use_generic_qeff_diffusion_pipeline():
+    """All maintained diffusers example scripts must use the generic entrypoint."""
+    repo_root = Path(__file__).resolve().parents[3]
+
+    for rel_path in EXAMPLE_SCRIPTS:
+        file_path = repo_root / rel_path
+        source = file_path.read_text(encoding="utf-8")
+
+        assert "from QEfficient import QEffDiffusionPipeline" in source
+        assert "QEffDiffusionPipeline.from_pretrained(" in source
+        assert "QEffFluxPipeline.from_pretrained(" not in source
+        assert "QEffWanPipeline.from_pretrained(" not in source
+        assert "QEffWanImageToVideoPipeline.from_pretrained(" not in source


### PR DESCRIPTION
## Summary
Adds a generic `QEffDiffusionPipeline` entrypoint for diffusers that auto-dispatches to the correct concrete QEff pipeline, while moving shared infra to a common base.

## What Changed
- Added `QEffDiffusionPipeline.from_pretrained(...)` dispatch by HF pipeline class and return of concrete child objects:
  - `QEffFluxPipeline`
  - `QEffWanPipeline`
  - `QEffWanImageToVideoPipeline`
- Centralized shared compile/export flow in generic base APIs.
- Refactored child pipelines to inherit and reuse the shared infra.
- Updated all diffusion example scripts (including custom + first-block-cache) to use generic factory creation.
- Added consolidated unit tests in `tests/unit_test/utils/test_diffusion_pipeline_infra.py`.
