### PR TITLE
(bugfix): Clarify CausalLM decode-only flag handling and fix PL=1 specialization naming

### DIFF
--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -3059,6 +3059,12 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         str
             Path to the generated ONNX graph file.
         """
+        if kwargs.pop("decode_only", False):
+            raise NotImplementedError(
+                "decode_only=True is not supported by QEFFAutoModelForCausalLM.export(). "
+                "Use the default non-prefill export path for standard CausalLM decode graphs."
+            )
+
         bs: int = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
         seq_len: int = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
 
@@ -3076,6 +3082,15 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             self.model.config, fbs if self.continuous_batching else bs, seq_len
         )
         enable_chunking = kwargs.get("enable_chunking", False)
+        if (
+            kwargs.get("retain_full_kv", False)
+            and self.model.config.model_type not in SPECIALIZED_DISAGG_SERVING_MODEL_ARCH
+        ):
+            logger.warning(
+                "retain_full_kv=True is only supported for specialized disaggregated serving models "
+                f"{sorted(SPECIALIZED_DISAGG_SERVING_MODEL_ARCH)}; ignoring it for model_type "
+                f"'{self.model.config.model_type}'."
+            )
 
         # TODO: move this to a DA Serving utility class
         if self.model.config.model_type in SPECIALIZED_DISAGG_SERVING_MODEL_ARCH:
@@ -3307,7 +3322,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         if full_batch_size:
             spec["full_batch_exec_size"] = exec_batch_size
         result = {k: v for k, v in spec.items() if v is not None}
-        result["_graph_name"] = "Prefill"
+        result["_graph_name"] = "Decode" if prefill_seq_len == 1 and kwargs.get("prefill_only") is False else "Prefill"
         return result
 
     def build_decode_specialization(
@@ -3544,6 +3559,14 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         ):
             raise ValueError("Currently, sampler does not support `num_speculative_tokens` > 0.")
 
+        if retain_full_kv and self.model.config.model_type not in SPECIALIZED_DISAGG_SERVING_MODEL_ARCH:
+            logger.warning(
+                "retain_full_kv=True is only supported for specialized disaggregated serving models "
+                f"{sorted(SPECIALIZED_DISAGG_SERVING_MODEL_ARCH)}; ignoring it for model_type "
+                f"'{self.model.config.model_type}'."
+            )
+            retain_full_kv = False
+
         # --- Specializations ---
         specializations = []
         if prefill_only is None or prefill_only or prefill_seq_len == 1:
@@ -3560,6 +3583,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                             batch_size=batch_size,
                             kv_cache_batch_size=kv_cache_batch_size,
                             full_batch_size=full_batch_size,
+                            prefill_only=prefill_only,
                         )
                     )
 

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -710,6 +710,54 @@ def test_proxy_toggle_onnx_transform_policy_for_vlm():
     _assert_proxy_only_onnx_transform_policy(qeff_proxy, enable_proxy=True)
 
 
+class TestCausalLMFlagDiagnostics:
+    """Unsupported/ignored CausalLM flags should fail or warn clearly."""
+
+    def _tiny_llama(self):
+        try:
+            return QEFFAutoModelForCausalLM.from_pretrained(
+                CAUSAL_RUNTIME_MODEL_IDS["llama"],
+                continuous_batching=True,
+                num_hidden_layers=2,
+                **MODEL_KWARGS,
+            )
+        except Exception as exc:
+            _skip_on_model_fetch_error(exc, CAUSAL_RUNTIME_MODEL_IDS["llama"])
+
+    def test_export_decode_only_rejected_for_standard_causal_lm(self, tmp_path):
+        qeff_model = self._tiny_llama()
+
+        with pytest.raises(NotImplementedError, match="decode_only=True is not supported"):
+            qeff_model.export(tmp_path / "decode-only", decode_only=True)
+
+    def test_compile_retain_full_kv_ignored_for_llama(self, tmp_path, monkeypatch, caplog):
+        qeff_model = self._tiny_llama()
+        onnx_path = tmp_path / "model.onnx"
+        onnx_path.write_bytes(b"fake")
+        captured_kwargs = {}
+
+        def fake_compile(**kwargs):
+            captured_kwargs.update(kwargs)
+            return tmp_path / "qpc"
+
+        monkeypatch.setattr(qeff_model, "_compile", fake_compile)
+        caplog.set_level(logging.WARNING, logger="QEfficient")
+
+        qeff_model.compile(
+            onnx_path=str(onnx_path),
+            compile_dir=str(tmp_path),
+            prefill_seq_len=1,
+            ctx_len=128,
+            full_batch_size=1,
+            prefill_only=False,
+            retain_full_kv=True,
+        )
+
+        assert captured_kwargs["retain_full_kv"] is False
+        assert captured_kwargs["specializations"][0]["_graph_name"] == "Decode"
+        assert "retain_full_kv=True is only supported" in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # Tests for the named-specializations format (backend team feature request)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR verifies the reported Llama decode-only compile behaviour

**Findings**:

  - `decode_only=True` is currently not supported by `QEFFAutoModelForCausalLM.export()`.
  - `retain_full_kv=True` is only applicable to specialized disaggregated-serving models such as GPT-OSS/Kimi, and has no
    effect for Llama.
  - `prefill_seq_len=1` with prefill_only=False was incorrectly tagged as Prefill in the generated specialization metadata.

**Changes**:

  - Raise a clear `NotImplementedError `when `decode_only=True` is passed to CausalLM export.
  - Warn and ignore `retain_full_kv=True` for non-specialized models such as Llama.
  - Tag `prefill_seq_len=1 and prefill_only=False` specializations as Decode.
  - Add quickcheck unit coverage for unsupported decode_only, ignored Llama retain_full_kv, and PL=1 decode specialization
    naming.

**Validation**:

  - Verified PL=1 now emits "name": "Decode" in specialization output.
  - Added unit test and Ran focused quickcheck tests successfully:
      - PYENV_VERSION=qeff pytest -q tests/unit_test/models/test_model_quickcheck.py::TestCausalLMFlagDiagnostics

cc: @quic-hemagnih @quic-rishinr