### PR TITLE
Add seed_oss support to QEfficient

### DIFF
--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -237,6 +237,23 @@ from transformers.models.whisper.modeling_whisper import (
     WhisperPositionalEmbedding,
 )
 
+# U6: seed_oss landed in transformers ~2025; guard against older pinned versions
+try:
+    from transformers.models.seed_oss.modeling_seed_oss import (
+        SeedOssAttention,
+        SeedOssDecoderLayer,
+        SeedOssForCausalLM,
+        SeedOssModel,
+        SeedOssRMSNorm,
+        SeedOssRotaryEmbedding,
+    )
+
+    _HAS_SEED_OSS = True
+except ImportError:
+    SeedOssAttention = SeedOssDecoderLayer = SeedOssForCausalLM = None
+    SeedOssModel = SeedOssRMSNorm = SeedOssRotaryEmbedding = None
+    _HAS_SEED_OSS = False
+
 from QEfficient.base.pytorch_transforms import ExternalModuleMapperTransform, ModuleMappingTransform
 from QEfficient.customop import CustomRMSNormAIC, GemmaCustomRMSNormAIC
 from QEfficient.transformers.embeddings.embedding_utils import POOLING_MAP, PooledModel, validate_user_pooling_function
@@ -506,6 +523,13 @@ from QEfficient.transformers.models.whisper.modeling_whisper import (
     QEffWhisperModel,
     QEffWhisperPositionalEmbedding,
 )
+from QEfficient.transformers.models.seed_oss.modeling_seed_oss import (
+    QEffSeedOssAttention,
+    QEffSeedOssDecoderLayer,
+    QEffSeedOssForCausalLM,
+    QEffSeedOssModel,
+    QEffSeedOssRotaryEmbedding,
+)
 from QEfficient.transformers.post_processing import build_and_attach_mlp, model_type_registry
 from QEfficient.transformers.sampler.sampler import sampler_forward
 from QEfficient.transformers.spd.spd_transform_forward import tlm_forward
@@ -734,6 +758,16 @@ class KVCacheTransform(ModuleMappingTransform):
     def apply(cls, model: nn.Module) -> Tuple[nn.Module, bool]:
         model, transformed = super().apply(model)
         return model, transformed
+
+
+# U6: SeedOss is recent (~2025); register only when the HF classes are importable
+if _HAS_SEED_OSS:
+    KVCacheTransform._module_mapping[SeedOssAttention] = QEffSeedOssAttention
+    KVCacheTransform._module_mapping[SeedOssDecoderLayer] = QEffSeedOssDecoderLayer
+    KVCacheTransform._module_mapping[SeedOssModel] = QEffSeedOssModel
+    KVCacheTransform._module_mapping[SeedOssForCausalLM] = QEffSeedOssForCausalLM
+    KVCacheTransform._module_mapping[SeedOssRotaryEmbedding] = QEffSeedOssRotaryEmbedding
+    CustomOpsTransform._module_mapping[SeedOssRMSNorm] = CustomRMSNormAIC
 
 
 class PrefillOnlyTransform(ModuleMappingTransform):

--- a/QEfficient/transformers/models/seed_oss/__init__.py
+++ b/QEfficient/transformers/models/seed_oss/__init__.py
@@ -1,0 +1,6 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------

