### PR TITLE
fix(0306): ONNX reuse for disaggregated compile and diffusion module

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -562,11 +562,11 @@ class QEFFBaseModel(ABC):
 
         moe_prefill_packed_chunk_size = compiler_options.pop("moe_prefill_packed_chunk_size", None)
         if onnx_path is None:
-            # Reuse an existing ONNX only when weights are already offloaded; otherwise
-            # export again so decode/prefill compile modes can produce different graphs.
-            if self.onnx_path is not None and (
-                self._is_weights_offloaded or any(param.is_meta for param in self.model.parameters())
-            ):
+            # If weights were offloaded after export, compiling must use the existing
+            # ONNX because re-exporting is no longer possible. Otherwise export for
+            # the current compile mode, e.g. decode vs. disaggregated prefill.
+            weights_offloaded = self._is_weights_offloaded or any(param.is_meta for param in self.model.parameters())
+            if self.onnx_path is not None and weights_offloaded:
                 onnx_path = self.onnx_path
             else:
                 onnx_path = self.get_onnx_path(

--- a/QEfficient/diffusers/pipelines/pipeline_module.py
+++ b/QEfficient/diffusers/pipelines/pipeline_module.py
@@ -130,7 +130,7 @@ class QEffTextEncoder(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options (e.g., num_cores, aic_num_of_activations)
         """
-        self._compile(specializations=specializations, **compiler_options)
+        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
 
 
 class QEffUNet(QEFFBaseModel):
@@ -207,7 +207,7 @@ class QEffUNet(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options
         """
-        self._compile(specializations=specializations, **compiler_options)
+        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
 
 
 class QEffVAE(QEFFBaseModel):
@@ -394,7 +394,7 @@ class QEffVAE(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options
         """
-        self._compile(specializations=specializations, **compiler_options)
+        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
 
 
 class QEffFluxTransformerModel(QEFFBaseModel):
@@ -543,7 +543,7 @@ class QEffFluxTransformerModel(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options (e.g., num_cores, aic_num_of_activations)
         """
-        self._compile(specializations=specializations, **compiler_options)
+        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
 
 
 class QEffWanTransformer(QEFFBaseModel):
@@ -630,7 +630,7 @@ class QEffWanTransformer(QEFFBaseModel):
         )
 
     def compile(self, specializations, **compiler_options) -> None:
-        self._compile(specializations=specializations, **compiler_options)
+        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
 
 
 class QEffWanUnifiedTransformer(QEFFBaseModel):
@@ -773,4 +773,4 @@ class QEffWanUnifiedTransformer(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options (e.g., num_cores, aic_num_of_activations)
         """
-        self._compile(specializations=specializations, **compiler_options)
+        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)

--- a/QEfficient/diffusers/pipelines/pipeline_module.py
+++ b/QEfficient/diffusers/pipelines/pipeline_module.py
@@ -130,7 +130,7 @@ class QEffTextEncoder(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options (e.g., num_cores, aic_num_of_activations)
         """
-        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
+        self._compile(specializations=specializations, **compiler_options)
 
 
 class QEffUNet(QEFFBaseModel):
@@ -207,7 +207,7 @@ class QEffUNet(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options
         """
-        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
+        self._compile(specializations=specializations, **compiler_options)
 
 
 class QEffVAE(QEFFBaseModel):
@@ -394,7 +394,7 @@ class QEffVAE(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options
         """
-        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
+        self._compile(specializations=specializations, **compiler_options)
 
 
 class QEffFluxTransformerModel(QEFFBaseModel):
@@ -543,7 +543,7 @@ class QEffFluxTransformerModel(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options (e.g., num_cores, aic_num_of_activations)
         """
-        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
+        self._compile(specializations=specializations, **compiler_options)
 
 
 class QEffWanTransformer(QEFFBaseModel):
@@ -630,7 +630,7 @@ class QEffWanTransformer(QEFFBaseModel):
         )
 
     def compile(self, specializations, **compiler_options) -> None:
-        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
+        self._compile(specializations=specializations, **compiler_options)
 
 
 class QEffWanUnifiedTransformer(QEFFBaseModel):
@@ -773,4 +773,4 @@ class QEffWanUnifiedTransformer(QEFFBaseModel):
             specializations (List[Dict]): Model specialization configurations
             **compiler_options: Additional compiler options (e.g., num_cores, aic_num_of_activations)
         """
-        self._compile(onnx_path=self.onnx_path, specializations=specializations, **compiler_options)
+        self._compile(specializations=specializations, **compiler_options)

--- a/QEfficient/diffusers/pipelines/pipeline_utils.py
+++ b/QEfficient/diffusers/pipelines/pipeline_utils.py
@@ -159,7 +159,11 @@ def compile_modules_parallel(
     def _prepare_and_compile(module_name: str, module_obj: Any) -> None:
         """Prepare specializations and compile a single module."""
         specializations = config["modules"][module_name]["specializations"].copy()
-        compile_kwargs = config["modules"][module_name]["compilation"]
+        compile_kwargs = config["modules"][module_name]["compilation"].copy()
+        # Diffusion pipelines export modules before compile. Use that ONNX here
+        # so compile does not re-export modules with incompatible export APIs.
+        if compile_kwargs.get("onnx_path") is None:
+            compile_kwargs["onnx_path"] = module_obj.onnx_path
 
         if (
             specialization_updates and module_name in specialization_updates
@@ -218,7 +222,11 @@ def compile_modules_sequential(
     for module_name, module_obj in tqdm(modules.items(), desc="Compiling modules", unit="module"):
         module_config = config["modules"]
         specializations = module_config[module_name]["specializations"].copy()
-        compile_kwargs = module_config[module_name]["compilation"]
+        compile_kwargs = module_config[module_name]["compilation"].copy()
+        # Diffusion pipelines export modules before compile. Use that ONNX here
+        # so compile does not re-export modules with incompatible export APIs.
+        if compile_kwargs.get("onnx_path") is None:
+            compile_kwargs["onnx_path"] = module_obj.onnx_path
 
         if (
             specialization_updates and module_name in specialization_updates


### PR DESCRIPTION
This PR fixes stale ONNX reuse in the shared compile path.

  Problem:
  - `_compile()` could reuse `self.onnx_path` from a previous compile.
  - In disaggregated serving, decode compile and prefill/chunked prefill compile need different ONNX graphs because the exported model forward/transforms differ.
  - Reusing decode ONNX for prefill could produce multiple QPCs from the same graph, which is incorrect for MoE prefill optimization.
  - For diffusion pipelines, compile can run after export, and some modules such as `QEffVAE` do not accept generic export kwargs like `offload_pt_weights`, causing CI failures when compile tried to re-export.

  Fix:
  - In `QEFFBaseModel._compile()`, reuse an existing ONNX only when weights are already offloaded/meta, since re-export is not possible in that state.
  - Otherwise, export for the current compile mode so decode and prefill/chunked prefill can produce distinct ONNX graphs.
  - In diffusion pipeline modules, pass `onnx_path=self.onnx_path` explicitly into `_compile()` so those modules compile the already-exported graph and avoid unintended re-export.

  Validation:
  - Qwen3-MoE disaggregated decode + chunked prefill ONNX regression passed.
  - VLM subfunction regression passed.