--- a/QEfficient/transformers/models/seed_oss/modeling_seed_oss.py
+++ b/QEfficient/transformers/models/seed_oss/modeling_seed_oss.py
@@ -1,0 +1,362 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from typing import List, Optional, Tuple, Type, Union
+
+import torch
+from torch import nn
+from transformers.cache_utils import Cache
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
+from transformers.models.seed_oss.configuration_seed_oss import SeedOssConfig
+from transformers.models.seed_oss.modeling_seed_oss import (
+    SeedOssAttention,
+    SeedOssDecoderLayer,
+    SeedOssForCausalLM,
+    SeedOssModel,
+    SeedOssRotaryEmbedding,
+    repeat_kv,
+    rotate_half,
+)
+
+from QEfficient.blocking.attention_blocking import (
+    AttentionBlockingConfig,
+    BlockingMode,
+    generic_blocked_attention_interface,
+    past_key_value_update,
+)
+from QEfficient.transformers.cache_utils import QEffDynamicCache
+from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
+from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
+
+
+class QEffSeedOssRotaryEmbedding(SeedOssRotaryEmbedding):
+    """
+    Precomputes a static sin/cos cache up to max_position_embeddings.
+    QEffSeedOssModel.__qeff_init__ reads .cos_cached / .sin_cached from this object
+    and stores them as model-level Parameters so the compiler sees them as
+    constant gather-sources.
+    """
+
+    def __init__(self, config: SeedOssConfig, device=None):
+        super().__init__(config=config, device=device)
+
+        t = torch.arange(self.max_seq_len_cached, device=self.inv_freq.device, dtype=torch.int64).type_as(
+            self.inv_freq
+        )
+        freqs = torch.outer(t, self.inv_freq)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        self.register_buffer("cos_cached", emb.cos().float(), persistent=False)
+        self.register_buffer("sin_cached", emb.sin().float(), persistent=False)
+
+
+def qeff_apply_rotary_pos_emb(q, k, cos, sin):
+    """Applies RoPE; cos/sin are already sliced and unsqueezed to [B, 1, S, head_dim]."""
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.to(q.dtype), k_embed.to(k.dtype)
+
+
+def eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    scaling: float,
+    **kwargs,
+):
+    # L2: repeat KV heads for GQA
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    # U1: use MIN_MASKED_ATTENTION_VALUE (not -inf) in torch.where
+    if attention_mask is not None:
+        attn_weights = torch.where(
+            attention_mask,
+            torch.tensor(MIN_MASKED_ATTENTION_VALUE, dtype=attn_weights.dtype),
+            attn_weights,
+        )
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output, attn_weights
+
+
+class QEffSeedOssAttention(SeedOssAttention):
+    """
+    SeedOss self-attention with QEfficient KV cache, blocking support, and
+    pre-threaded RoPE (position_embeddings already sliced at model level).
+    """
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor],
+        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        comp_ctx_lengths: Optional[torch.LongTensor] = None,
+        batch_index: Optional[torch.LongTensor] = None,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        kwargs.pop("output_attentions", None)
+        kwargs.pop("return_dict", None)
+        kwargs.pop("labels", None)
+
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+        # L1: apply pre-threaded RoPE (cos/sin sliced and unsqueezed at model level)
+        cos, sin = position_embeddings
+        query_states, key_states = qeff_apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        blocking_config = getattr(self, "attn_blocking_config", AttentionBlockingConfig())
+        use_blocking = blocking_config is not None and (blocking_config.mode != BlockingMode.NONE)
+
+        if use_blocking:
+            attn_output, attn_weights = generic_blocked_attention_interface(
+                module=self,
+                query=query_states,
+                key=key_states,
+                value=value_states,
+                attention_mask=attention_mask,
+                scaling=self.scaling,
+                layer_idx=self.layer_idx,
+                past_key_value=past_key_values,
+                blocking_config=blocking_config,
+                comp_ctx_length=comp_ctx_lengths,
+                batch_index=batch_index,
+                position_ids=position_ids,
+                past_seen_tokens=past_key_values.get_seq_length(self.layer_idx) if past_key_values is not None else 0,
+            )
+        else:
+            key_states, value_states, _ = past_key_value_update(
+                module=self,
+                key=key_states,
+                value=value_states,
+                attention_mask=attention_mask,
+                past_key_value=past_key_values,
+                comp_ctx_lengths=comp_ctx_lengths,
+                batch_index=batch_index,
+                position_ids=position_ids,
+            )
+            attn_output, attn_weights = eager_attention_forward(
+                self,
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                scaling=self.scaling,
+                **kwargs,
+            )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+class QEffSeedOssDecoderLayer(SeedOssDecoderLayer):
+    """
+    SeedOss decoder layer — threads pre-computed RoPE (position_embeddings) through
+    to the attention module; adds batch_index and comp_ctx_lengths for CB support.
+    """
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        comp_ctx_lengths: Optional[torch.LongTensor] = None,
+        batch_index: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            comp_ctx_lengths=comp_ctx_lengths,
+            batch_index=batch_index,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class QEffSeedOssModel(SeedOssModel):
+    """
+    SeedOss base model with:
+    - Single model-level RoPE computation (L1)
+    - QEffDynamicCache for KV cache
+    - Causal mask via _create_causal_mask
+    """
+
+    def __qeff_init__(self):
+        self.rotary_emb = QEffSeedOssRotaryEmbedding(config=self.config)
+        # attention_scaling=1.0 for default RoPE; kept explicit for future rope_scaling variants
+        self.cos_cached = torch.nn.Parameter(self.rotary_emb.cos_cached * self.rotary_emb.attention_scaling)
+        self.sin_cached = torch.nn.Parameter(self.rotary_emb.sin_cached * self.rotary_emb.attention_scaling)
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        comp_ctx_lengths: Optional[torch.LongTensor] = None,
+        batch_index: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Union[Tuple, BaseModelOutputWithPast]:
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        return_legacy_cache = False
+        if use_cache and not isinstance(past_key_values, Cache):
+            return_legacy_cache = True
+            past_key_values = QEffDynamicCache.from_legacy_cache(past_key_values)
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(
+                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+            )
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        causal_mask = _create_causal_mask(position_ids=position_ids, target_length=past_seen_tokens)
+
+        hidden_states = inputs_embeds
+
+        all_hidden_states = () if output_hidden_states else None
+
+        # L1: compute RoPE once at model level, thread as position_embeddings to all layers
+        cos = self.cos_cached[position_ids].unsqueeze(1)  # [B, 1, S, head_dim]
+        sin = self.sin_cached[position_ids].unsqueeze(1)  # [B, 1, S, head_dim]
+        position_embeddings = (cos, sin)
+
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask,
+                position_embeddings=position_embeddings,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                comp_ctx_lengths=comp_ctx_lengths,
+                batch_index=batch_index,
+                use_cache=use_cache,
+                cache_position=cache_position,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if return_legacy_cache:
+            past_key_values = past_key_values.to_legacy_cache()
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+            hidden_states=all_hidden_states,
+        )
+
+
+class QEffSeedOssForCausalLM(SeedOssForCausalLM):
+    """
+    SeedOss causal LM with INT32 last-token logit extraction (U2).
+    """
+
+    def get_submodules_for_export(self) -> Type[nn.Module]:
+        return {QEffSeedOssDecoderLayer}
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Union[Cache, List[torch.FloatTensor]]] = None,
+        comp_ctx_lengths: Optional[torch.LongTensor] = None,
+        batch_index: Optional[torch.LongTensor] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            comp_ctx_lengths=comp_ctx_lengths,
+            batch_index=batch_index,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        # U2: INT32 index for last-token logit gather (not INT64)
+        logit_index = position_ids.to(torch.int32).argmax(1, keepdim=True)
+        hidden_states = outputs.last_hidden_state[torch.arange(position_ids.shape[0]).view(-1, 1), logit_index]
+        logits = self.lm_head(hidden_states).float()
+
+        return CausalLMOutputWithPast(
+            loss=None,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )

--- a/QEfficient/utils/run_utils.py
+++ b/QEfficient/utils/run_utils.py
@@ -107,6 +107,9 @@ class ApiRunner:
             :numpy.ndarray: Generated output tokens
         """
         model_inputs = self.input_handler.tokenizer(self.input_handler.prompt[0], return_tensors="pt")
+        # token_type_ids is returned by some PreTrainedTokenizerFast instances but is not a
+        # valid kwarg for decoder-only causal-LMs; drop it to avoid _validate_model_kwargs errors.
+        model_inputs.pop("token_type_ids", None)
 
         input_len = model_inputs["input_ids"].shape[-1]
 

--- a/tests/configs/causal_model_configs.json
+++ b/tests/configs/causal_model_configs.json
@@ -40,6 +40,18 @@
       }
     },
     {
+      "model_name": "ByteDance-Seed/Seed-OSS-36B-Instruct",
+      "model_type": "seed_oss",
+      "additional_params": {
+        "num_hidden_layers": 1,
+        "hidden_size": 64,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "intermediate_size": 256,
+        "head_dim": 16
+      }
+    },
+    {
       "model_name": "Salesforce/codegen-350M-mono",
       "model_type": "codegen",
       "additional_params": {


### PR DESCRIPTION
## Summary
- Add QEfficient support for `SeedOssForCausalLM` (`ByteDance-Seed/Seed-OSS-36B-Instruct`)
- Add new model files under `QEfficient/transformers/models/seed_oss/`
- Register SeedOss mappings in `pytorch_transforms.py`
- Add tiny test config entry for `seed_oss`
- Fix HF generation helper to drop `token_type_ids` before decoder-only `generate()`

## Validation
- Tiny 4-stage pipeline: PASS
- Full compile: PASS (~42 min, TS4 4-device, mxfp6+mxint8_kv, ctx=1024)
- TTFT: 0.29 s
- Decode: 13.3 tok/s (64% of 20.9 tok/s roofline)
- Quality: P1 ratio 1.048 PASS; P2 raw 1.329 WARN due single first-token mxfp6 divergence; stripped-content ratio 0.715

## Notes
- Architecture category: LLM (decoder-only)
- Branch includes model-onboarding fixes observed during validation