### PR TITLE
Reduce whole-model ONNX export memory

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -48,6 +48,15 @@ from QEfficient.utils import (
     to_named_specializations,
 )
 from QEfficient.utils.export_utils import export_wrapper
+from QEfficient.utils.mem_profile import (
+    ExportMemoryProfiler,
+    flatten_torch_tensors,
+    onnx_initializer_summary,
+    profile_torch_onnx_internals,
+)
+from QEfficient.utils.onnx_external_weights import (
+    attach_external_initializers_from_torch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -307,6 +316,19 @@ class QEFFBaseModel(ABC):
         """
         # TODO: Hack for retain_full_kv, handle this outside
         export_kwargs.pop("retain_full_kv", None)
+        low_memory_external_initializers = export_kwargs.pop("_qeff_low_memory_external_initializers", False)
+        export_params_disabled = export_kwargs.get("export_params") is False or os.environ.get(
+            "QEFF_ONNX_EXPORT_PARAMS", ""
+        ).lower() in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }
+        low_memory_external_initializers = low_memory_external_initializers or export_params_disabled
+        if low_memory_external_initializers:
+            export_kwargs.setdefault("export_params", False)
+            export_kwargs.setdefault("do_constant_folding", False)
         onnx_path = export_dir / f"{self.model_name}.onnx"
 
         # Return early if ONNX already exists
@@ -388,51 +410,92 @@ class QEFFBaseModel(ABC):
             dynamic_axes = {rename_map.get(k, k): v for k, v in dynamic_axes.items()}
             input_names = aligned_input_names
 
-        try:
-            torch.onnx.export(
-                self.model,
-                (),
-                str(onnx_path),
-                kwargs=example_inputs,
-                input_names=input_names,
-                output_names=output_names,
-                dynamic_axes=dynamic_axes,
-                opset_version=constants.ONNX_EXPORT_OPSET,
-                **export_kwargs,
-            )
-            logger.info("PyTorch export successful")
-            _ = self._offload_model_weights(offload_pt_weights)
-            model = onnx.load(onnx_path, load_external_data=False)
+        with ExportMemoryProfiler(f"{self.model_name}._export") as mem_profiler:
+            mem_profiler.tensor_summary("model.parameters", self.model.parameters())
+            mem_profiler.tensor_summary("model.buffers", self.model.buffers())
+            mem_profiler.tensor_summary("example_inputs", flatten_torch_tensors(example_inputs))
 
-            needs_external_tensor_data = any(
-                transform in self._onnx_transforms for transform in (FP16ClipTransform, SplitTensorsTransform)
-            )
-            transform_kwargs = {
-                "onnx_base_dir": str(export_dir) if needs_external_tensor_data else None,
-                "model_name": self.model_name,
-            }
-            if onnx_transform_kwargs is not None:
-                transform_kwargs.update(onnx_transform_kwargs)
+            try:
+                with mem_profiler.stage("torch.onnx.export"), profile_torch_onnx_internals(mem_profiler):
+                    torch.onnx.export(
+                        self.model,
+                        (),
+                        str(onnx_path),
+                        kwargs=example_inputs,
+                        input_names=input_names,
+                        output_names=output_names,
+                        dynamic_axes=dynamic_axes,
+                        opset_version=constants.ONNX_EXPORT_OPSET,
+                        **export_kwargs,
+                    )
+                logger.info("PyTorch export successful")
+                mem_profiler.snapshot(
+                    "torch.onnx.export.file",
+                    {
+                        "onnx_path": str(onnx_path),
+                        "file_size_bytes": onnx_path.stat().st_size if onnx_path.exists() else None,
+                    },
+                )
 
-            onnx_transforms = OnnxTransformPipeline(transforms=self._onnx_transforms)
-            model, transformed = onnx_transforms.apply(model, **transform_kwargs)
+                needs_external_tensor_data = any(
+                    transform in self._onnx_transforms for transform in (FP16ClipTransform, SplitTensorsTransform)
+                )
+                if low_memory_external_initializers and needs_external_tensor_data:
+                    raise RuntimeError(
+                        "QEFF_LOW_MEMORY_ONNX_EXPORT is incompatible with ONNX transforms that need tensor data "
+                        "loaded into the ModelProto. Disable FP16ClipTransform/SplitTensorsTransform or unset "
+                        "QEFF_LOW_MEMORY_ONNX_EXPORT."
+                    )
 
-            # Add metadata to the model
-            model.metadata_props.append(
-                onnx.StringStringEntryProto(key="qeff_transforms", value=",".join(self._transform_names()))
-            )
-            logger.info("ONNX transforms applied")
+                if low_memory_external_initializers:
+                    with mem_profiler.stage("onnx.load.graph_only", {"load_external_data": False}):
+                        model = onnx.load(onnx_path, load_external_data=False)
+                    with mem_profiler.stage("onnx.attach_external_initializers"):
+                        external_summary = attach_external_initializers_from_torch(model, self.model, onnx_path)
+                    mem_profiler.snapshot("onnx.attach_external_initializers.summary", external_summary)
+                    with mem_profiler.stage("offload_pt_weights", {"enabled": offload_pt_weights}):
+                        _ = self._offload_model_weights(offload_pt_weights)
+                else:
+                    with mem_profiler.stage("offload_pt_weights", {"enabled": offload_pt_weights}):
+                        _ = self._offload_model_weights(offload_pt_weights)
+                    with mem_profiler.stage("onnx.load", {"load_external_data": False}):
+                        model = onnx.load(onnx_path, load_external_data=False)
+                mem_profiler.snapshot("onnx.load.summary", onnx_initializer_summary(model))
 
-            onnx_path_tmp = onnx_path.with_suffix(onnx_path.suffix + ".tmp")
-            onnx.save(model, onnx_path_tmp)
-            onnx_path_tmp.replace(onnx_path)
-            del model
-            gc.collect()
-            logger.info("Transformed ONNX saved")
+                transform_kwargs = {
+                    "onnx_base_dir": str(export_dir) if needs_external_tensor_data else None,
+                    "model_name": self.model_name,
+                }
+                if onnx_transform_kwargs is not None:
+                    transform_kwargs.update(onnx_transform_kwargs)
 
-        except Exception as e:
-            logger.error(f"ONNX export or transforms failed: {e}")
-            raise e
+                onnx_transforms = OnnxTransformPipeline(transforms=self._onnx_transforms)
+                with mem_profiler.stage("onnx.transforms", {"transforms": ",".join(self._transform_names())}):
+                    model, transformed = onnx_transforms.apply(model, **transform_kwargs)
+
+                # Add metadata to the model
+                model.metadata_props.append(
+                    onnx.StringStringEntryProto(key="qeff_transforms", value=",".join(self._transform_names()))
+                )
+                logger.info("ONNX transforms applied")
+
+                onnx_path_tmp = onnx_path.with_suffix(onnx_path.suffix + ".tmp")
+                with mem_profiler.stage("onnx.save"):
+                    if low_memory_external_initializers:
+                        with open(onnx_path_tmp, "wb") as onnx_file:
+                            onnx_file.write(model.SerializeToString())
+                    else:
+                        onnx.save(model, onnx_path_tmp)
+                with mem_profiler.stage("onnx.replace"):
+                    onnx_path_tmp.replace(onnx_path)
+                with mem_profiler.stage("onnx.model.free"):
+                    del model
+                    gc.collect()
+                logger.info("Transformed ONNX saved")
+
+            except Exception as e:
+                logger.error(f"ONNX export or transforms failed: {e}")
+                raise e
 
         self.onnx_path = onnx_path
         return onnx_path

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -8,6 +8,7 @@
 import gc
 import inspect
 import logging
+import os
 import shutil
 import subprocess
 import warnings
@@ -59,6 +60,45 @@ from QEfficient.utils.onnx_external_weights import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class LowMemoryExternalInitializerError(RuntimeError):
+    """Raised when low-memory ONNX initializer reconstruction is incomplete."""
+
+
+def _validate_low_memory_external_initializers(
+    model, external_summary: Dict[str, object], input_names: List[str]
+) -> None:
+    """Validate that externalized torch weights are no longer graph inputs."""
+
+    unsupported_count = int(external_summary.get("unsupported_initializer_input_count", 0))
+    if unsupported_count:
+        raise LowMemoryExternalInitializerError(
+            "Low-memory ONNX export could not externalize graph inputs with unsupported dtypes: "
+            f"{external_summary.get('unsupported_initializer_inputs', [])}"
+        )
+
+    missing_count = int(external_summary.get("missing_initializer_input_count", 0))
+    if missing_count:
+        raise LowMemoryExternalInitializerError(
+            "Low-memory ONNX export left torch parameter/buffer inputs unattached: "
+            f"{external_summary.get('missing_initializer_inputs', [])}"
+        )
+
+    graph_input_names = {graph_input.name for graph_input in model.graph.input}
+    initializer_names = {initializer.name for initializer in model.graph.initializer}
+    overlapping_names = sorted(graph_input_names & initializer_names)
+    if overlapping_names:
+        raise LowMemoryExternalInitializerError(
+            f"Low-memory ONNX export left initializer names in graph inputs: {overlapping_names[:10]}"
+        )
+
+    unexpected_graph_inputs = sorted(graph_input_names - set(input_names))
+    if unexpected_graph_inputs:
+        raise LowMemoryExternalInitializerError(
+            "Low-memory ONNX export could not resolve unexpected graph inputs after external initializer "
+            f"attachment: {unexpected_graph_inputs[:10]}"
+        )
 
 
 class QEFFBaseModel(ABC):
@@ -328,7 +368,6 @@ class QEFFBaseModel(ABC):
         low_memory_external_initializers = low_memory_external_initializers or export_params_disabled
         if low_memory_external_initializers:
             export_kwargs.setdefault("export_params", False)
-            export_kwargs.setdefault("do_constant_folding", False)
         onnx_path = export_dir / f"{self.model_name}.onnx"
 
         # Return early if ONNX already exists
@@ -415,8 +454,16 @@ class QEFFBaseModel(ABC):
             mem_profiler.tensor_summary("model.buffers", self.model.buffers())
             mem_profiler.tensor_summary("example_inputs", flatten_torch_tensors(example_inputs))
 
-            try:
-                with mem_profiler.stage("torch.onnx.export"), profile_torch_onnx_internals(mem_profiler):
+            def _cleanup_partial_low_memory_export():
+                for path in (
+                    onnx_path,
+                    onnx_path.with_name(f"{onnx_path.name}.data"),
+                    onnx_path.with_suffix(onnx_path.suffix + ".tmp"),
+                ):
+                    path.unlink(missing_ok=True)
+
+            def _run_torch_onnx_export(current_export_kwargs, stage_name):
+                with mem_profiler.stage(stage_name), profile_torch_onnx_internals(mem_profiler):
                     torch.onnx.export(
                         self.model,
                         (),
@@ -426,16 +473,28 @@ class QEFFBaseModel(ABC):
                         output_names=output_names,
                         dynamic_axes=dynamic_axes,
                         opset_version=constants.ONNX_EXPORT_OPSET,
-                        **export_kwargs,
+                        **current_export_kwargs,
                     )
                 logger.info("PyTorch export successful")
                 mem_profiler.snapshot(
-                    "torch.onnx.export.file",
+                    f"{stage_name}.file",
                     {
                         "onnx_path": str(onnx_path),
                         "file_size_bytes": onnx_path.stat().st_size if onnx_path.exists() else None,
                     },
                 )
+
+            def _load_model_with_external_initializers():
+                with mem_profiler.stage("onnx.load.graph_only", {"load_external_data": False}):
+                    graph_model = onnx.load(onnx_path, load_external_data=False)
+                with mem_profiler.stage("onnx.attach_external_initializers"):
+                    external_summary = attach_external_initializers_from_torch(graph_model, self.model, onnx_path)
+                _validate_low_memory_external_initializers(graph_model, external_summary, input_names)
+                mem_profiler.snapshot("onnx.attach_external_initializers.summary", external_summary)
+                return graph_model
+
+            try:
+                _run_torch_onnx_export(export_kwargs, "torch.onnx.export")
 
                 needs_external_tensor_data = any(
                     transform in self._onnx_transforms for transform in (FP16ClipTransform, SplitTensorsTransform)
@@ -448,11 +507,19 @@ class QEFFBaseModel(ABC):
                     )
 
                 if low_memory_external_initializers:
-                    with mem_profiler.stage("onnx.load.graph_only", {"load_external_data": False}):
-                        model = onnx.load(onnx_path, load_external_data=False)
-                    with mem_profiler.stage("onnx.attach_external_initializers"):
-                        external_summary = attach_external_initializers_from_torch(model, self.model, onnx_path)
-                    mem_profiler.snapshot("onnx.attach_external_initializers.summary", external_summary)
+                    try:
+                        model = _load_model_with_external_initializers()
+                    except LowMemoryExternalInitializerError as exc:
+                        logger.warning(
+                            "Low-memory ONNX external initializer reconstruction failed with default constant "
+                            "folding; retrying once with do_constant_folding=False. Error: %s",
+                            exc,
+                        )
+                        _cleanup_partial_low_memory_export()
+                        retry_export_kwargs = dict(export_kwargs)
+                        retry_export_kwargs["do_constant_folding"] = False
+                        _run_torch_onnx_export(retry_export_kwargs, "torch.onnx.export.retry_without_constant_folding")
+                        model = _load_model_with_external_initializers()
                     with mem_profiler.stage("offload_pt_weights", {"enabled": offload_pt_weights}):
                         _ = self._offload_model_weights(offload_pt_weights)
                 else:

--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -237,6 +237,31 @@ class RenameFunctionOutputsTransform(BaseOnnxTransform):
                         if orig in model_out_map:
                             graph.output[model_out_map[orig]].name = new
                 layer_idx += 1
+
+        # Fallback: the decoder layer may not have been emitted as an ONNX function
+        # (e.g. torch.onnx declines to functionize it). In that case the retained-state
+        # outputs remain as plain top-level nodes still carrying the `_InternalRetainedState`
+        # suffix that `_setup_onnx_subfunctions` applied. The compiler's custom-IO config
+        # expects the `_RetainedState` suffix, so rename any leftovers directly on the graph.
+        rename_map = {
+            out.name: out.name.replace("_InternalRetainedState", "_RetainedState")
+            for out in graph.output
+            if "_InternalRetainedState" in out.name
+        }
+        if rename_map:
+            renamed = True
+            for out in graph.output:
+                if out.name in rename_map:
+                    out.name = rename_map[out.name]
+            # Keep producers (and any consumers) consistent with the renamed tensors.
+            for node in graph.node:
+                for i, name in enumerate(node.output):
+                    if name in rename_map:
+                        node.output[i] = rename_map[name]
+                for i, name in enumerate(node.input):
+                    if name in rename_map:
+                        node.input[i] = rename_map[name]
+
         return renamed
 
 

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -82,9 +82,8 @@ from QEfficient.utils import (
 from QEfficient.utils.check_ccl_specializations import process_ccl_specializations
 from QEfficient.utils.logging_utils import logger
 from QEfficient.utils.safetensor_materializer import (
-    load_safetensor_checkpoint_into_model,
-    maybe_materialize_safetensor_checkpoint,
-    normalize_torch_dtype,
+    load_hf_model_with_optional_safetensor_streaming,
+    prepare_safetensor_streaming_from_pretrained_source,
 )
 from QEfficient.utils.sampler_utils import get_sampling_inputs_and_outputs
 
@@ -100,10 +99,6 @@ TORCH_TO_NUMPY_DTYPE_MAP = {
     torch.bfloat16: np.float16,  # Since numpy doesn't support bfloat16
     torch.float32: np.float32,
 }
-
-
-_QEFF_STREAMING_CHECKPOINT_PATH_KWARG = "_qeff_streaming_checkpoint_path"
-_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG = "_qeff_streaming_checkpoint_dtype"
 
 
 def _resolve_torch_dtype(kwargs: dict) -> None:
@@ -260,108 +255,6 @@ def _filter_custom_io_for_onnx(custom_io: dict, onnx_path: Optional[Union[str, P
     return filtered
 
 
-def _prepare_weight_materialized_from_pretrained_source(pretrained_model_name_or_path: str, kwargs: dict) -> str:
-    """Use explicit torch_dtype as the checkpoint/export precision for streaming load.
-
-    For example, torch_dtype=torch.float16 materializes floating safetensor
-    weights as fp16 first, then streams them into a meta-initialized model so
-    load/export does not hold both the source checkpoint dtype and fp16 copy.
-    If torch_dtype is omitted, this returns the original source and preserves
-    the existing Hugging Face load path.
-    """
-    requested_torch_dtype = kwargs.get("torch_dtype") if "torch_dtype" in kwargs else kwargs.get("dtype")
-    _resolve_torch_dtype(kwargs)
-    if requested_torch_dtype is None:
-        if kwargs.get("low_cpu_mem_usage", None):
-            logger.warning("Updating low_cpu_mem_usage=False")
-        kwargs["low_cpu_mem_usage"] = False
-        return pretrained_model_name_or_path
-
-    try:
-        materialized_checkpoint = maybe_materialize_safetensor_checkpoint(
-            pretrained_model_name_or_path,
-            kwargs.get("torch_dtype"),
-            cache_dir=os.environ.get("QEFF_MATERIALIZED_CHECKPOINT_DIR"),
-            revision=kwargs.get("revision"),
-            token=kwargs.get("token", kwargs.get("use_auth_token")),
-            local_files_only=kwargs.get("local_files_only", False),
-            hub_cache_dir=kwargs.get("cache_dir"),
-        )
-    except (OSError, ValueError) as exc:
-        logger.warning("Skipping QEfficient streaming checkpoint load: %s", exc)
-        materialized_checkpoint = None
-
-    if materialized_checkpoint is None:
-        if kwargs.get("low_cpu_mem_usage", None):
-            logger.warning("Updating low_cpu_mem_usage=False")
-        kwargs["low_cpu_mem_usage"] = False
-        return pretrained_model_name_or_path
-
-    kwargs[_QEFF_STREAMING_CHECKPOINT_PATH_KWARG] = str(materialized_checkpoint.path)
-    kwargs[_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG] = kwargs.get("torch_dtype")
-    kwargs["low_cpu_mem_usage"] = True
-    kwargs["use_safetensors"] = True
-    if materialized_checkpoint.materialized:
-        logger.info(
-            "Loading model from QEfficient materialized %s checkpoint: %s",
-            materialized_checkpoint.target_dtype,
-            materialized_checkpoint.path,
-        )
-    return str(materialized_checkpoint.path)
-
-
-def _set_config_torch_dtype(config, torch_dtype: torch.dtype) -> None:
-    if config is None:
-        return
-    if hasattr(config, "torch_dtype"):
-        config.torch_dtype = torch_dtype
-    for child_name in ("text_config", "vision_config", "llm_config"):
-        if hasattr(config, child_name):
-            _set_config_torch_dtype(getattr(config, child_name), torch_dtype)
-
-
-def _load_hf_model_with_optional_streaming(auto_class, pretrained_model_name_or_path, args: tuple, kwargs: dict):
-    streaming_checkpoint_path = kwargs.pop(_QEFF_STREAMING_CHECKPOINT_PATH_KWARG, None)
-    streaming_dtype = kwargs.pop(_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG, None)
-    if streaming_checkpoint_path is None:
-        return auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
-
-    if args:
-        logger.warning("QEfficient streaming checkpoint load does not support positional model args; using HF loader.")
-        return auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
-
-    config = kwargs.get("config")
-    if config is None:
-        config_kwargs = {}
-        for key in ("cache_dir", "revision", "token", "use_auth_token", "local_files_only", "trust_remote_code"):
-            if key in kwargs:
-                config_kwargs[key] = kwargs[key]
-        config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
-
-    constructor_kwargs = {}
-    for key in ("attn_implementation", "trust_remote_code", "torch_dtype", "dtype"):
-        if key in kwargs:
-            constructor_kwargs[key] = kwargs[key]
-
-    normalized_streaming_dtype = normalize_torch_dtype(streaming_dtype)
-    if normalized_streaming_dtype is not None:
-        _set_config_torch_dtype(config, normalized_streaming_dtype)
-
-    logger.info("Streaming safetensors checkpoint into model from %s", streaming_checkpoint_path)
-    with torch.device("meta"):
-        model = auto_class.from_config(config, **constructor_kwargs)
-    if normalized_streaming_dtype is not None:
-        _set_config_torch_dtype(getattr(model, "config", None), normalized_streaming_dtype)
-    load_summary = load_safetensor_checkpoint_into_model(model, streaming_checkpoint_path, target_dtype=streaming_dtype)
-    logger.info(
-        "Loaded %s tensors (%s bytes) through QEfficient streaming safetensor loader",
-        load_summary.loaded_tensor_count,
-        load_summary.loaded_tensor_bytes,
-    )
-    model.eval()
-    return model
-
-
 class QEFFTransformersBase(QEFFBaseModel):
     """
     Base class for QEfficient wrappers around HuggingFace transformer models.
@@ -423,10 +316,12 @@ class QEFFTransformersBase(QEFFBaseModel):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+        pretrained_model_name_or_path = prepare_safetensor_streaming_from_pretrained_source(
             pretrained_model_name_or_path, kwargs
         )
-        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
+        model = load_hf_model_with_optional_safetensor_streaming(
+            cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs
+        )
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -593,10 +488,12 @@ class QEFFAutoModel(QEFFTransformersBase):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+        pretrained_model_name_or_path = prepare_safetensor_streaming_from_pretrained_source(
             pretrained_model_name_or_path, kwargs
         )
-        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
+        model = load_hf_model_with_optional_safetensor_streaming(
+            cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs
+        )
 
         # This is support models that should be classified to in a different auto class but transformers load them via this class
         kv_offload = kwargs.pop("kv_offload", None)
@@ -976,10 +873,12 @@ class QEFFAutoModelForSequenceClassification(QEFFTransformersBase):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+        pretrained_model_name_or_path = prepare_safetensor_streaming_from_pretrained_source(
             pretrained_model_name_or_path, kwargs
         )
-        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
+        model = load_hf_model_with_optional_safetensor_streaming(
+            cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs
+        )
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
         return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path, **kwargs)
 
@@ -1578,10 +1477,12 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             }
         )
 
-        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+        pretrained_model_name_or_path = prepare_safetensor_streaming_from_pretrained_source(
             pretrained_model_name_or_path, kwargs
         )
-        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, (), kwargs)
+        model = load_hf_model_with_optional_safetensor_streaming(
+            cls._hf_auto_class, pretrained_model_name_or_path, (), kwargs
+        )
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -2730,16 +2631,16 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        from transformers import AutoConfig
-
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
         config._attn_implementation = "eager"
         config.vision_config.use_flash_attn = "false"
         kwargs["config"] = config
-        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+        pretrained_model_name_or_path = prepare_safetensor_streaming_from_pretrained_source(
             pretrained_model_name_or_path, kwargs
         )
-        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
+        model = load_hf_model_with_optional_safetensor_streaming(
+            cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs
+        )
         kwargs.pop("config", None)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
@@ -3407,10 +3308,12 @@ class QEFFAutoModelForImageTextToText:
             # only used as a config holder.
             model = _build_meta_model(cls._hf_auto_class, pretrained_model_name_or_path, kwargs)
         else:
-            pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+            pretrained_model_name_or_path = prepare_safetensor_streaming_from_pretrained_source(
                 pretrained_model_name_or_path, kwargs
             )
-            model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, (), kwargs)
+            model = load_hf_model_with_optional_safetensor_streaming(
+                cls._hf_auto_class, pretrained_model_name_or_path, (), kwargs
+            )
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -3684,10 +3587,12 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             # model internally via the layer-wise driver.
             model = _build_meta_model(cls._hf_auto_class, pretrained_model_name_or_path, kwargs)
         else:
-            pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+            pretrained_model_name_or_path = prepare_safetensor_streaming_from_pretrained_source(
                 pretrained_model_name_or_path, kwargs
             )
-            model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
+            model = load_hf_model_with_optional_safetensor_streaming(
+                cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs
+            )
         if qaic_config is not None:
             qaic_config["pretrained_model_name_or_path"] = pretrained_model_name_or_path
 
@@ -5209,10 +5114,12 @@ class QEFFAutoModelForCTC(QEFFTransformersBase):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+        pretrained_model_name_or_path = prepare_safetensor_streaming_from_pretrained_source(
             pretrained_model_name_or_path, kwargs
         )
-        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
+        model = load_hf_model_with_optional_safetensor_streaming(
+            cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs
+        )
 
         # This is support models that should be classified to in a different auto class but transformers load them via this class
         kv_offload = kwargs.pop("kv_offload", None)

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -16,6 +16,7 @@ import onnx
 import torch
 import torch.nn as nn
 from transformers import (
+    AutoConfig,
     AutoImageProcessor,
     AutoModel,
     AutoModelForCausalLM,
@@ -80,6 +81,11 @@ from QEfficient.utils import (
 )
 from QEfficient.utils.check_ccl_specializations import process_ccl_specializations
 from QEfficient.utils.logging_utils import logger
+from QEfficient.utils.safetensor_materializer import (
+    load_safetensor_checkpoint_into_model,
+    maybe_materialize_safetensor_checkpoint,
+    normalize_torch_dtype,
+)
 from QEfficient.utils.sampler_utils import get_sampling_inputs_and_outputs
 
 CUSTOM_IO_DTYPE_MAP = {
@@ -94,6 +100,10 @@ TORCH_TO_NUMPY_DTYPE_MAP = {
     torch.bfloat16: np.float16,  # Since numpy doesn't support bfloat16
     torch.float32: np.float32,
 }
+
+
+_QEFF_STREAMING_CHECKPOINT_PATH_KWARG = "_qeff_streaming_checkpoint_path"
+_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG = "_qeff_streaming_checkpoint_dtype"
 
 
 def _resolve_torch_dtype(kwargs: dict) -> None:
@@ -250,6 +260,108 @@ def _filter_custom_io_for_onnx(custom_io: dict, onnx_path: Optional[Union[str, P
     return filtered
 
 
+def _prepare_weight_materialized_from_pretrained_source(pretrained_model_name_or_path: str, kwargs: dict) -> str:
+    """Use explicit torch_dtype as the checkpoint/export precision for streaming load.
+
+    For example, torch_dtype=torch.float16 materializes floating safetensor
+    weights as fp16 first, then streams them into a meta-initialized model so
+    load/export does not hold both the source checkpoint dtype and fp16 copy.
+    If torch_dtype is omitted, this returns the original source and preserves
+    the existing Hugging Face load path.
+    """
+    requested_torch_dtype = kwargs.get("torch_dtype") if "torch_dtype" in kwargs else kwargs.get("dtype")
+    _resolve_torch_dtype(kwargs)
+    if requested_torch_dtype is None:
+        if kwargs.get("low_cpu_mem_usage", None):
+            logger.warning("Updating low_cpu_mem_usage=False")
+        kwargs["low_cpu_mem_usage"] = False
+        return pretrained_model_name_or_path
+
+    try:
+        materialized_checkpoint = maybe_materialize_safetensor_checkpoint(
+            pretrained_model_name_or_path,
+            kwargs.get("torch_dtype"),
+            cache_dir=os.environ.get("QEFF_MATERIALIZED_CHECKPOINT_DIR"),
+            revision=kwargs.get("revision"),
+            token=kwargs.get("token", kwargs.get("use_auth_token")),
+            local_files_only=kwargs.get("local_files_only", False),
+            hub_cache_dir=kwargs.get("cache_dir"),
+        )
+    except (OSError, ValueError) as exc:
+        logger.warning("Skipping QEfficient streaming checkpoint load: %s", exc)
+        materialized_checkpoint = None
+
+    if materialized_checkpoint is None:
+        if kwargs.get("low_cpu_mem_usage", None):
+            logger.warning("Updating low_cpu_mem_usage=False")
+        kwargs["low_cpu_mem_usage"] = False
+        return pretrained_model_name_or_path
+
+    kwargs[_QEFF_STREAMING_CHECKPOINT_PATH_KWARG] = str(materialized_checkpoint.path)
+    kwargs[_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG] = kwargs.get("torch_dtype")
+    kwargs["low_cpu_mem_usage"] = True
+    kwargs["use_safetensors"] = True
+    if materialized_checkpoint.materialized:
+        logger.info(
+            "Loading model from QEfficient materialized %s checkpoint: %s",
+            materialized_checkpoint.target_dtype,
+            materialized_checkpoint.path,
+        )
+    return str(materialized_checkpoint.path)
+
+
+def _set_config_torch_dtype(config, torch_dtype: torch.dtype) -> None:
+    if config is None:
+        return
+    if hasattr(config, "torch_dtype"):
+        config.torch_dtype = torch_dtype
+    for child_name in ("text_config", "vision_config", "llm_config"):
+        if hasattr(config, child_name):
+            _set_config_torch_dtype(getattr(config, child_name), torch_dtype)
+
+
+def _load_hf_model_with_optional_streaming(auto_class, pretrained_model_name_or_path, args: tuple, kwargs: dict):
+    streaming_checkpoint_path = kwargs.pop(_QEFF_STREAMING_CHECKPOINT_PATH_KWARG, None)
+    streaming_dtype = kwargs.pop(_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG, None)
+    if streaming_checkpoint_path is None:
+        return auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+    if args:
+        logger.warning("QEfficient streaming checkpoint load does not support positional model args; using HF loader.")
+        return auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+    config = kwargs.get("config")
+    if config is None:
+        config_kwargs = {}
+        for key in ("cache_dir", "revision", "token", "use_auth_token", "local_files_only", "trust_remote_code"):
+            if key in kwargs:
+                config_kwargs[key] = kwargs[key]
+        config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
+
+    constructor_kwargs = {}
+    for key in ("attn_implementation", "trust_remote_code", "torch_dtype", "dtype"):
+        if key in kwargs:
+            constructor_kwargs[key] = kwargs[key]
+
+    normalized_streaming_dtype = normalize_torch_dtype(streaming_dtype)
+    if normalized_streaming_dtype is not None:
+        _set_config_torch_dtype(config, normalized_streaming_dtype)
+
+    logger.info("Streaming safetensors checkpoint into model from %s", streaming_checkpoint_path)
+    with torch.device("meta"):
+        model = auto_class.from_config(config, **constructor_kwargs)
+    if normalized_streaming_dtype is not None:
+        _set_config_torch_dtype(getattr(model, "config", None), normalized_streaming_dtype)
+    load_summary = load_safetensor_checkpoint_into_model(model, streaming_checkpoint_path, target_dtype=streaming_dtype)
+    logger.info(
+        "Loaded %s tensors (%s bytes) through QEfficient streaming safetensor loader",
+        load_summary.loaded_tensor_count,
+        load_summary.loaded_tensor_bytes,
+    )
+    model.eval()
+    return model
+
+
 class QEFFTransformersBase(QEFFBaseModel):
     """
     Base class for QEfficient wrappers around HuggingFace transformer models.
@@ -311,8 +423,10 @@ class QEFFTransformersBase(QEFFBaseModel):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        _resolve_torch_dtype(kwargs)
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+            pretrained_model_name_or_path, kwargs
+        )
+        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -479,8 +593,10 @@ class QEFFAutoModel(QEFFTransformersBase):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        _resolve_torch_dtype(kwargs)
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+            pretrained_model_name_or_path, kwargs
+        )
+        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
 
         # This is support models that should be classified to in a different auto class but transformers load them via this class
         kv_offload = kwargs.pop("kv_offload", None)
@@ -860,8 +976,10 @@ class QEFFAutoModelForSequenceClassification(QEFFTransformersBase):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        _resolve_torch_dtype(kwargs)
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+            pretrained_model_name_or_path, kwargs
+        )
+        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
         return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path, **kwargs)
 
@@ -1460,8 +1578,10 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             }
         )
 
-        _resolve_torch_dtype(kwargs)
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+            pretrained_model_name_or_path, kwargs
+        )
+        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, (), kwargs)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -2615,8 +2735,12 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
         config._attn_implementation = "eager"
         config.vision_config.use_flash_attn = "false"
-        _resolve_torch_dtype(kwargs)
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, config, *args, **kwargs)
+        kwargs["config"] = config
+        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+            pretrained_model_name_or_path, kwargs
+        )
+        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
+        kwargs.pop("config", None)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -3274,8 +3398,8 @@ class QEFFAutoModelForImageTextToText:
             }
         )
 
-        _resolve_torch_dtype(kwargs)
         if layerwise:
+            _resolve_torch_dtype(kwargs)
             # Layer-wise mode: build the outer model on the meta device so the
             # caller's ``from_pretrained`` does not pull the full checkpoint
             # into RAM. compile()/export() rebuilds a real per-window model
@@ -3283,7 +3407,10 @@ class QEFFAutoModelForImageTextToText:
             # only used as a config holder.
             model = _build_meta_model(cls._hf_auto_class, pretrained_model_name_or_path, kwargs)
         else:
-            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
+            pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+                pretrained_model_name_or_path, kwargs
+            )
+            model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, (), kwargs)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -3549,15 +3676,18 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             }
         )
 
-        _resolve_torch_dtype(kwargs)
         if layerwise:
+            _resolve_torch_dtype(kwargs)
             # Layer-wise mode: build the outer model on the meta device. The
             # caller still gets a typed wrapper, but no checkpoint weights are
             # pulled into RAM. compile()/export() rebuilds a real per-window
             # model internally via the layer-wise driver.
             model = _build_meta_model(cls._hf_auto_class, pretrained_model_name_or_path, kwargs)
         else:
-            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+            pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+                pretrained_model_name_or_path, kwargs
+            )
+            model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
         if qaic_config is not None:
             qaic_config["pretrained_model_name_or_path"] = pretrained_model_name_or_path
 
@@ -5079,8 +5209,10 @@ class QEFFAutoModelForCTC(QEFFTransformersBase):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        _resolve_torch_dtype(kwargs)
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        pretrained_model_name_or_path = _prepare_weight_materialized_from_pretrained_source(
+            pretrained_model_name_or_path, kwargs
+        )
+        model = _load_hf_model_with_optional_streaming(cls._hf_auto_class, pretrained_model_name_or_path, args, kwargs)
 
         # This is support models that should be classified to in a different auto class but transformers load them via this class
         kv_offload = kwargs.pop("kv_offload", None)

--- a/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -208,7 +208,7 @@ class QEffPrefillChunkedQwen3MoeSparseMoeBlock(Qwen3MoeSparseMoeBlock):
         if self.norm_topk_prob:
             top_w /= top_w.sum(-1, keepdim=True)
         top_w = top_w.to(hidden_states.dtype)
-        routing_weights = torch.zeros_like(router_logits)
+        routing_weights = hidden_states.new_zeros(router_logits.shape)
         routing_weights.scatter_(1, top_i, top_w)
 
         gate_proj_w, up_proj_w, down_proj_w = self._split_expert_weights(H)
@@ -229,7 +229,7 @@ class QEffPrefillChunkedQwen3MoeSparseMoeBlock(Qwen3MoeSparseMoeBlock):
         if self.norm_topk_prob:
             top_w /= top_w.sum(-1, keepdim=True)
         top_w = top_w.to(hidden_states.dtype)
-        routing_weights = torch.zeros_like(router_logits)
+        routing_weights = hidden_states.new_zeros(router_logits.shape)
         routing_weights.scatter_(1, top_i, top_w)
 
         num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)

--- a/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -651,8 +651,9 @@ class QEffQwen3VLTextModel(Qwen3VLTextModel):
 class QEffQwen3VLEncoderWrapper(nn.Module):
     def __init__(self, model):
         super().__init__()
-        self.model = model.model
-        self.model.vision_model = self.model.visual
+        self.config = model.config
+        self.visual = model.model.visual
+        self.vision_model = self.visual
 
     def get_submodules_for_export(self) -> Type[nn.Module]:
         """
@@ -661,10 +662,10 @@ class QEffQwen3VLEncoderWrapper(nn.Module):
             This method should return the *class object* (not an instance).
             Downstream code can use this to find/build subfunctions for repeated blocks.
         """
-        return {self.model.visual.blocks[0].__class__}
+        return {self.visual.blocks[0].__class__}
 
     def forward(self, pixel_values, image_grid_thw):
-        image_embeds, deepstack_feature_lists = self.model.visual(pixel_values, grid_thw=image_grid_thw)
+        image_embeds, deepstack_feature_lists = self.visual(pixel_values, grid_thw=image_grid_thw)
         bs = image_grid_thw.shape[0]
         split_size = torch.floor_divide(torch.tensor(image_embeds.size(0)), bs)
         image_embeds = image_embeds.reshape(bs, split_size, image_embeds.size(1))
@@ -678,8 +679,10 @@ class QEffQwen3VLEncoderWrapper(nn.Module):
 class QEffQwen3VLDecoderWrapper(nn.Module):
     def __init__(self, model):
         super().__init__()
-        self.model = model
-        self.language_model = self.model.model.language_model
+        self.config = model.config
+        self.image_token_id = model.config.image_token_id
+        self.language_model = model.model.language_model
+        self.lm_head = model.lm_head
 
     def get_submodules_for_export(self) -> Type[nn.Module]:
         """
@@ -701,9 +704,9 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
         batch_index: Optional[torch.LongTensor] = None,
         comp_ctx_lengths: Optional[List[int]] = None,
     ):
-        inputs_embeds = self.model.get_input_embeddings()(input_ids)
+        inputs_embeds = self.language_model.embed_tokens(input_ids)
         B, N, C = inputs_embeds.shape
-        selected = input_ids == self.model.config.image_token_id
+        selected = input_ids == self.image_token_id
         indices1 = selected.to(torch.int64).cumsum(1) - 1
         indices1 = torch.where(indices1 != -1, indices1 + image_idx, indices1)
         indices0 = torch.arange(selected.unsqueeze(0).shape[0]).view(-1, 1)
@@ -736,7 +739,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
         )
         logit_index = position_ids[0].to(torch.int32).argmax(1, keepdim=True)
         hidden_states = outputs.last_hidden_state[torch.arange(position_ids[0].shape[0]).view(-1, 1), logit_index]
-        logits = self.model.lm_head(hidden_states)
+        logits = self.lm_head(hidden_states)
         image_idx = (indices1.max() + 1).unsqueeze(0).unsqueeze(0)
         if _should_export_embedding_output(self):
             return logits, vision_embeds, deepstack_features, image_idx, hidden_states, outputs.past_key_values

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -5,6 +5,7 @@
 #
 # -----------------------------------------------------------------------------
 import math
+import os
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import torch
@@ -759,8 +760,9 @@ class QEffQwen3VLMoeModel(Qwen3VLMoeModel):
 class QEffQwen3VLEncoderWrapper(nn.Module):
     def __init__(self, model):
         super().__init__()
-        self.model = model.model
-        self.model.vision_model = self.model.visual
+        self.config = model.config
+        self.visual = model.model.visual
+        self.vision_model = self.visual
 
     def get_submodules_for_export(self) -> Type[nn.Module]:
         """
@@ -769,10 +771,10 @@ class QEffQwen3VLEncoderWrapper(nn.Module):
             This method should return the *class object* (not an instance).
             Downstream code can use this to find/build subfunctions for repeated blocks.
         """
-        return {self.model.visual.blocks[0].__class__}
+        return {self.visual.blocks[0].__class__}
 
     def forward(self, pixel_values, image_grid_thw):
-        image_embeds, deepstack_feature_lists = self.model.visual(pixel_values, grid_thw=image_grid_thw)
+        image_embeds, deepstack_feature_lists = self.visual(pixel_values, grid_thw=image_grid_thw)
         bs = image_grid_thw.shape[0]
         split_size = torch.floor_divide(torch.tensor(image_embeds.size(0)), bs)
         image_embeds = image_embeds.reshape(bs, split_size, image_embeds.size(1))
@@ -811,8 +813,10 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
 
     def __init__(self, model):
         super().__init__()
-        self.model = model
-        self.language_model = self.model.model.language_model
+        self.config = model.config
+        self.image_token_id = model.config.image_token_id
+        self.language_model = model.model.language_model
+        self.lm_head = model.lm_head
 
     def get_submodules_for_export(self) -> Type[nn.Module]:
         """
@@ -836,7 +840,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
         comp_ctx_lengths: Optional[List[int]] = None,
     ):
         if inputs_embeds is None:
-            inputs_embeds = self.model.model.get_input_embeddings()(input_ids)
+            inputs_embeds = self.language_model.embed_tokens(input_ids)
         else:
             inputs_embeds = inputs_embeds
 
@@ -844,7 +848,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
             # Default (non-layerwise) path: image merge + full decoder + lm_head in
             # a single forward, identical to the pre-layerwise behavior/output contract.
             B, N, C = inputs_embeds.shape
-            selected = input_ids == self.model.config.image_token_id
+            selected = input_ids == self.image_token_id
             indices1 = selected.to(torch.int64).cumsum(1) - 1
             indices1 = torch.where(indices1 != -1, indices1 + image_idx, indices1)
             indices0 = torch.arange(selected.unsqueeze(0).shape[0]).view(-1, 1)
@@ -875,13 +879,13 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
             )
             logit_index = position_ids[0].to(torch.int32).argmax(1, keepdim=True)
             hidden_states = outputs.last_hidden_state[torch.arange(position_ids[0].shape[0]).view(-1, 1), logit_index]
-            logits = self.model.lm_head(hidden_states)
+            logits = self.lm_head(hidden_states)
             image_idx = (indices1.max() + 1).unsqueeze(0).unsqueeze(0)
             return logits, vision_embeds, deepstack_features, image_idx, outputs.past_key_values
 
         if QEffQwen3VLMoeTextModel._start == 0:
             B, N, C = inputs_embeds.shape
-            selected = input_ids == self.model.config.image_token_id
+            selected = input_ids == self.image_token_id
             indices1 = selected.to(torch.int64).cumsum(1) - 1
             indices1 = torch.where(indices1 != -1, indices1 + image_idx, indices1)
             indices0 = torch.arange(selected.unsqueeze(0).shape[0]).view(-1, 1)
@@ -935,7 +939,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
             )
             logit_index = position_ids[0].to(torch.int32).argmax(1, keepdim=True)
             hidden_states = outputs.last_hidden_state[torch.arange(position_ids[0].shape[0]).view(-1, 1), logit_index]
-            logits = self.model.lm_head(hidden_states)
+            logits = self.lm_head(hidden_states)
             return logits, outputs.past_key_values
 
         else:

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -5,7 +5,6 @@
 #
 # -----------------------------------------------------------------------------
 import math
-import os
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 import torch

--- a/QEfficient/utils/export_utils.py
+++ b/QEfficient/utils/export_utils.py
@@ -7,6 +7,7 @@
 
 import copy
 import inspect
+import os
 import re
 import warnings
 from pathlib import Path
@@ -41,6 +42,8 @@ def export_wrapper(func):
 
     def wrapper(self, *args, **kwargs):
         cache_probe = kwargs.pop("_layerwise_cache_probe", False)
+        _apply_low_memory_export_defaults(self, kwargs)
+
         # 1. Setup ONNX subfunctions if requested
         if use_onnx_subfunctions := kwargs.pop("use_onnx_subfunctions", False):
             args, kwargs = _setup_onnx_subfunctions(self, args, kwargs)
@@ -70,6 +73,33 @@ def export_wrapper(func):
         return onnx_path
 
     return wrapper
+
+
+def _env_enabled(name: str) -> bool:
+    return os.environ.get(name, "").lower() in {"1", "true", "yes", "on"}
+
+
+def _env_disabled(name: str) -> bool:
+    return os.environ.get(name, "").lower() in {"0", "false", "no", "off"}
+
+
+def _onnx_transforms_need_tensor_data(qeff_model) -> bool:
+    tensor_data_transforms = {"FP16ClipTransform", "SplitTensorsTransform"}
+    return any(
+        getattr(transform, "__name__", str(transform)) in tensor_data_transforms
+        for transform in qeff_model._onnx_transforms
+    )
+
+
+def _apply_low_memory_export_defaults(qeff_model, kwargs) -> None:
+    export_params_disabled = _env_disabled("QEFF_ONNX_EXPORT_PARAMS") or kwargs.get("export_params") is False
+    if not (_env_enabled("QEFF_LOW_MEMORY_ONNX_EXPORT") or export_params_disabled):
+        return
+    if kwargs.get("use_onnx_subfunctions", False) or _onnx_transforms_need_tensor_data(qeff_model):
+        return
+    kwargs["_qeff_low_memory_external_initializers"] = True
+    kwargs.setdefault("export_params", False)
+    kwargs.setdefault("do_constant_folding", False)
 
 
 def _prepare_export_directory(qeff_model, kwargs) -> Path:

--- a/QEfficient/utils/export_utils.py
+++ b/QEfficient/utils/export_utils.py
@@ -99,7 +99,6 @@ def _apply_low_memory_export_defaults(qeff_model, kwargs) -> None:
         return
     kwargs["_qeff_low_memory_external_initializers"] = True
     kwargs.setdefault("export_params", False)
-    kwargs.setdefault("do_constant_folding", False)
 
 
 def _prepare_export_directory(qeff_model, kwargs) -> Path:

--- a/QEfficient/utils/mem_profile.py
+++ b/QEfficient/utils/mem_profile.py
@@ -1,0 +1,366 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# ----------------------------------------------------------------------------
+
+import functools
+import gc
+import os
+import resource
+import sys
+import threading
+import time
+import tracemalloc
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Optional
+
+try:
+    import psutil
+except Exception:  # pragma: no cover - psutil is optional for profiling only.
+    psutil = None
+
+try:
+    import torch
+except Exception:  # pragma: no cover - keeps this utility import-safe.
+    torch = None
+
+
+_ENABLED_VALUES = {"1", "true", "yes", "on"}
+
+
+def is_export_memory_profile_enabled() -> bool:
+    return os.environ.get("QEFF_PROFILE_EXPORT_MEMORY", "").lower() in _ENABLED_VALUES
+
+
+def _format_bytes(num_bytes: Optional[int]) -> str:
+    if num_bytes is None:
+        return "n/a"
+    value = float(num_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(value) < 1024.0 or unit == "TiB":
+            return f"{value:.2f} {unit}"
+        value /= 1024.0
+    return f"{num_bytes} B"
+
+
+def format_bytes(num_bytes: Optional[int]) -> str:
+    return _format_bytes(num_bytes)
+
+
+def _proc_status_value(name: str) -> Optional[int]:
+    try:
+        with open("/proc/self/status", "r", encoding="utf-8") as status_file:
+            for line in status_file:
+                if line.startswith(name + ":"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        return int(parts[1]) * 1024
+    except OSError:
+        return None
+    return None
+
+
+def _ru_maxrss_bytes() -> int:
+    peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return peak
+    return peak * 1024
+
+
+@dataclass
+class MemorySnapshot:
+    label: str
+    timestamp: float
+    rss: Optional[int]
+    uss: Optional[int]
+    vms: Optional[int]
+    hwm: Optional[int]
+    ru_maxrss: Optional[int]
+    py_current: Optional[int]
+    py_peak: Optional[int]
+    extra: Dict[str, object] = field(default_factory=dict)
+
+
+class ExportMemoryProfiler:
+    def __init__(self, name: str, enabled: Optional[bool] = None) -> None:
+        self.name = name
+        self.enabled = is_export_memory_profile_enabled() if enabled is None else enabled
+        self._process = psutil.Process(os.getpid()) if self.enabled and psutil is not None else None
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._sampler: Optional[threading.Thread] = None
+        self._sampling_interval = float(os.environ.get("QEFF_PROFILE_MEMORY_INTERVAL_SEC", "0.10"))
+        self._current_stage = "idle"
+        self._stage_peak_rss: Dict[str, int] = {}
+        self._global_peak_rss = 0
+        self._global_peak_hwm = 0
+        self._global_peak_ru_maxrss = 0
+        self._snapshots: list[MemorySnapshot] = []
+        self._tracemalloc_started = False
+
+    def __enter__(self) -> "ExportMemoryProfiler":
+        if not self.enabled:
+            return self
+        if os.environ.get("QEFF_PROFILE_PYTHON_MEMORY", "").lower() in _ENABLED_VALUES and not tracemalloc.is_tracing():
+            tracemalloc.start()
+            self._tracemalloc_started = True
+        self.snapshot("start", self._static_memory_summary())
+        self._sampler = threading.Thread(target=self._sample_loop, name="qeff-export-memory-profiler", daemon=True)
+        self._sampler.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if not self.enabled:
+            return
+        self.snapshot("end", {"exception": exc_type.__name__ if exc_type else None})
+        self._stop.set()
+        if self._sampler is not None:
+            self._sampler.join(timeout=1.0)
+        self.report()
+        if self._tracemalloc_started:
+            tracemalloc.stop()
+
+    @contextmanager
+    def stage(self, label: str, extra: Optional[Dict[str, object]] = None):
+        if not self.enabled:
+            yield
+            return
+        previous_stage = self._current_stage
+        self._current_stage = label
+        gc.collect()
+        start = time.perf_counter()
+        start_snapshot = self.snapshot(label + ":begin", extra)
+        try:
+            yield
+        finally:
+            gc.collect()
+            elapsed = time.perf_counter() - start
+            end_snapshot = self.snapshot(label + ":end", {"elapsed_sec": f"{elapsed:.3f}"})
+            peak = self._stage_peak_rss.get(label)
+            delta = None
+            hwm_delta = None
+            ru_delta = None
+            if start_snapshot.rss is not None and end_snapshot.rss is not None:
+                delta = end_snapshot.rss - start_snapshot.rss
+            if start_snapshot.hwm is not None and end_snapshot.hwm is not None:
+                hwm_delta = end_snapshot.hwm - start_snapshot.hwm
+            if start_snapshot.ru_maxrss is not None and end_snapshot.ru_maxrss is not None:
+                ru_delta = end_snapshot.ru_maxrss - start_snapshot.ru_maxrss
+            self._emit(
+                "stage "
+                f"{label}: elapsed={elapsed:.3f}s rss_delta={_format_bytes(delta)} "
+                f"hwm_delta={_format_bytes(hwm_delta)} ru_maxrss_delta={_format_bytes(ru_delta)} "
+                f"stage_peak_rss={_format_bytes(peak)}"
+            )
+            self._current_stage = previous_stage
+
+    def snapshot(self, label: str, extra: Optional[Dict[str, object]] = None) -> MemorySnapshot:
+        if not self.enabled:
+            return MemorySnapshot(label, time.time(), None, None, None, None, None, None, None, extra or {})
+        rss = uss = vms = None
+        if self._process is not None:
+            mem = self._process.memory_info()
+            rss = mem.rss
+            vms = mem.vms
+            try:
+                uss = self._process.memory_full_info().uss
+            except Exception:
+                uss = None
+        else:
+            rss = _proc_status_value("VmRSS")
+            vms = _proc_status_value("VmSize")
+        hwm = _proc_status_value("VmHWM")
+        ru_maxrss = _ru_maxrss_bytes()
+        py_current = py_peak = None
+        if tracemalloc.is_tracing():
+            py_current, py_peak = tracemalloc.get_traced_memory()
+        snapshot = MemorySnapshot(label, time.time(), rss, uss, vms, hwm, ru_maxrss, py_current, py_peak, extra or {})
+        with self._lock:
+            self._snapshots.append(snapshot)
+            if rss is not None:
+                self._global_peak_rss = max(self._global_peak_rss, rss)
+            if hwm is not None:
+                self._global_peak_hwm = max(self._global_peak_hwm, hwm)
+            if ru_maxrss is not None:
+                self._global_peak_ru_maxrss = max(self._global_peak_ru_maxrss, ru_maxrss)
+        self._emit_snapshot(snapshot)
+        return snapshot
+
+    def tensor_summary(self, label: str, tensors: Iterable[object]) -> None:
+        if not self.enabled:
+            return
+        count = 0
+        bytes_by_dtype: Dict[str, int] = {}
+        devices: Dict[str, int] = {}
+        for tensor in tensors:
+            if torch is None or not isinstance(tensor, torch.Tensor):
+                continue
+            count += 1
+            bytes_by_dtype[str(tensor.dtype)] = (
+                bytes_by_dtype.get(str(tensor.dtype), 0) + tensor.numel() * tensor.element_size()
+            )
+            devices[str(tensor.device)] = devices.get(str(tensor.device), 0) + 1
+        total_bytes = sum(bytes_by_dtype.values())
+        self._emit(
+            f"tensor_summary {label}: count={count} total={_format_bytes(total_bytes)} "
+            f"by_dtype={{{', '.join(f'{k}: {_format_bytes(v)}' for k, v in sorted(bytes_by_dtype.items()))}}} "
+            f"devices={devices}"
+        )
+
+    def report(self) -> None:
+        if not self.enabled:
+            return
+        self._emit(
+            f"report {self.name}: sampled_peak_rss={_format_bytes(self._global_peak_rss)} "
+            f"peak_hwm={_format_bytes(self._global_peak_hwm)} "
+            f"peak_ru_maxrss={_format_bytes(self._global_peak_ru_maxrss)}"
+        )
+        if self._stage_peak_rss:
+            stages = ", ".join(f"{stage}={_format_bytes(value)}" for stage, value in self._stage_peak_rss.items())
+            self._emit(f"report stage_peaks: {stages}")
+
+    def _sample_loop(self) -> None:
+        while not self._stop.is_set():
+            rss = None
+            if self._process is not None:
+                try:
+                    rss = self._process.memory_info().rss
+                except Exception:
+                    rss = None
+            else:
+                rss = _proc_status_value("VmRSS")
+            if rss is not None:
+                with self._lock:
+                    self._global_peak_rss = max(self._global_peak_rss, rss)
+                    self._stage_peak_rss[self._current_stage] = max(
+                        self._stage_peak_rss.get(self._current_stage, 0), rss
+                    )
+            self._stop.wait(self._sampling_interval)
+
+    def _emit_snapshot(self, snapshot: MemorySnapshot) -> None:
+        extra = ""
+        if snapshot.extra:
+            extra = " " + " ".join(f"{key}={value}" for key, value in snapshot.extra.items())
+        self._emit(
+            f"snapshot {snapshot.label}: rss={_format_bytes(snapshot.rss)} uss={_format_bytes(snapshot.uss)} "
+            f"vms={_format_bytes(snapshot.vms)} hwm={_format_bytes(snapshot.hwm)} "
+            f"ru_maxrss={_format_bytes(snapshot.ru_maxrss)} py={_format_bytes(snapshot.py_current)}/"
+            f"{_format_bytes(snapshot.py_peak)}{extra}"
+        )
+
+    def _emit(self, message: str) -> None:
+        print(f"[QEFF-MEM] {message}", file=sys.stderr, flush=True)
+
+    def _static_memory_summary(self) -> Dict[str, object]:
+        summary: Dict[str, object] = {
+            "pid": os.getpid(),
+            "psutil": psutil is not None,
+            "sampling_interval_sec": self._sampling_interval,
+        }
+        if torch is not None:
+            summary["torch"] = getattr(torch, "__version__", "unknown")
+            summary["default_dtype"] = str(torch.get_default_dtype())
+        return summary
+
+
+def flatten_torch_tensors(value: object):
+    if torch is not None and isinstance(value, torch.Tensor):
+        yield value
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from flatten_torch_tensors(item)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from flatten_torch_tensors(item)
+
+
+def onnx_initializer_summary(model) -> Dict[str, object]:
+    try:
+        from onnx import TensorProto
+    except Exception:
+        return {}
+    dtype_sizes = {
+        TensorProto.FLOAT: 4,
+        TensorProto.UINT8: 1,
+        TensorProto.INT8: 1,
+        TensorProto.UINT16: 2,
+        TensorProto.INT16: 2,
+        TensorProto.INT32: 4,
+        TensorProto.INT64: 8,
+        TensorProto.STRING: 0,
+        TensorProto.BOOL: 1,
+        TensorProto.FLOAT16: 2,
+        TensorProto.DOUBLE: 8,
+        TensorProto.UINT32: 4,
+        TensorProto.UINT64: 8,
+        TensorProto.COMPLEX64: 8,
+        TensorProto.COMPLEX128: 16,
+        TensorProto.BFLOAT16: 2,
+    }
+    bytes_by_type: Dict[str, int] = {}
+    raw_bytes = 0
+    external_count = 0
+    initializer_count = 0
+    for tensor in model.graph.initializer:
+        initializer_count += 1
+        numel = 1
+        for dim in tensor.dims:
+            numel *= dim
+        estimated = numel * dtype_sizes.get(tensor.data_type, 0)
+        dtype = TensorProto.DataType.Name(tensor.data_type)
+        bytes_by_type[dtype] = bytes_by_type.get(dtype, 0) + estimated
+        raw_bytes += len(tensor.raw_data)
+        if tensor.data_location == TensorProto.EXTERNAL:
+            external_count += 1
+    return {
+        "initializer_count": initializer_count,
+        "initializer_estimated_bytes": _format_bytes(sum(bytes_by_type.values())),
+        "initializer_raw_bytes_loaded": _format_bytes(raw_bytes),
+        "initializer_external_count": external_count,
+        "initializer_by_type": {key: _format_bytes(value) for key, value in sorted(bytes_by_type.items())},
+    }
+
+
+@contextmanager
+def profile_torch_onnx_internals(profiler: ExportMemoryProfiler):
+    if not profiler.enabled or torch is None:
+        yield
+        return
+
+    try:
+        import torch.onnx.utils as onnx_utils
+    except Exception:
+        yield
+        return
+
+    names = (
+        "_trace_and_get_graph_from_model",
+        "_create_jit_graph",
+        "_optimize_graph",
+        "_model_to_graph",
+        "_export",
+    )
+    originals = {}
+
+    def wrap(name, fn):
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            with profiler.stage(f"torch.onnx.utils.{name}"):
+                return fn(*args, **kwargs)
+
+        return wrapped
+
+    for name in names:
+        fn = getattr(onnx_utils, name, None)
+        if fn is None:
+            continue
+        originals[name] = fn
+        setattr(onnx_utils, name, wrap(name, fn))
+    try:
+        yield
+    finally:
+        for name, fn in originals.items():
+            setattr(onnx_utils, name, fn)

--- a/QEfficient/utils/onnx_external_weights.py
+++ b/QEfficient/utils/onnx_external_weights.py
@@ -1,0 +1,116 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# ----------------------------------------------------------------------------
+
+import os
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import onnx
+import torch
+from onnx import TensorProto, external_data_helper
+
+from QEfficient.utils.mem_profile import format_bytes
+
+_TORCH_TO_ONNX_DTYPE = {
+    torch.float16: TensorProto.FLOAT16,
+    torch.float32: TensorProto.FLOAT,
+    torch.float64: TensorProto.DOUBLE,
+    torch.bfloat16: TensorProto.BFLOAT16,
+    torch.int8: TensorProto.INT8,
+    torch.uint8: TensorProto.UINT8,
+    torch.int16: TensorProto.INT16,
+    torch.int32: TensorProto.INT32,
+    torch.int64: TensorProto.INT64,
+    torch.bool: TensorProto.BOOL,
+}
+
+
+def low_memory_external_initializers_enabled() -> bool:
+    return os.environ.get("QEFF_LOW_MEMORY_ONNX_EXPORT", "").lower() in {"1", "true", "yes", "on"}
+
+
+def iter_named_tensors(module: torch.nn.Module) -> Iterable[Tuple[str, torch.Tensor]]:
+    yield from module.named_parameters(remove_duplicate=False)
+    yield from module.named_buffers(remove_duplicate=False)
+
+
+def attach_external_initializers_from_torch(
+    model: onnx.ModelProto,
+    torch_model: torch.nn.Module,
+    onnx_path: Path,
+    data_file_name: str | None = None,
+) -> Dict[str, object]:
+    tensor_map = {name: tensor for name, tensor in iter_named_tensors(torch_model)}
+    initializer_names = set()
+    data_file_name = data_file_name or f"{onnx_path.name}.data"
+    data_path = onnx_path.parent / data_file_name
+    data_path.parent.mkdir(parents=True, exist_ok=True)
+
+    total_bytes = 0
+    attached_count = 0
+    missing_names = []
+    unsupported_names = []
+
+    with open(data_path, "wb") as data_file:
+        for graph_input in list(model.graph.input):
+            name = graph_input.name
+            tensor = tensor_map.get(name)
+            if tensor is None:
+                continue
+            if tensor.dtype not in _TORCH_TO_ONNX_DTYPE:
+                unsupported_names.append(f"{name}:{tensor.dtype}")
+                continue
+
+            detached = tensor.detach()
+            if detached.device.type != "cpu":
+                detached = detached.cpu()
+            if not detached.is_contiguous():
+                detached = detached.contiguous()
+
+            offset = data_file.tell()
+            if detached.dtype is torch.bfloat16:
+                tensor_bytes = detached.view(torch.uint16).numpy()
+            else:
+                tensor_bytes = detached.numpy()
+            data_file.write(memoryview(tensor_bytes))
+            length = data_file.tell() - offset
+
+            initializer = TensorProto()
+            initializer.name = name
+            initializer.data_type = _TORCH_TO_ONNX_DTYPE[detached.dtype]
+            initializer.dims.extend(list(detached.shape))
+            initializer.raw_data = b""
+            external_data_helper.set_external_data(
+                initializer,
+                location=data_file_name,
+                offset=offset,
+                length=length,
+            )
+            model.graph.initializer.append(initializer)
+            initializer_names.add(name)
+            attached_count += 1
+            total_bytes += length
+
+    retained_inputs = [graph_input for graph_input in model.graph.input if graph_input.name not in initializer_names]
+    del model.graph.input[:]
+    model.graph.input.extend(retained_inputs)
+
+    for graph_input in model.graph.input:
+        name = graph_input.name
+        if name in tensor_map and name not in initializer_names:
+            missing_names.append(name)
+
+    return {
+        "external_initializer_count": attached_count,
+        "external_initializer_bytes": format_bytes(total_bytes),
+        "external_data_path": str(data_path),
+        "external_data_file_size": format_bytes(data_path.stat().st_size if data_path.exists() else 0),
+        "missing_initializer_inputs": missing_names[:10],
+        "missing_initializer_input_count": len(missing_names),
+        "unsupported_initializer_inputs": unsupported_names[:10],
+        "unsupported_initializer_input_count": len(unsupported_names),
+    }

--- a/QEfficient/utils/safetensor_materializer.py
+++ b/QEfficient/utils/safetensor_materializer.py
@@ -1,0 +1,429 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# ----------------------------------------------------------------------------
+
+import gc
+import hashlib
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+from huggingface_hub import snapshot_download
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from QEfficient.utils.constants import QEFF_MODELS_DIR
+from QEfficient.utils.logging_utils import logger
+
+QEFF_MATERIALIZED_CHECKPOINT_DIR_ENV = "QEFF_MATERIALIZED_CHECKPOINT_DIR"
+QEFF_MATERIALIZE_FORCE_ENV = "QEFF_MATERIALIZE_FORCE"
+
+_INDEX_FILE = "model.safetensors.index.json"
+_SINGLE_FILE = "model.safetensors"
+_MARKER_FILE = "qeff_materialized_checkpoint.json"
+_WEIGHT_SUFFIXES = (".safetensors", ".bin", ".pt", ".pth", ".ckpt", ".h5", ".msgpack")
+
+_TORCH_DTYPE_TO_CONFIG = {
+    torch.float16: "float16",
+    torch.bfloat16: "bfloat16",
+    torch.float32: "float32",
+    torch.float64: "float64",
+}
+
+_SAFETENSOR_FLOAT_DTYPES = {
+    "F16": torch.float16,
+    "BF16": torch.bfloat16,
+    "F32": torch.float32,
+    "F64": torch.float64,
+}
+
+
+@dataclass(frozen=True)
+class MaterializedCheckpoint:
+    path: Path
+    source_path: Path
+    target_dtype: torch.dtype
+    materialized: bool
+    dtype_aligned: bool
+
+
+@dataclass(frozen=True)
+class StreamingLoadResult:
+    loaded_tensor_count: int
+    loaded_tensor_bytes: int
+    missing_parameter_names: List[str]
+    missing_buffer_names: List[str]
+    unexpected_tensor_names: List[str]
+
+
+def env_flag(name: str) -> bool:
+    value = os.environ.get(name, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def normalize_torch_dtype(dtype: Any) -> Optional[torch.dtype]:
+    if dtype is None or dtype == "auto":
+        return None
+    if isinstance(dtype, torch.dtype):
+        return dtype
+    if isinstance(dtype, str):
+        normalized = dtype.lower()
+        if normalized.startswith("torch."):
+            normalized = normalized[len("torch.") :]
+        for torch_dtype, config_value in _TORCH_DTYPE_TO_CONFIG.items():
+            if normalized == config_value:
+                return torch_dtype
+    raise ValueError(f"Unsupported torch dtype for checkpoint materialization: {dtype!r}")
+
+
+def materialize_safetensor_checkpoint(
+    pretrained_model_name_or_path: Union[str, os.PathLike],
+    target_dtype: torch.dtype,
+    cache_dir: Optional[Union[str, os.PathLike]] = None,
+    revision: Optional[str] = None,
+    token: Optional[Union[str, bool]] = None,
+    local_files_only: bool = False,
+    force: bool = False,
+    hub_cache_dir: Optional[Union[str, os.PathLike]] = None,
+) -> MaterializedCheckpoint:
+    source_path = _resolve_source_path(
+        pretrained_model_name_or_path,
+        revision=revision,
+        token=token,
+        local_files_only=local_files_only,
+        hub_cache_dir=hub_cache_dir,
+    )
+    layout = _load_safetensor_layout(source_path)
+    if not _checkpoint_requires_conversion(source_path, layout["shards"], target_dtype):
+        return MaterializedCheckpoint(
+            path=source_path,
+            source_path=source_path,
+            target_dtype=target_dtype,
+            materialized=False,
+            dtype_aligned=True,
+        )
+
+    output_root_value = cache_dir or os.environ.get(QEFF_MATERIALIZED_CHECKPOINT_DIR_ENV)
+    if output_root_value:
+        output_root = Path(output_root_value).expanduser()
+    else:
+        output_root = Path(QEFF_MODELS_DIR) / "materialized_checkpoints"
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    cache_key = _cache_key(source_path, layout["shards"], target_dtype, revision)
+    target_path = output_root / f"{source_path.name}-{_TORCH_DTYPE_TO_CONFIG[target_dtype]}-{cache_key[:12]}"
+    marker_path = target_path / _MARKER_FILE
+    if marker_path.exists() and not force:
+        return MaterializedCheckpoint(
+            path=target_path,
+            source_path=source_path,
+            target_dtype=target_dtype,
+            materialized=True,
+            dtype_aligned=True,
+        )
+    if target_path.exists():
+        shutil.rmtree(target_path)
+
+    logger.info("Materializing %s checkpoint at %s into %s", target_dtype, source_path, target_path)
+    with TemporaryDirectory(dir=output_root, prefix=f".{target_path.name}.") as temp_dir:
+        temp_path = Path(temp_dir)
+        _copy_non_weight_files(source_path, temp_path)
+        converted_size = _convert_checkpoint_files(source_path, temp_path, layout, target_dtype)
+        _write_materialized_config(temp_path, target_dtype)
+        _write_marker(temp_path, source_path, target_dtype, layout["shards"], converted_size)
+        shutil.move(str(temp_path), target_path)
+
+    return MaterializedCheckpoint(
+        path=target_path,
+        source_path=source_path,
+        target_dtype=target_dtype,
+        materialized=True,
+        dtype_aligned=True,
+    )
+
+
+def maybe_materialize_safetensor_checkpoint(
+    pretrained_model_name_or_path: Union[str, os.PathLike],
+    target_dtype: Any,
+    *,
+    enabled: Optional[bool] = None,
+    cache_dir: Optional[Union[str, os.PathLike]] = None,
+    revision: Optional[str] = None,
+    token: Optional[Union[str, bool]] = None,
+    local_files_only: bool = False,
+    force: Optional[bool] = None,
+    hub_cache_dir: Optional[Union[str, os.PathLike]] = None,
+) -> Optional[MaterializedCheckpoint]:
+    normalized_dtype = normalize_torch_dtype(target_dtype)
+    should_materialize = normalized_dtype is not None if enabled is None else enabled
+    if not should_materialize or normalized_dtype is None:
+        return None
+    if normalized_dtype not in _TORCH_DTYPE_TO_CONFIG:
+        raise ValueError(f"Unsupported target dtype for QEfficient checkpoint materialization: {normalized_dtype}")
+
+    return materialize_safetensor_checkpoint(
+        pretrained_model_name_or_path,
+        normalized_dtype,
+        cache_dir=cache_dir,
+        revision=revision,
+        token=token,
+        local_files_only=local_files_only,
+        force=env_flag(QEFF_MATERIALIZE_FORCE_ENV) if force is None else force,
+        hub_cache_dir=hub_cache_dir,
+    )
+
+
+def load_safetensor_checkpoint_into_model(
+    model: torch.nn.Module,
+    checkpoint_path: Union[str, os.PathLike],
+    target_dtype: Any = None,
+) -> StreamingLoadResult:
+    checkpoint_path = Path(checkpoint_path).expanduser().resolve()
+    layout = _load_safetensor_layout(checkpoint_path)
+    normalized_dtype = normalize_torch_dtype(target_dtype)
+
+    expected_parameters = dict(model.named_parameters())
+    expected_buffers = dict(model.named_buffers())
+    expected_names = set(expected_parameters) | set(expected_buffers)
+    loaded_names = set()
+    unexpected_names = []
+    loaded_tensor_count = 0
+    loaded_tensor_bytes = 0
+
+    for shard in layout["shards"]:
+        with safe_open(checkpoint_path / shard, framework="pt", device="cpu") as reader:
+            for name in reader.keys():
+                if name not in expected_names:
+                    unexpected_names.append(name)
+                    continue
+                tensor = reader.get_tensor(name)
+                if normalized_dtype is not None and tensor.is_floating_point() and tensor.dtype != normalized_dtype:
+                    tensor = tensor.to(dtype=normalized_dtype)
+                _set_module_tensor(model, name, tensor)
+                loaded_names.add(name)
+                loaded_tensor_count += 1
+                loaded_tensor_bytes += tensor.numel() * tensor.element_size()
+        gc.collect()
+
+    if hasattr(model, "tie_weights"):
+        model.tie_weights()
+
+    missing_parameter_names = _remaining_meta_names(model.named_parameters(), loaded_names)
+    missing_buffer_names = _remaining_meta_names(model.named_buffers(), loaded_names)
+    _materialize_missing_meta_buffers(model, missing_buffer_names, normalized_dtype)
+    missing_buffer_names = _remaining_meta_names(model.named_buffers(), loaded_names)
+    if missing_parameter_names:
+        raise RuntimeError(
+            "QEfficient streaming checkpoint load left parameters on meta device: "
+            + ", ".join(missing_parameter_names[:10])
+        )
+
+    return StreamingLoadResult(
+        loaded_tensor_count=loaded_tensor_count,
+        loaded_tensor_bytes=loaded_tensor_bytes,
+        missing_parameter_names=missing_parameter_names,
+        missing_buffer_names=missing_buffer_names,
+        unexpected_tensor_names=unexpected_names,
+    )
+
+
+def _remaining_meta_names(named_tensors, loaded_names: set[str]) -> List[str]:
+    return [name for name, tensor in named_tensors if name not in loaded_names and tensor.device.type == "meta"]
+
+
+def _materialize_missing_meta_buffers(
+    model: torch.nn.Module,
+    missing_buffer_names: List[str],
+    target_dtype: Optional[torch.dtype],
+) -> None:
+    for name in missing_buffer_names:
+        module, tensor_name = _get_parent_module(model, name)
+        old_buffer = module._buffers[tensor_name]
+        dtype = target_dtype if target_dtype is not None and old_buffer.is_floating_point() else old_buffer.dtype
+        module._buffers[tensor_name] = torch.zeros(old_buffer.shape, dtype=dtype, device="cpu")
+
+
+def _set_module_tensor(model: torch.nn.Module, name: str, tensor: torch.Tensor) -> None:
+    module, tensor_name = _get_parent_module(model, name)
+    if tensor_name in module._parameters:
+        old_parameter = module._parameters[tensor_name]
+        requires_grad = old_parameter.requires_grad if old_parameter is not None else False
+        module._parameters[tensor_name] = torch.nn.Parameter(tensor, requires_grad=requires_grad)
+        return
+    if tensor_name in module._buffers:
+        module._buffers[tensor_name] = tensor
+        return
+    setattr(module, tensor_name, tensor)
+
+
+def _get_parent_module(model: torch.nn.Module, tensor_name: str) -> tuple[torch.nn.Module, str]:
+    if "." not in tensor_name:
+        return model, tensor_name
+    module_name, child_name = tensor_name.rsplit(".", 1)
+    return model.get_submodule(module_name), child_name
+
+
+def _resolve_source_path(
+    pretrained_model_name_or_path: Union[str, os.PathLike],
+    *,
+    revision: Optional[str],
+    token: Optional[Union[str, bool]],
+    local_files_only: bool,
+    hub_cache_dir: Optional[Union[str, os.PathLike]],
+) -> Path:
+    candidate = Path(pretrained_model_name_or_path).expanduser()
+    if candidate.exists():
+        return candidate.resolve()
+    return Path(
+        snapshot_download(
+            repo_id=str(pretrained_model_name_or_path),
+            revision=revision,
+            token=token,
+            local_files_only=local_files_only,
+            cache_dir=hub_cache_dir,
+        )
+    ).resolve()
+
+
+def _load_safetensor_layout(source_path: Path) -> Dict[str, Any]:
+    index_path = source_path / _INDEX_FILE
+    if index_path.exists():
+        with index_path.open() as handle:
+            index = json.load(handle)
+        shards = sorted(set(index.get("weight_map", {}).values()))
+        if not shards:
+            raise ValueError(f"Safetensors index has no weight_map entries: {index_path}")
+        return {"index": index, "index_name": _INDEX_FILE, "shards": shards}
+
+    model_file = source_path / _SINGLE_FILE
+    if model_file.exists():
+        return {"index": None, "index_name": None, "shards": [_SINGLE_FILE]}
+
+    candidates = sorted(path.name for path in source_path.glob("*.safetensors"))
+    if len(candidates) == 1:
+        return {"index": None, "index_name": None, "shards": candidates}
+
+    raise ValueError(
+        "QEfficient checkpoint materialization requires a safetensors checkpoint with "
+        f"{_SINGLE_FILE} or {_INDEX_FILE}; found {candidates or 'none'} in {source_path}"
+    )
+
+
+def _checkpoint_requires_conversion(source_path: Path, shards: List[str], target_dtype: torch.dtype) -> bool:
+    for shard in shards:
+        with safe_open(source_path / shard, framework="pt", device="cpu") as reader:
+            for name in reader.keys():
+                safe_dtype = reader.get_slice(name).get_dtype()
+                if _SAFETENSOR_FLOAT_DTYPES.get(safe_dtype) not in {None, target_dtype}:
+                    return True
+    return False
+
+
+def _cache_key(source_path: Path, shards: List[str], target_dtype: torch.dtype, revision: Optional[str]) -> str:
+    file_stats = []
+    for shard in shards:
+        path = source_path / shard
+        stat = path.stat()
+        file_stats.append({"name": shard, "size": stat.st_size, "mtime_ns": stat.st_mtime_ns})
+    payload = {
+        "source": str(source_path),
+        "revision": revision,
+        "target_dtype": _TORCH_DTYPE_TO_CONFIG[target_dtype],
+        "files": file_stats,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True).encode()).hexdigest()
+
+
+def _copy_non_weight_files(source_path: Path, target_path: Path) -> None:
+    for item in source_path.rglob("*"):
+        relative_path = item.relative_to(source_path)
+        if item.is_dir():
+            (target_path / relative_path).mkdir(parents=True, exist_ok=True)
+            continue
+        if item.suffix in _WEIGHT_SUFFIXES or item.name == _INDEX_FILE:
+            continue
+        destination = target_path / relative_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(item, destination)
+
+
+def _convert_checkpoint_files(
+    source_path: Path, target_path: Path, layout: Dict[str, Any], target_dtype: torch.dtype
+) -> int:
+    total_size = 0
+    for shard in layout["shards"]:
+        source_file = source_path / shard
+        target_file = target_path / shard
+        target_file.parent.mkdir(parents=True, exist_ok=True)
+        tensors = {}
+        with safe_open(source_file, framework="pt", device="cpu") as reader:
+            metadata = reader.metadata() or {"format": "pt"}
+            for name in reader.keys():
+                tensor = reader.get_tensor(name)
+                if tensor.is_floating_point() and tensor.dtype != target_dtype:
+                    tensor = tensor.to(dtype=target_dtype)
+                tensors[name] = tensor
+        save_file(tensors, target_file, metadata=metadata)
+        total_size += target_file.stat().st_size
+        del tensors
+        gc.collect()
+
+    if layout["index"] is not None:
+        index = dict(layout["index"])
+        metadata = dict(index.get("metadata", {}))
+        metadata["total_size"] = total_size
+        index["metadata"] = metadata
+        with (target_path / layout["index_name"]).open("w") as handle:
+            json.dump(index, handle, indent=2, sort_keys=True)
+
+    return total_size
+
+
+def _write_materialized_config(target_path: Path, target_dtype: torch.dtype) -> None:
+    config_path = target_path / "config.json"
+    if not config_path.exists():
+        return
+    with config_path.open() as handle:
+        config = json.load(handle)
+    _replace_torch_dtype(config, _TORCH_DTYPE_TO_CONFIG[target_dtype])
+    with config_path.open("w") as handle:
+        json.dump(config, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def _replace_torch_dtype(value: Any, dtype_name: str) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if key == "torch_dtype":
+                value[key] = dtype_name
+            else:
+                _replace_torch_dtype(item, dtype_name)
+    elif isinstance(value, list):
+        for item in value:
+            _replace_torch_dtype(item, dtype_name)
+
+
+def _write_marker(
+    target_path: Path,
+    source_path: Path,
+    target_dtype: torch.dtype,
+    shards: List[str],
+    converted_size: int,
+) -> None:
+    marker = {
+        "source_path": str(source_path),
+        "target_dtype": _TORCH_DTYPE_TO_CONFIG[target_dtype],
+        "shards": shards,
+        "converted_size": converted_size,
+    }
+    with (target_path / _MARKER_FILE).open("w") as handle:
+        json.dump(marker, handle, indent=2, sort_keys=True)
+        handle.write("\n")

--- a/QEfficient/utils/safetensor_materializer.py
+++ b/QEfficient/utils/safetensor_materializer.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -19,7 +20,9 @@ import torch
 from huggingface_hub import snapshot_download
 from safetensors import safe_open
 from safetensors.torch import save_file
+from transformers import AutoConfig
 
+from QEfficient.utils import constants
 from QEfficient.utils.constants import QEFF_MODELS_DIR
 from QEfficient.utils.logging_utils import logger
 
@@ -30,6 +33,8 @@ _INDEX_FILE = "model.safetensors.index.json"
 _SINGLE_FILE = "model.safetensors"
 _MARKER_FILE = "qeff_materialized_checkpoint.json"
 _WEIGHT_SUFFIXES = (".safetensors", ".bin", ".pt", ".pth", ".ckpt", ".h5", ".msgpack")
+_QEFF_STREAMING_CHECKPOINT_PATH_KWARG = "_qeff_streaming_checkpoint_path"
+_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG = "_qeff_streaming_checkpoint_dtype"
 
 _TORCH_DTYPE_TO_CONFIG = {
     torch.float16: "float16",
@@ -37,6 +42,8 @@ _TORCH_DTYPE_TO_CONFIG = {
     torch.float32: "float32",
     torch.float64: "float64",
 }
+
+_SAFETENSOR_PARALLEL_WORKERS = min(4, os.cpu_count() or 4)
 
 _SAFETENSOR_FLOAT_DTYPES = {
     "F16": torch.float16,
@@ -48,6 +55,8 @@ _SAFETENSOR_FLOAT_DTYPES = {
 
 @dataclass(frozen=True)
 class MaterializedCheckpoint:
+    """Path metadata for an explicitly materialized safetensor checkpoint copy."""
+
     path: Path
     source_path: Path
     target_dtype: torch.dtype
@@ -56,7 +65,18 @@ class MaterializedCheckpoint:
 
 
 @dataclass(frozen=True)
+class StreamingCheckpoint:
+    """Path metadata for directly streaming a safetensor checkpoint."""
+
+    path: Path
+    target_dtype: torch.dtype
+    dtype_aligned: bool
+
+
+@dataclass(frozen=True)
 class StreamingLoadResult:
+    """Summary of tensors loaded into a meta-initialized model."""
+
     loaded_tensor_count: int
     loaded_tensor_bytes: int
     missing_parameter_names: List[str]
@@ -65,11 +85,13 @@ class StreamingLoadResult:
 
 
 def env_flag(name: str) -> bool:
+    """Return True when an environment variable uses a truthy value."""
+
     value = os.environ.get(name, "")
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def normalize_torch_dtype(dtype: Any) -> Optional[torch.dtype]:
+def _normalize_torch_dtype(dtype: Any) -> Optional[torch.dtype]:
     if dtype is None or dtype == "auto":
         return None
     if isinstance(dtype, torch.dtype):
@@ -81,7 +103,7 @@ def normalize_torch_dtype(dtype: Any) -> Optional[torch.dtype]:
         for torch_dtype, config_value in _TORCH_DTYPE_TO_CONFIG.items():
             if normalized == config_value:
                 return torch_dtype
-    raise ValueError(f"Unsupported torch dtype for checkpoint materialization: {dtype!r}")
+    raise ValueError(f"Unsupported torch dtype for QEfficient safetensor loading: {dtype!r}")
 
 
 def materialize_safetensor_checkpoint(
@@ -94,6 +116,13 @@ def materialize_safetensor_checkpoint(
     force: bool = False,
     hub_cache_dir: Optional[Union[str, os.PathLike]] = None,
 ) -> MaterializedCheckpoint:
+    """Create or reuse a local safetensor checkpoint copy in the requested dtype."""
+
+    target_dtype = _normalize_torch_dtype(target_dtype)
+    if target_dtype not in _TORCH_DTYPE_TO_CONFIG:
+        raise ValueError(f"Unsupported target dtype for QEfficient checkpoint materialization: {target_dtype}")
+    force = force or env_flag(QEFF_MATERIALIZE_FORCE_ENV)
+
     source_path = _resolve_source_path(
         pretrained_model_name_or_path,
         revision=revision,
@@ -150,35 +179,144 @@ def materialize_safetensor_checkpoint(
     )
 
 
-def maybe_materialize_safetensor_checkpoint(
+def resolve_safetensor_checkpoint_for_streaming(
     pretrained_model_name_or_path: Union[str, os.PathLike],
     target_dtype: Any,
     *,
-    enabled: Optional[bool] = None,
-    cache_dir: Optional[Union[str, os.PathLike]] = None,
     revision: Optional[str] = None,
     token: Optional[Union[str, bool]] = None,
     local_files_only: bool = False,
-    force: Optional[bool] = None,
     hub_cache_dir: Optional[Union[str, os.PathLike]] = None,
-) -> Optional[MaterializedCheckpoint]:
-    normalized_dtype = normalize_torch_dtype(target_dtype)
-    should_materialize = normalized_dtype is not None if enabled is None else enabled
-    if not should_materialize or normalized_dtype is None:
+) -> Optional[StreamingCheckpoint]:
+    """Resolve a safetensor checkpoint that can be streamed directly into a model."""
+
+    normalized_dtype = _normalize_torch_dtype(target_dtype)
+    if normalized_dtype is None:
         return None
     if normalized_dtype not in _TORCH_DTYPE_TO_CONFIG:
-        raise ValueError(f"Unsupported target dtype for QEfficient checkpoint materialization: {normalized_dtype}")
+        raise ValueError(f"Unsupported target dtype for QEfficient checkpoint streaming: {normalized_dtype}")
 
-    return materialize_safetensor_checkpoint(
+    source_path = _resolve_source_path(
         pretrained_model_name_or_path,
-        normalized_dtype,
-        cache_dir=cache_dir,
         revision=revision,
         token=token,
         local_files_only=local_files_only,
-        force=env_flag(QEFF_MATERIALIZE_FORCE_ENV) if force is None else force,
         hub_cache_dir=hub_cache_dir,
     )
+    layout = _load_safetensor_layout(source_path)
+    return StreamingCheckpoint(
+        path=source_path,
+        target_dtype=normalized_dtype,
+        dtype_aligned=not _checkpoint_requires_conversion(source_path, layout["shards"], normalized_dtype),
+    )
+
+
+def prepare_safetensor_streaming_from_pretrained_source(pretrained_model_name_or_path: str, kwargs: dict) -> str:
+    """Prepare ``from_pretrained`` kwargs for QEfficient direct safetensor streaming."""
+
+    requested_torch_dtype = kwargs.get("torch_dtype") if "torch_dtype" in kwargs else kwargs.get("dtype")
+    _resolve_qeff_torch_dtype(kwargs)
+    if requested_torch_dtype is None:
+        return pretrained_model_name_or_path
+
+    try:
+        streaming_checkpoint = resolve_safetensor_checkpoint_for_streaming(
+            pretrained_model_name_or_path,
+            kwargs.get("torch_dtype"),
+            revision=kwargs.get("revision"),
+            token=kwargs.get("token", kwargs.get("use_auth_token")),
+            local_files_only=kwargs.get("local_files_only", False),
+            hub_cache_dir=kwargs.get("cache_dir"),
+        )
+    except (OSError, ValueError) as exc:
+        logger.warning("Skipping QEfficient streaming checkpoint load: %s", exc)
+        return pretrained_model_name_or_path
+
+    if streaming_checkpoint is None:
+        return pretrained_model_name_or_path
+
+    kwargs[_QEFF_STREAMING_CHECKPOINT_PATH_KWARG] = str(streaming_checkpoint.path)
+    kwargs[_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG] = kwargs.get("torch_dtype")
+    kwargs["low_cpu_mem_usage"] = True
+    kwargs["use_safetensors"] = True
+    if streaming_checkpoint.dtype_aligned:
+        logger.info("Streaming safetensors checkpoint directly from %s", streaming_checkpoint.path)
+    else:
+        logger.info(
+            "Streaming safetensors checkpoint directly from %s with %s casts",
+            streaming_checkpoint.path,
+            streaming_checkpoint.target_dtype,
+        )
+    return str(streaming_checkpoint.path)
+
+
+def load_hf_model_with_optional_safetensor_streaming(
+    auto_class, pretrained_model_name_or_path, args: tuple, kwargs: dict
+):
+    """Load a Hugging Face model, streaming safetensors into a meta model when prepared."""
+
+    streaming_checkpoint_path = kwargs.pop(_QEFF_STREAMING_CHECKPOINT_PATH_KWARG, None)
+    streaming_dtype = kwargs.pop(_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG, None)
+    if streaming_checkpoint_path is None:
+        return auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+    if args:
+        logger.warning("QEfficient streaming checkpoint load does not support positional model args; using HF loader.")
+        return auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+    config = kwargs.get("config")
+    if config is None:
+        config_kwargs = {}
+        for key in ("cache_dir", "revision", "token", "use_auth_token", "local_files_only", "trust_remote_code"):
+            if key in kwargs:
+                config_kwargs[key] = kwargs[key]
+        config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
+
+    constructor_kwargs = {}
+    for key in ("attn_implementation", "trust_remote_code", "torch_dtype", "dtype"):
+        if key in kwargs:
+            constructor_kwargs[key] = kwargs[key]
+
+    normalized_streaming_dtype = _normalize_torch_dtype(streaming_dtype)
+    if normalized_streaming_dtype is not None:
+        _set_config_torch_dtype(config, normalized_streaming_dtype)
+
+    logger.info("Streaming safetensors checkpoint into model from %s", streaming_checkpoint_path)
+    with torch.device("meta"):
+        model = auto_class.from_config(config, **constructor_kwargs)
+    if normalized_streaming_dtype is not None:
+        _set_config_torch_dtype(getattr(model, "config", None), normalized_streaming_dtype)
+    load_summary = load_safetensor_checkpoint_into_model(model, streaming_checkpoint_path, target_dtype=streaming_dtype)
+    logger.info(
+        "Loaded %s tensors (%s bytes) through QEfficient streaming safetensor loader",
+        load_summary.loaded_tensor_count,
+        load_summary.loaded_tensor_bytes,
+    )
+    model.eval()
+    return model
+
+
+def _resolve_qeff_torch_dtype(kwargs: dict) -> None:
+    aic_hw_version = constants.DEFAULT_AIC_HW_VERSION
+    current_dtype = kwargs.get("torch_dtype", None)
+
+    if (current_dtype is None or current_dtype == torch.bfloat16) and aic_hw_version != "ai200":
+        if current_dtype == torch.bfloat16:
+            logger.warning(
+                "torch_dtype=bfloat16 is not supported on %s. Overriding to torch.float32.",
+                aic_hw_version,
+            )
+        kwargs["torch_dtype"] = torch.float32
+
+
+def _set_config_torch_dtype(config, torch_dtype: torch.dtype) -> None:
+    if config is None:
+        return
+    if hasattr(config, "torch_dtype"):
+        config.torch_dtype = torch_dtype
+    for child_name in ("text_config", "vision_config", "llm_config"):
+        if hasattr(config, child_name):
+            _set_config_torch_dtype(getattr(config, child_name), torch_dtype)
 
 
 def load_safetensor_checkpoint_into_model(
@@ -186,32 +324,58 @@ def load_safetensor_checkpoint_into_model(
     checkpoint_path: Union[str, os.PathLike],
     target_dtype: Any = None,
 ) -> StreamingLoadResult:
+    """Stream safetensor shards into matching parameters and buffers on CPU."""
+
     checkpoint_path = Path(checkpoint_path).expanduser().resolve()
     layout = _load_safetensor_layout(checkpoint_path)
-    normalized_dtype = normalize_torch_dtype(target_dtype)
+    normalized_dtype = _normalize_torch_dtype(target_dtype)
 
     expected_parameters = dict(model.named_parameters())
     expected_buffers = dict(model.named_buffers())
     expected_names = set(expected_parameters) | set(expected_buffers)
+    checkpoint_name_to_shard = _index_safetensor_names(checkpoint_path, layout["shards"])
+    legacy_expert_source_names = _collect_legacy_expert_source_names(expected_parameters, checkpoint_name_to_shard)
     loaded_names = set()
     unexpected_names = []
     loaded_tensor_count = 0
     loaded_tensor_bytes = 0
 
-    for shard in layout["shards"]:
+    def load_shard(shard: str) -> tuple[list[tuple[str, torch.Tensor]], list[str]]:
+        loaded_tensors = []
+        shard_unexpected_names = []
         with safe_open(checkpoint_path / shard, framework="pt", device="cpu") as reader:
             for name in reader.keys():
                 if name not in expected_names:
-                    unexpected_names.append(name)
+                    if name not in legacy_expert_source_names:
+                        shard_unexpected_names.append(name)
                     continue
                 tensor = reader.get_tensor(name)
                 if normalized_dtype is not None and tensor.is_floating_point() and tensor.dtype != normalized_dtype:
                     tensor = tensor.to(dtype=normalized_dtype)
-                _set_module_tensor(model, name, tensor)
-                loaded_names.add(name)
-                loaded_tensor_count += 1
-                loaded_tensor_bytes += tensor.numel() * tensor.element_size()
+                loaded_tensors.append((name, tensor))
+        return loaded_tensors, shard_unexpected_names
+
+    for loaded_tensors, shard_unexpected_names in _iter_shard_results(layout["shards"], load_shard):
+        unexpected_names.extend(shard_unexpected_names)
+        for name, tensor in loaded_tensors:
+            _set_module_tensor(model, name, tensor)
+            loaded_names.add(name)
+            loaded_tensor_count += 1
+            loaded_tensor_bytes += tensor.numel() * tensor.element_size()
+        del loaded_tensors
         gc.collect()
+
+    packed_count, packed_bytes, packed_names = _materialize_legacy_expert_parameters(
+        model,
+        expected_parameters,
+        loaded_names,
+        checkpoint_path,
+        checkpoint_name_to_shard,
+        normalized_dtype,
+    )
+    loaded_tensor_count += packed_count
+    loaded_tensor_bytes += packed_bytes
+    loaded_names.update(packed_names)
 
     if hasattr(model, "tie_weights"):
         model.tie_weights()
@@ -233,6 +397,202 @@ def load_safetensor_checkpoint_into_model(
         missing_buffer_names=missing_buffer_names,
         unexpected_tensor_names=unexpected_names,
     )
+
+
+def _index_safetensor_names(checkpoint_path: Path, shards: List[str]) -> Dict[str, str]:
+    name_to_shard = {}
+    for shard in shards:
+        with safe_open(checkpoint_path / shard, framework="pt", device="cpu") as reader:
+            for name in reader.keys():
+                name_to_shard[name] = shard
+    return name_to_shard
+
+
+def _collect_legacy_expert_source_names(
+    expected_parameters: Dict[str, torch.nn.Parameter],
+    checkpoint_name_to_shard: Dict[str, str],
+) -> set[str]:
+    source_names = set()
+    for target_name, parameter in expected_parameters.items():
+        if target_name.endswith(".experts.gate_up_proj"):
+            source_names.update(
+                _legacy_expert_source_names(
+                    target_name,
+                    tuple(parameter.shape),
+                    (("gate_proj", "weight"), ("up_proj", "weight")),
+                    checkpoint_name_to_shard,
+                )
+            )
+        elif target_name.endswith(".experts.down_proj"):
+            source_names.update(
+                _legacy_expert_source_names(
+                    target_name,
+                    tuple(parameter.shape),
+                    (("down_proj", "weight"),),
+                    checkpoint_name_to_shard,
+                )
+            )
+    return source_names
+
+
+def _legacy_expert_source_names(
+    target_name: str,
+    target_shape: tuple[int, ...],
+    projections: tuple[tuple[str, str], ...],
+    checkpoint_name_to_shard: Dict[str, str],
+) -> List[str]:
+    if len(target_shape) != 3:
+        return []
+    base_name = target_name.rsplit(".", 1)[0]
+    source_names = [
+        f"{base_name}.{expert_idx}.{projection}.{weight_name}"
+        for expert_idx in range(target_shape[0])
+        for projection, weight_name in projections
+    ]
+    if all(name in checkpoint_name_to_shard for name in source_names):
+        return source_names
+    return []
+
+
+def _materialize_legacy_expert_parameters(
+    model: torch.nn.Module,
+    expected_parameters: Dict[str, torch.nn.Parameter],
+    loaded_names: set[str],
+    checkpoint_path: Path,
+    checkpoint_name_to_shard: Dict[str, str],
+    target_dtype: Optional[torch.dtype],
+) -> tuple[int, int, set[str]]:
+    loaded_tensor_count = 0
+    loaded_tensor_bytes = 0
+    packed_names = set()
+
+    for target_name, parameter in expected_parameters.items():
+        if target_name in loaded_names or parameter.device.type != "meta":
+            continue
+        if target_name.endswith(".experts.gate_up_proj"):
+            tensor = _load_legacy_gate_up_experts(
+                target_name, parameter, checkpoint_path, checkpoint_name_to_shard, target_dtype
+            )
+        elif target_name.endswith(".experts.down_proj"):
+            tensor = _load_legacy_down_experts(
+                target_name, parameter, checkpoint_path, checkpoint_name_to_shard, target_dtype
+            )
+        else:
+            continue
+        if tensor is None:
+            continue
+        _set_module_tensor(model, target_name, tensor)
+        packed_names.add(target_name)
+        loaded_tensor_count += 1
+        loaded_tensor_bytes += tensor.numel() * tensor.element_size()
+        del tensor
+        gc.collect()
+
+    return loaded_tensor_count, loaded_tensor_bytes, packed_names
+
+
+def _load_legacy_gate_up_experts(
+    target_name: str,
+    parameter: torch.nn.Parameter,
+    checkpoint_path: Path,
+    checkpoint_name_to_shard: Dict[str, str],
+    target_dtype: Optional[torch.dtype],
+) -> Optional[torch.Tensor]:
+    target_shape = tuple(parameter.shape)
+    source_names = _legacy_expert_source_names(
+        target_name,
+        target_shape,
+        (("gate_proj", "weight"), ("up_proj", "weight")),
+        checkpoint_name_to_shard,
+    )
+    if not source_names:
+        return None
+
+    output = torch.empty(target_shape, dtype=_target_parameter_dtype(parameter, target_dtype), device="cpu")
+    base_name = target_name.rsplit(".", 1)[0]
+    for expert_idx in range(target_shape[0]):
+        gate = _read_safetensor_tensor(
+            checkpoint_path, checkpoint_name_to_shard, f"{base_name}.{expert_idx}.gate_proj.weight", target_dtype
+        )
+        up = _read_safetensor_tensor(
+            checkpoint_path, checkpoint_name_to_shard, f"{base_name}.{expert_idx}.up_proj.weight", target_dtype
+        )
+        packed = torch.cat((gate, up), dim=0)
+        output[expert_idx].copy_(_align_legacy_expert_slice(packed, output[expert_idx].shape, target_name))
+    return output
+
+
+def _load_legacy_down_experts(
+    target_name: str,
+    parameter: torch.nn.Parameter,
+    checkpoint_path: Path,
+    checkpoint_name_to_shard: Dict[str, str],
+    target_dtype: Optional[torch.dtype],
+) -> Optional[torch.Tensor]:
+    target_shape = tuple(parameter.shape)
+    source_names = _legacy_expert_source_names(
+        target_name,
+        target_shape,
+        (("down_proj", "weight"),),
+        checkpoint_name_to_shard,
+    )
+    if not source_names:
+        return None
+
+    output = torch.empty(target_shape, dtype=_target_parameter_dtype(parameter, target_dtype), device="cpu")
+    base_name = target_name.rsplit(".", 1)[0]
+    for expert_idx in range(target_shape[0]):
+        down = _read_safetensor_tensor(
+            checkpoint_path, checkpoint_name_to_shard, f"{base_name}.{expert_idx}.down_proj.weight", target_dtype
+        )
+        output[expert_idx].copy_(_align_legacy_expert_slice(down, output[expert_idx].shape, target_name))
+    return output
+
+
+def _read_safetensor_tensor(
+    checkpoint_path: Path,
+    checkpoint_name_to_shard: Dict[str, str],
+    tensor_name: str,
+    target_dtype: Optional[torch.dtype],
+) -> torch.Tensor:
+    with safe_open(checkpoint_path / checkpoint_name_to_shard[tensor_name], framework="pt", device="cpu") as reader:
+        tensor = reader.get_tensor(tensor_name)
+    if target_dtype is not None and tensor.is_floating_point() and tensor.dtype != target_dtype:
+        tensor = tensor.to(dtype=target_dtype)
+    return tensor
+
+
+def _target_parameter_dtype(parameter: torch.nn.Parameter, target_dtype: Optional[torch.dtype]) -> torch.dtype:
+    if target_dtype is not None and parameter.is_floating_point():
+        return target_dtype
+    return parameter.dtype
+
+
+def _align_legacy_expert_slice(tensor: torch.Tensor, target_shape: torch.Size, target_name: str) -> torch.Tensor:
+    expected_shape = tuple(target_shape)
+    if tuple(tensor.shape) == expected_shape:
+        return tensor
+    if tensor.ndim == 2 and tuple(tensor.transpose(0, 1).shape) == expected_shape:
+        return tensor.transpose(0, 1).contiguous()
+    raise RuntimeError(
+        f"Cannot map legacy expert tensor into {target_name}: checkpoint slice shape {tuple(tensor.shape)} "
+        f"does not match target slice shape {expected_shape}"
+    )
+
+
+def _iter_shard_results(shards: List[str], worker):
+    """Run shard I/O jobs through a small thread pool and yield completed results."""
+
+    worker_count = min(len(shards), _SAFETENSOR_PARALLEL_WORKERS)
+    if worker_count <= 1:
+        for shard in shards:
+            yield worker(shard)
+        return
+
+    with ThreadPoolExecutor(max_workers=worker_count) as thread_pool:
+        futures = [thread_pool.submit(worker, shard) for shard in shards]
+        for future in as_completed(futures):
+            yield future.result()
 
 
 def _remaining_meta_names(named_tensors, loaded_names: set[str]) -> List[str]:
@@ -312,7 +672,7 @@ def _load_safetensor_layout(source_path: Path) -> Dict[str, Any]:
         return {"index": None, "index_name": None, "shards": candidates}
 
     raise ValueError(
-        "QEfficient checkpoint materialization requires a safetensors checkpoint with "
+        "QEfficient safetensor loading requires a checkpoint with "
         f"{_SINGLE_FILE} or {_INDEX_FILE}; found {candidates or 'none'} in {source_path}"
     )
 
@@ -358,8 +718,7 @@ def _copy_non_weight_files(source_path: Path, target_path: Path) -> None:
 def _convert_checkpoint_files(
     source_path: Path, target_path: Path, layout: Dict[str, Any], target_dtype: torch.dtype
 ) -> int:
-    total_size = 0
-    for shard in layout["shards"]:
+    def convert_shard(shard: str) -> int:
         source_file = source_path / shard
         target_file = target_path / shard
         target_file.parent.mkdir(parents=True, exist_ok=True)
@@ -372,9 +731,12 @@ def _convert_checkpoint_files(
                     tensor = tensor.to(dtype=target_dtype)
                 tensors[name] = tensor
         save_file(tensors, target_file, metadata=metadata)
-        total_size += target_file.stat().st_size
+        converted_size = target_file.stat().st_size
         del tensors
         gc.collect()
+        return converted_size
+
+    total_size = sum(_iter_shard_results(layout["shards"], convert_shard))
 
     if layout["index"] is not None:
         index = dict(layout["index"])

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ pip install dist/qefficient-0.0.1.dev0-py3-none-any.whl
 
 For more details about using ``QEfficient`` via Cloud AI 100 Apps SDK, visit [Linux Installation Guide](https://quic.github.io/efficient-transformers/source/installation.html)
 
+## Low-memory export options
+
+When `torch_dtype` is passed to `QEFFAutoModelForCausalLM.from_pretrained`, QEfficient treats it as the load/export precision. For safetensor checkpoints, floating tensors are materialized once in that dtype and then streamed into a meta-initialized model. For example, `torch_dtype=torch.float16` creates/reuses fp16 materialized shards and avoids holding both the original checkpoint dtype and the fp16 export copy in host RAM.
+
+If `torch_dtype` is omitted, the loader follows the existing default path. `QEFF_MATERIALIZED_CHECKPOINT_DIR` can be set to choose where the materialized checkpoint cache is stored.
+
+ONNX initializer offload is opt-in and is not enabled by default. Set `QEFF_LOW_MEMORY_ONNX_EXPORT=1`, pass `export_params=False` to `export()`, or set `QEFF_ONNX_EXPORT_PARAMS=0` to export the ONNX graph first and then attach PyTorch weights as external ONNX initializers. This keeps initializer bytes out of the in-memory `ModelProto` during transform/save. `QEFF_LOW_MEMORY_ONNX_EXPORT=1` is ignored for ONNX subfunctions and transforms that need tensor data loaded in memory; explicit `export_params=False` or `QEFF_ONNX_EXPORT_PARAMS=0` remains a hard request and will fail if those transforms require initializer tensors in the graph.
+
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -119,15 +119,6 @@ pip install dist/qefficient-0.0.1.dev0-py3-none-any.whl
 
 For more details about using ``QEfficient`` via Cloud AI 100 Apps SDK, visit [Linux Installation Guide](https://quic.github.io/efficient-transformers/source/installation.html)
 
-## Low-memory export options
-
-When `torch_dtype` is passed to `QEFFAutoModelForCausalLM.from_pretrained`, QEfficient treats it as the load/export precision. For safetensor checkpoints, floating tensors are materialized once in that dtype and then streamed into a meta-initialized model. For example, `torch_dtype=torch.float16` creates/reuses fp16 materialized shards and avoids holding both the original checkpoint dtype and the fp16 export copy in host RAM.
-
-If `torch_dtype` is omitted, the loader follows the existing default path. `QEFF_MATERIALIZED_CHECKPOINT_DIR` can be set to choose where the materialized checkpoint cache is stored.
-
-ONNX initializer offload is opt-in and is not enabled by default. Set `QEFF_LOW_MEMORY_ONNX_EXPORT=1`, pass `export_params=False` to `export()`, or set `QEFF_ONNX_EXPORT_PARAMS=0` to export the ONNX graph first and then attach PyTorch weights as external ONNX initializers. This keeps initializer bytes out of the in-memory `ModelProto` during transform/save. `QEFF_LOW_MEMORY_ONNX_EXPORT=1` is ignored for ONNX subfunctions and transforms that need tensor data loaded in memory; explicit `export_params=False` or `QEFF_ONNX_EXPORT_PARAMS=0` remains a hard request and will fail if those transforms require initializer tensors in the graph.
-
-
 ## Documentation
 
 * [Quick Start Guide](https://quic.github.io/efficient-transformers/source/quick_start.html)

--- a/docs/source/quick_start.md
+++ b/docs/source/quick_start.md
@@ -37,6 +37,15 @@ User can export a model to ONNX using the CLI command. This will convert the mod
 ```bash
 python -m QEfficient.cloud.export --model_name gpt2
 ```
+
+**Low-memory export options**
+
+When `torch_dtype` is passed to `QEFFAutoModelForCausalLM.from_pretrained`, QEfficient treats it as the load/export precision. For safetensor checkpoints, floating tensors are streamed directly into a meta-initialized model and cast one tensor at a time. For example, `torch_dtype=torch.float16` loads fp16 weights without creating a second converted checkpoint copy on disk.
+
+If `torch_dtype` is omitted, QEfficient follows the existing default load path. ONNX initializer offload is opt-in and is not enabled by default. Set `QEFF_LOW_MEMORY_ONNX_EXPORT=1`, pass `export_params=False` to `export()`, or set `QEFF_ONNX_EXPORT_PARAMS=0` to export the ONNX graph first and then attach PyTorch weights as external ONNX initializers. This keeps initializer bytes out of the in-memory `ModelProto` during transform/save while preserving the exporter default constant-folding behavior unless explicitly overridden.
+
+`QEFF_LOW_MEMORY_ONNX_EXPORT=1` is ignored for ONNX subfunctions and transforms that need tensor data loaded in memory; explicit `export_params=False` or `QEFF_ONNX_EXPORT_PARAMS=0` remains a hard request and will fail if those transforms require initializer tensors in the graph.
+
 ---
 
 #### Compile

--- a/examples/text_generation/basic_inference.py
+++ b/examples/text_generation/basic_inference.py
@@ -27,10 +27,10 @@ def main():
         choices=["float16", "bfloat16", "float32"],
         default=None,
         help=(
-            "Optional load/export precision. For example, float16 materializes floating "
-            "safetensor weights as fp16 before streaming them into the model, avoiding "
-            "an extra bf16/fp16 checkpoint copy during export. If omitted, QEfficient "
-            "uses its existing default loading behavior."
+            "Optional load/export precision. For example, float16 streams floating "
+            "safetensor weights into the model as fp16 one tensor at a time, avoiding "
+            "an extra checkpoint copy during export. If omitted, QEfficient uses its "
+            "existing default loading behavior."
         ),
     )
     parser.add_argument(
@@ -42,9 +42,9 @@ def main():
     args = parser.parse_args()
 
     # Load tokenizer and model. If --torch-dtype is set, QEfficient uses that
-    # precision for load/export and streams a matching materialized safetensors
-    # checkpoint into the model to reduce host RAM during export. Leaving it unset
-    # preserves the existing default loader path.
+    # precision for load/export and streams safetensors directly into the model to
+    # reduce host RAM during export. Leaving it unset preserves the existing
+    # default loader path.
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
     model_kwargs = {}
     if args.torch_dtype is not None:

--- a/examples/text_generation/basic_inference.py
+++ b/examples/text_generation/basic_inference.py
@@ -7,6 +7,7 @@
 
 import argparse
 
+import torch
 from transformers import AutoTokenizer
 
 from QEfficient import QEFFAutoModelForCausalLM
@@ -22,6 +23,17 @@ def main():
     parser.add_argument("--num-cores", type=int, default=16, help="Number of cores")
     parser.add_argument("--aic-hw-version", type=str, default="ai100", help="Version of aic hardware")
     parser.add_argument(
+        "--torch-dtype",
+        choices=["float16", "bfloat16", "float32"],
+        default=None,
+        help=(
+            "Optional load/export precision. For example, float16 materializes floating "
+            "safetensor weights as fp16 before streaming them into the model, avoiding "
+            "an extra bf16/fp16 checkpoint copy during export. If omitted, QEfficient "
+            "uses its existing default loading behavior."
+        ),
+    )
+    parser.add_argument(
         "--device-group",
         type=lambda device_ids: [int(x) for x in device_ids.strip("[]").split(",")],
         default=None,
@@ -29,9 +41,15 @@ def main():
     )
     args = parser.parse_args()
 
-    # Load tokenizer and model
+    # Load tokenizer and model. If --torch-dtype is set, QEfficient uses that
+    # precision for load/export and streams a matching materialized safetensors
+    # checkpoint into the model to reduce host RAM during export. Leaving it unset
+    # preserves the existing default loader path.
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
-    model = QEFFAutoModelForCausalLM.from_pretrained(args.model_name)
+    model_kwargs = {}
+    if args.torch_dtype is not None:
+        model_kwargs["torch_dtype"] = getattr(torch, args.torch_dtype)
+    model = QEFFAutoModelForCausalLM.from_pretrained(args.model_name, **model_kwargs)
 
     # Compile the model
     qpc_path = model.compile(

--- a/tests/base/test_export_memory_offload.py
+++ b/tests/base/test_export_memory_offload.py
@@ -5,7 +5,9 @@
 #
 # -----------------------------------------------------------------------------
 
+import onnx
 import pytest
+from onnx import TensorProto
 from transformers import AutoConfig, AutoModelForCausalLM
 
 from QEfficient.transformers.models.modeling_auto import QEFFAutoModelForCausalLM
@@ -79,6 +81,44 @@ def test_re_export_behavior_with_offloaded_weights(tmp_cache):
     # Re-export should fail with RuntimeError due to offloaded weights
     with pytest.raises(RuntimeError, match="weights have been offloaded"):
         qeff_model.export()
+
+
+def test_default_export_keeps_initializers_inline(tmp_cache):
+    """Low-memory ONNX initializer offload is opt-in, not the default export path."""
+    model = AutoModelForCausalLM.from_config(test_config, **model_kwargs)
+    qeff_model = QEFFAutoModelForCausalLM(model, continuous_batching=False)
+
+    onnx_path = qeff_model.export(tmp_cache / "default", offload_pt_weights=False)
+    graph_only_model = onnx.load(onnx_path, load_external_data=False)
+
+    assert graph_only_model.graph.initializer
+    assert all(initializer.data_location != TensorProto.EXTERNAL for initializer in graph_only_model.graph.initializer)
+
+
+def test_low_memory_export_externalizes_initializers(tmp_cache, monkeypatch):
+    """Low-memory export keeps ONNX initializer bytes out of the in-memory ModelProto."""
+    monkeypatch.setenv("QEFF_LOW_MEMORY_ONNX_EXPORT", "1")
+    model = AutoModelForCausalLM.from_config(test_config, **model_kwargs)
+    qeff_model = QEFFAutoModelForCausalLM(model, continuous_batching=False)
+
+    onnx_path = qeff_model.export(tmp_cache / "lowmem", offload_pt_weights=False)
+    onnx.checker.check_model(str(onnx_path), full_check=False)
+    graph_only_model = onnx.load(onnx_path, load_external_data=False)
+
+    external_initializers = [
+        initializer
+        for initializer in graph_only_model.graph.initializer
+        if initializer.data_location == TensorProto.EXTERNAL
+    ]
+    assert external_initializers
+    assert all(len(initializer.raw_data) == 0 for initializer in external_initializers)
+
+    graph_input_names = {graph_input.name for graph_input in graph_only_model.graph.input}
+    initializer_names = {initializer.name for initializer in graph_only_model.graph.initializer}
+    assert graph_input_names.isdisjoint(initializer_names)
+
+    loaded_model = onnx.load(onnx_path, load_external_data=True)
+    assert sum(len(initializer.raw_data) for initializer in loaded_model.graph.initializer) > 0
 
 
 def test_vlm_dual_qpc_memory_offload_behavior():

--- a/tests/base/test_export_memory_offload.py
+++ b/tests/base/test_export_memory_offload.py
@@ -8,9 +8,14 @@
 import onnx
 import pytest
 from onnx import TensorProto
-from transformers import AutoConfig, AutoModelForCausalLM
+from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForSequenceClassification
 
-from QEfficient.transformers.models.modeling_auto import QEFFAutoModelForCausalLM
+from QEfficient.base import modeling_qeff
+from QEfficient.transformers.models.modeling_auto import (
+    QEFFAutoModelForCausalLM,
+    QEFFAutoModelForSequenceClassification,
+)
+from QEfficient.utils.export_utils import _apply_low_memory_export_defaults
 
 # Simple test config for memory reduction testing
 test_config = AutoConfig.for_model(
@@ -93,6 +98,67 @@ def test_default_export_keeps_initializers_inline(tmp_cache):
 
     assert graph_only_model.graph.initializer
     assert all(initializer.data_location != TensorProto.EXTERNAL for initializer in graph_only_model.graph.initializer)
+
+
+def test_low_memory_export_keeps_constant_folding_default(monkeypatch):
+    monkeypatch.setenv("QEFF_LOW_MEMORY_ONNX_EXPORT", "1")
+    kwargs = {}
+
+    class DummyQEFFModel:
+        _onnx_transforms = []
+
+    _apply_low_memory_export_defaults(DummyQEFFModel(), kwargs)
+
+    assert kwargs["export_params"] is False
+    assert "do_constant_folding" not in kwargs
+
+
+def _tiny_sequence_classification_qeff_model():
+    config = AutoConfig.for_model(
+        "bert",
+        hidden_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        intermediate_size=16,
+        vocab_size=17,
+        max_position_embeddings=64,
+        num_labels=2,
+    )
+    model = AutoModelForSequenceClassification.from_config(config)
+    model.eval()
+    return QEFFAutoModelForSequenceClassification(model)
+
+
+def test_low_memory_export_retries_without_constant_folding_on_externalizer_validation_failure(tmp_cache, monkeypatch):
+    monkeypatch.setenv("QEFF_LOW_MEMORY_ONNX_EXPORT", "1")
+    export_constant_folding_values = []
+    original_export = modeling_qeff.torch.onnx.export
+
+    def export_spy(*args, **kwargs):
+        export_constant_folding_values.append(kwargs.get("do_constant_folding", "unset"))
+        return original_export(*args, **kwargs)
+
+    original_attach = modeling_qeff.attach_external_initializers_from_torch
+    attach_call_count = 0
+
+    def attach_spy(*args, **kwargs):
+        nonlocal attach_call_count
+        attach_call_count += 1
+        summary = dict(original_attach(*args, **kwargs))
+        if attach_call_count == 1:
+            summary["missing_initializer_input_count"] = 1
+            summary["missing_initializer_inputs"] = ["bert.embeddings.word_embeddings.weight"]
+        return summary
+
+    monkeypatch.setattr(modeling_qeff.torch.onnx, "export", export_spy)
+    monkeypatch.setattr(modeling_qeff, "attach_external_initializers_from_torch", attach_spy)
+    qeff_model = _tiny_sequence_classification_qeff_model()
+
+    onnx_path = qeff_model.export(tmp_cache / "retry")
+
+    assert onnx_path.is_file()
+    assert attach_call_count == 2
+    assert export_constant_folding_values == ["unset", False]
 
 
 def test_low_memory_export_externalizes_initializers(tmp_cache, monkeypatch):

--- a/tests/base/test_safetensor_materializer.py
+++ b/tests/base/test_safetensor_materializer.py
@@ -12,13 +12,11 @@ from safetensors import safe_open
 from safetensors.torch import save_file
 from transformers import AutoConfig, AutoModelForCausalLM
 
-from QEfficient.transformers.models.modeling_auto import (
-    QEFFAutoModelForCausalLM,
-    _prepare_weight_materialized_from_pretrained_source,
-)
+from QEfficient.transformers.models.modeling_auto import QEFFAutoModelForCausalLM
 from QEfficient.utils.safetensor_materializer import (
     load_safetensor_checkpoint_into_model,
     materialize_safetensor_checkpoint,
+    prepare_safetensor_streaming_from_pretrained_source,
 )
 
 
@@ -43,6 +41,45 @@ def _write_tiny_safetensor_checkpoint(path):
         path / "model.safetensors",
         metadata={"format": "pt"},
     )
+
+
+def _write_sharded_tiny_safetensor_checkpoint(path):
+    path.mkdir()
+    with (path / "config.json").open("w") as handle:
+        json.dump(
+            {
+                "architectures": ["TinyForCausalLM"],
+                "model_type": "tiny",
+                "torch_dtype": "bfloat16",
+                "text_config": {"torch_dtype": "bfloat16"},
+            },
+            handle,
+        )
+    save_file(
+        {
+            "bf16_weight": torch.ones(2, 3, dtype=torch.bfloat16),
+            "int_weight": torch.ones(1, dtype=torch.int64),
+        },
+        path / "model-00001-of-00002.safetensors",
+        metadata={"format": "pt"},
+    )
+    save_file(
+        {"fp32_weight": torch.ones(3, 2, dtype=torch.float32)},
+        path / "model-00002-of-00002.safetensors",
+        metadata={"format": "pt"},
+    )
+    with (path / "model.safetensors.index.json").open("w") as handle:
+        json.dump(
+            {
+                "metadata": {"total_size": 0},
+                "weight_map": {
+                    "bf16_weight": "model-00001-of-00002.safetensors",
+                    "int_weight": "model-00001-of-00002.safetensors",
+                    "fp32_weight": "model-00002-of-00002.safetensors",
+                },
+            },
+            handle,
+        )
 
 
 def test_materialize_safetensor_checkpoint_converts_floating_tensors(tmp_path):
@@ -73,13 +110,34 @@ def test_materialize_safetensor_checkpoint_converts_floating_tensors(tmp_path):
         assert reader.get_tensor("bf16_weight").dtype == torch.bfloat16
 
 
-def test_loader_hook_skips_materialization_without_explicit_dtype(tmp_path, monkeypatch):
+def test_materialize_safetensor_checkpoint_converts_shards_in_parallel(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    _write_sharded_tiny_safetensor_checkpoint(source_path)
+    monkeypatch.setattr("QEfficient.utils.safetensor_materializer._SAFETENSOR_PARALLEL_WORKERS", 2)
+
+    materialized = materialize_safetensor_checkpoint(
+        source_path,
+        torch.float16,
+        cache_dir=tmp_path / "qeff_materialized",
+    )
+
+    with safe_open(materialized.path / "model-00001-of-00002.safetensors", framework="pt", device="cpu") as reader:
+        assert reader.get_tensor("bf16_weight").dtype == torch.float16
+        assert reader.get_tensor("int_weight").dtype == torch.int64
+    with safe_open(materialized.path / "model-00002-of-00002.safetensors", framework="pt", device="cpu") as reader:
+        assert reader.get_tensor("fp32_weight").dtype == torch.float16
+    with (materialized.path / "model.safetensors.index.json").open() as handle:
+        index = json.load(handle)
+    assert index["metadata"]["total_size"] > 0
+
+
+def test_loader_hook_skips_streaming_without_explicit_dtype(tmp_path, monkeypatch):
     source_path = tmp_path / "source"
     _write_tiny_safetensor_checkpoint(source_path)
     monkeypatch.setenv("QEFF_MATERIALIZED_CHECKPOINT_DIR", str(tmp_path / "qeff_materialized"))
-    kwargs = {}
+    kwargs = {"low_cpu_mem_usage": False}
 
-    prepared_path = _prepare_weight_materialized_from_pretrained_source(str(source_path), kwargs)
+    prepared_path = prepare_safetensor_streaming_from_pretrained_source(str(source_path), kwargs)
 
     assert prepared_path == str(source_path)
     assert kwargs["torch_dtype"] == torch.float32
@@ -88,19 +146,20 @@ def test_loader_hook_skips_materialization_without_explicit_dtype(tmp_path, monk
     assert not (tmp_path / "qeff_materialized").exists()
 
 
-def test_materialized_loader_hook_uses_streaming_load_kwargs(tmp_path, monkeypatch):
+def test_loader_hook_streams_source_checkpoint_without_materialized_copy(tmp_path, monkeypatch):
     source_path = tmp_path / "source"
     _write_tiny_safetensor_checkpoint(source_path)
     monkeypatch.setenv("QEFF_MATERIALIZED_CHECKPOINT_DIR", str(tmp_path / "qeff_materialized"))
     kwargs = {"torch_dtype": torch.float16, "low_cpu_mem_usage": False}
 
-    prepared_path = _prepare_weight_materialized_from_pretrained_source(str(source_path), kwargs)
+    prepared_path = prepare_safetensor_streaming_from_pretrained_source(str(source_path), kwargs)
 
-    assert prepared_path != str(source_path)
+    assert prepared_path == str(source_path.resolve())
     assert kwargs["low_cpu_mem_usage"] is True
     assert kwargs["use_safetensors"] is True
+    assert not (tmp_path / "qeff_materialized").exists()
     with safe_open(f"{prepared_path}/model.safetensors", framework="pt", device="cpu") as reader:
-        assert reader.get_tensor("bf16_weight").dtype == torch.float16
+        assert reader.get_tensor("bf16_weight").dtype == torch.bfloat16
 
 
 def test_streaming_loader_populates_meta_model_from_safetensors(tmp_path):
@@ -133,7 +192,7 @@ def test_streaming_loader_populates_meta_model_from_safetensors(tmp_path):
     assert torch.equal(source_model.transformer.wte.weight, target_model.transformer.wte.weight)
 
 
-def test_from_pretrained_loads_materialized_checkpoint(tmp_path, monkeypatch):
+def test_from_pretrained_streams_fp16_checkpoint_without_materialized_copy(tmp_path, monkeypatch):
     source_path = tmp_path / "source"
     materialized_dir = tmp_path / "qeff_materialized"
     monkeypatch.setenv("QEFF_MATERIALIZED_CHECKPOINT_DIR", str(materialized_dir))
@@ -152,4 +211,4 @@ def test_from_pretrained_loads_materialized_checkpoint(tmp_path, monkeypatch):
     qeff_model = QEFFAutoModelForCausalLM.from_pretrained(str(source_path), torch_dtype=torch.float16)
 
     assert next(qeff_model.model.parameters()).dtype == torch.float16
-    assert any(materialized_dir.iterdir())
+    assert not materialized_dir.exists()

--- a/tests/base/test_safetensor_materializer.py
+++ b/tests/base/test_safetensor_materializer.py
@@ -1,0 +1,155 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+import json
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+from transformers import AutoConfig, AutoModelForCausalLM
+
+from QEfficient.transformers.models.modeling_auto import (
+    QEFFAutoModelForCausalLM,
+    _prepare_weight_materialized_from_pretrained_source,
+)
+from QEfficient.utils.safetensor_materializer import (
+    load_safetensor_checkpoint_into_model,
+    materialize_safetensor_checkpoint,
+)
+
+
+def _write_tiny_safetensor_checkpoint(path):
+    path.mkdir()
+    with (path / "config.json").open("w") as handle:
+        json.dump(
+            {
+                "architectures": ["TinyForCausalLM"],
+                "model_type": "tiny",
+                "torch_dtype": "bfloat16",
+                "text_config": {"torch_dtype": "bfloat16"},
+            },
+            handle,
+        )
+    save_file(
+        {
+            "bf16_weight": torch.ones(2, 3, dtype=torch.bfloat16),
+            "fp32_weight": torch.ones(3, 2, dtype=torch.float32),
+            "int_weight": torch.ones(1, dtype=torch.int64),
+        },
+        path / "model.safetensors",
+        metadata={"format": "pt"},
+    )
+
+
+def test_materialize_safetensor_checkpoint_converts_floating_tensors(tmp_path):
+    source_path = tmp_path / "source"
+    _write_tiny_safetensor_checkpoint(source_path)
+
+    materialized = materialize_safetensor_checkpoint(
+        source_path,
+        torch.float16,
+        cache_dir=tmp_path / "qeff_materialized",
+    )
+
+    assert materialized.materialized
+    assert materialized.path != source_path
+    assert (materialized.path / "qeff_materialized_checkpoint.json").exists()
+
+    with safe_open(materialized.path / "model.safetensors", framework="pt", device="cpu") as reader:
+        assert reader.get_tensor("bf16_weight").dtype == torch.float16
+        assert reader.get_tensor("fp32_weight").dtype == torch.float16
+        assert reader.get_tensor("int_weight").dtype == torch.int64
+
+    with (materialized.path / "config.json").open() as handle:
+        config = json.load(handle)
+    assert config["torch_dtype"] == "float16"
+    assert config["text_config"]["torch_dtype"] == "float16"
+
+    with safe_open(source_path / "model.safetensors", framework="pt", device="cpu") as reader:
+        assert reader.get_tensor("bf16_weight").dtype == torch.bfloat16
+
+
+def test_loader_hook_skips_materialization_without_explicit_dtype(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    _write_tiny_safetensor_checkpoint(source_path)
+    monkeypatch.setenv("QEFF_MATERIALIZED_CHECKPOINT_DIR", str(tmp_path / "qeff_materialized"))
+    kwargs = {}
+
+    prepared_path = _prepare_weight_materialized_from_pretrained_source(str(source_path), kwargs)
+
+    assert prepared_path == str(source_path)
+    assert kwargs["torch_dtype"] == torch.float32
+    assert kwargs["low_cpu_mem_usage"] is False
+    assert "use_safetensors" not in kwargs
+    assert not (tmp_path / "qeff_materialized").exists()
+
+
+def test_materialized_loader_hook_uses_streaming_load_kwargs(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    _write_tiny_safetensor_checkpoint(source_path)
+    monkeypatch.setenv("QEFF_MATERIALIZED_CHECKPOINT_DIR", str(tmp_path / "qeff_materialized"))
+    kwargs = {"torch_dtype": torch.float16, "low_cpu_mem_usage": False}
+
+    prepared_path = _prepare_weight_materialized_from_pretrained_source(str(source_path), kwargs)
+
+    assert prepared_path != str(source_path)
+    assert kwargs["low_cpu_mem_usage"] is True
+    assert kwargs["use_safetensors"] is True
+    with safe_open(f"{prepared_path}/model.safetensors", framework="pt", device="cpu") as reader:
+        assert reader.get_tensor("bf16_weight").dtype == torch.float16
+
+
+def test_streaming_loader_populates_meta_model_from_safetensors(tmp_path):
+    source_path = tmp_path / "source"
+    config = AutoConfig.for_model(
+        "gpt2",
+        n_layer=1,
+        n_head=2,
+        n_embd=8,
+        vocab_size=17,
+        n_positions=16,
+        n_ctx=16,
+    )
+    source_model = AutoModelForCausalLM.from_config(config, attn_implementation="eager").to(torch.float16)
+    source_model.save_pretrained(source_path, safe_serialization=True)
+
+    with torch.device("meta"):
+        target_model = AutoModelForCausalLM.from_config(
+            config,
+            attn_implementation="eager",
+            torch_dtype=torch.float16,
+        )
+
+    result = load_safetensor_checkpoint_into_model(target_model, source_path, target_dtype=torch.float16)
+
+    assert result.loaded_tensor_count > 0
+    assert not result.missing_parameter_names
+    assert all(parameter.device.type == "cpu" for parameter in target_model.parameters())
+    assert next(target_model.parameters()).dtype == torch.float16
+    assert torch.equal(source_model.transformer.wte.weight, target_model.transformer.wte.weight)
+
+
+def test_from_pretrained_loads_materialized_checkpoint(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    materialized_dir = tmp_path / "qeff_materialized"
+    monkeypatch.setenv("QEFF_MATERIALIZED_CHECKPOINT_DIR", str(materialized_dir))
+    config = AutoConfig.for_model(
+        "gpt2",
+        n_layer=1,
+        n_head=2,
+        n_embd=8,
+        vocab_size=17,
+        n_positions=16,
+        n_ctx=16,
+    )
+    model = AutoModelForCausalLM.from_config(config, attn_implementation="eager").to(torch.bfloat16)
+    model.save_pretrained(source_path, safe_serialization=True)
+
+    qeff_model = QEFFAutoModelForCausalLM.from_pretrained(str(source_path), torch_dtype=torch.float16)
+
+    assert next(qeff_model.model.parameters()).dtype == torch.float16
+    assert any(materialized_dir.iterdir())

--- a/tests/transformers/models/test_moe_prefill_blocked.py
+++ b/tests/transformers/models/test_moe_prefill_blocked.py
@@ -7,6 +7,7 @@
 import copy
 from collections import Counter
 
+import pytest
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM
 
@@ -197,6 +198,33 @@ def test_qwen3moe_blocked_forward_parity():
 
     assert orig.shape == blocked.shape
     assert (orig - blocked).abs().max().item() < 0.1, "Qwen3MOE parity failed"
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_qwen3moe_blocked_forward_accepts_half_precision_router_logits(dtype):
+    from QEfficient.transformers.models.qwen3_moe.modeling_qwen3_moe import (
+        QEffPrefillChunkedQwen3MoeSparseMoeBlock,
+    )
+
+    config = AutoConfig.for_model("qwen3_moe", **QWEN3_MOE_CFG)
+    model = AutoModelForCausalLM.from_config(config, **MODEL_KWARGS).to(dtype)
+    block = next(
+        module
+        for _, module in model.named_modules()
+        if hasattr(module, "experts") and hasattr(module, "gate") and hasattr(module.gate, "num_experts")
+    )
+    block.__class__ = QEffPrefillChunkedQwen3MoeSparseMoeBlock
+    block.__qeff_init__()
+    block.expert_blocking_num_nsp = 2
+    block.expert_blocking_packed_chunk_size = 256
+
+    x = torch.randn(1, 8, config.hidden_size, dtype=dtype)
+    with torch.no_grad():
+        blocked, router_logits = block.forward(x)
+
+    assert blocked.dtype == dtype
+    assert router_logits.dtype == torch.float32
+    assert torch.isfinite(blocked.float()).all()
 
 
 def test_qwen3moe_decode_export(tmp_path):

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -18,6 +18,7 @@ This file intentionally uses two coverage tiers:
      but do not yet have a stable CPU runtime parity path in the consolidated test
 """
 
+import json
 import logging
 import os
 import shutil
@@ -32,6 +33,8 @@ import onnx
 import onnxruntime as ort
 import pytest
 import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
 from transformers import (
     AutoConfig,
     AutoModel,
@@ -43,6 +46,7 @@ from transformers import (
     Qwen2Config,
 )
 
+from QEfficient.base import modeling_qeff
 from QEfficient.transformers.models.modeling_auto import (
     QEFFAutoModel,
     QEFFAutoModelForCausalLM,
@@ -53,7 +57,13 @@ from QEfficient.transformers.models.modeling_auto import (
 )
 from QEfficient.transformers.quantizers.auto import replace_transformers_quantizers
 from QEfficient.utils._utils import _infer_specialization_name, to_named_specializations
+from QEfficient.utils.export_utils import _apply_low_memory_export_defaults
 from QEfficient.utils.run_utils import ApiRunner
+from QEfficient.utils.safetensor_materializer import (
+    load_safetensor_checkpoint_into_model,
+    materialize_safetensor_checkpoint,
+    prepare_safetensor_streaming_from_pretrained_source,
+)
 
 ort.set_default_logger_severity(3)
 logging.getLogger("QEfficient").setLevel(logging.ERROR)
@@ -537,6 +547,277 @@ def test_seq_classification_cpu_parity_and_export(tmp_path):
 
     assert np.allclose(hf_logits, qeff_logits, atol=1e-5)
     assert np.allclose(hf_logits, ort_logits, atol=1e-5)
+
+
+class _QuickcheckTinyMetaModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty(2, 3))
+        self.register_buffer("scale", torch.empty(3))
+
+
+def _write_quickcheck_safetensor_checkpoint(path: Path) -> None:
+    path.mkdir()
+    with (path / "config.json").open("w") as handle:
+        json.dump(
+            {
+                "architectures": ["TinyForCausalLM"],
+                "model_type": "tiny",
+                "torch_dtype": "bfloat16",
+                "text_config": {"torch_dtype": "bfloat16"},
+            },
+            handle,
+        )
+    save_file(
+        {
+            "bf16_weight": torch.ones(2, 3, dtype=torch.bfloat16),
+            "fp32_weight": torch.ones(3, 2, dtype=torch.float32),
+            "int_weight": torch.ones(1, dtype=torch.int64),
+        },
+        path / "model.safetensors",
+        metadata={"format": "pt"},
+    )
+
+
+def _write_quickcheck_sharded_safetensor_checkpoint(path: Path) -> None:
+    path.mkdir()
+    with (path / "config.json").open("w") as handle:
+        json.dump({"model_type": "tiny", "torch_dtype": "bfloat16"}, handle)
+    save_file(
+        {
+            "weight": torch.ones(2, 3, dtype=torch.bfloat16),
+            "int_weight": torch.ones(1, dtype=torch.int64),
+        },
+        path / "model-00001-of-00002.safetensors",
+        metadata={"format": "pt"},
+    )
+    save_file(
+        {"scale": torch.arange(3, dtype=torch.float32)},
+        path / "model-00002-of-00002.safetensors",
+        metadata={"format": "pt"},
+    )
+    with (path / "model.safetensors.index.json").open("w") as handle:
+        json.dump(
+            {
+                "metadata": {"total_size": 0},
+                "weight_map": {
+                    "weight": "model-00001-of-00002.safetensors",
+                    "int_weight": "model-00001-of-00002.safetensors",
+                    "scale": "model-00002-of-00002.safetensors",
+                },
+            },
+            handle,
+        )
+
+
+def _quickcheck_tiny_sequence_classifier():
+    config = AutoConfig.for_model(
+        "bert",
+        hidden_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        intermediate_size=16,
+        vocab_size=17,
+        max_position_embeddings=64,
+        num_labels=2,
+    )
+    model = AutoModelForSequenceClassification.from_config(config)
+    model.eval()
+    return QEFFAutoModelForSequenceClassification(model)
+
+
+def test_quickcheck_materialize_safetensor_checkpoint_converts_floating_tensors(tmp_path):
+    source_path = tmp_path / "source"
+    _write_quickcheck_safetensor_checkpoint(source_path)
+
+    materialized = materialize_safetensor_checkpoint(
+        source_path,
+        torch.float16,
+        cache_dir=tmp_path / "qeff_materialized",
+    )
+
+    with safe_open(materialized.path / "model.safetensors", framework="pt", device="cpu") as reader:
+        assert reader.get_tensor("bf16_weight").dtype == torch.float16
+        assert reader.get_tensor("fp32_weight").dtype == torch.float16
+        assert reader.get_tensor("int_weight").dtype == torch.int64
+    with (materialized.path / "config.json").open() as handle:
+        config = json.load(handle)
+    assert config["torch_dtype"] == "float16"
+    assert config["text_config"]["torch_dtype"] == "float16"
+    with safe_open(source_path / "model.safetensors", framework="pt", device="cpu") as reader:
+        assert reader.get_tensor("bf16_weight").dtype == torch.bfloat16
+
+
+def test_quickcheck_materialize_safetensor_checkpoint_converts_shards(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    _write_quickcheck_sharded_safetensor_checkpoint(source_path)
+    monkeypatch.setattr("QEfficient.utils.safetensor_materializer._SAFETENSOR_PARALLEL_WORKERS", 2)
+
+    materialized = materialize_safetensor_checkpoint(
+        source_path,
+        torch.float16,
+        cache_dir=tmp_path / "qeff_materialized",
+    )
+
+    with safe_open(materialized.path / "model-00001-of-00002.safetensors", framework="pt", device="cpu") as reader:
+        assert reader.get_tensor("weight").dtype == torch.float16
+        assert reader.get_tensor("int_weight").dtype == torch.int64
+    with safe_open(materialized.path / "model-00002-of-00002.safetensors", framework="pt", device="cpu") as reader:
+        assert reader.get_tensor("scale").dtype == torch.float16
+    with (materialized.path / "model.safetensors.index.json").open() as handle:
+        index = json.load(handle)
+    assert index["metadata"]["total_size"] > 0
+
+
+def test_quickcheck_loader_hook_skips_streaming_without_explicit_dtype(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    _write_quickcheck_safetensor_checkpoint(source_path)
+    monkeypatch.setenv("QEFF_MATERIALIZED_CHECKPOINT_DIR", str(tmp_path / "qeff_materialized"))
+    kwargs = {"low_cpu_mem_usage": False}
+
+    prepared_path = prepare_safetensor_streaming_from_pretrained_source(str(source_path), kwargs)
+
+    assert prepared_path == str(source_path)
+    assert kwargs["torch_dtype"] == torch.float32
+    assert kwargs["low_cpu_mem_usage"] is False
+    assert "use_safetensors" not in kwargs
+    assert not (tmp_path / "qeff_materialized").exists()
+
+
+def test_quickcheck_streaming_loader_casts_sharded_checkpoint(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    _write_quickcheck_sharded_safetensor_checkpoint(source_path)
+    monkeypatch.setattr("QEfficient.utils.safetensor_materializer._SAFETENSOR_PARALLEL_WORKERS", 2)
+
+    with torch.device("meta"):
+        model = _QuickcheckTinyMetaModule()
+
+    result = load_safetensor_checkpoint_into_model(model, source_path, target_dtype=torch.float16)
+
+    assert result.loaded_tensor_count == 2
+    assert not result.missing_parameter_names
+    assert model.weight.dtype == torch.float16
+    assert model.scale.dtype == torch.float16
+    assert torch.equal(model.scale, torch.arange(3, dtype=torch.float16))
+
+
+def test_quickcheck_default_export_keeps_initializers_inline(tmp_path):
+    qeff_model = _quickcheck_tiny_sequence_classifier()
+
+    onnx_path = _exported_onnx_path(qeff_model.export(tmp_path / "default"))
+    graph_only_model = onnx.load(onnx_path, load_external_data=False)
+
+    assert graph_only_model.graph.initializer
+    assert all(
+        initializer.data_location != onnx.TensorProto.EXTERNAL for initializer in graph_only_model.graph.initializer
+    )
+
+
+def test_quickcheck_low_memory_export_keeps_constant_folding_default(monkeypatch):
+    monkeypatch.setenv("QEFF_LOW_MEMORY_ONNX_EXPORT", "1")
+    kwargs = {}
+
+    class DummyQEFFModel:
+        _onnx_transforms = []
+
+    _apply_low_memory_export_defaults(DummyQEFFModel(), kwargs)
+
+    assert kwargs["export_params"] is False
+    assert "do_constant_folding" not in kwargs
+
+
+def test_quickcheck_low_memory_export_retries_without_constant_folding_on_externalizer_validation_failure(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("QEFF_LOW_MEMORY_ONNX_EXPORT", "1")
+    export_constant_folding_values = []
+    original_export = modeling_qeff.torch.onnx.export
+
+    def export_spy(*args, **kwargs):
+        export_constant_folding_values.append(kwargs.get("do_constant_folding", "unset"))
+        return original_export(*args, **kwargs)
+
+    original_attach = modeling_qeff.attach_external_initializers_from_torch
+    attach_call_count = 0
+
+    def attach_spy(*args, **kwargs):
+        nonlocal attach_call_count
+        attach_call_count += 1
+        summary = dict(original_attach(*args, **kwargs))
+        if attach_call_count == 1:
+            summary["missing_initializer_input_count"] = 1
+            summary["missing_initializer_inputs"] = ["bert.embeddings.word_embeddings.weight"]
+        return summary
+
+    monkeypatch.setattr(modeling_qeff.torch.onnx, "export", export_spy)
+    monkeypatch.setattr(modeling_qeff, "attach_external_initializers_from_torch", attach_spy)
+    qeff_model = _quickcheck_tiny_sequence_classifier()
+
+    onnx_path = _exported_onnx_path(qeff_model.export(tmp_path / "retry"))
+
+    assert onnx_path.is_file()
+    assert attach_call_count == 2
+    assert export_constant_folding_values == ["unset", False]
+
+
+@pytest.mark.llm_model
+def test_causal_from_pretrained_streams_fp16_safetensors(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    materialized_dir = tmp_path / "materialized"
+    monkeypatch.setenv("QEFF_MATERIALIZED_CHECKPOINT_DIR", str(materialized_dir))
+    config = AutoConfig.for_model(
+        "gpt2",
+        n_layer=1,
+        n_head=2,
+        n_embd=8,
+        vocab_size=17,
+        n_positions=64,
+        n_ctx=64,
+    )
+    source_model = AutoModelForCausalLM.from_config(config, attn_implementation="eager").to(torch.bfloat16)
+    source_model.save_pretrained(source_path, safe_serialization=True)
+
+    qeff_model = QEFFAutoModelForCausalLM.from_pretrained(str(source_path), torch_dtype=torch.float16)
+
+    assert next(qeff_model.model.parameters()).dtype == torch.float16
+    assert all(parameter.device.type == "cpu" for parameter in qeff_model.model.parameters())
+    assert not materialized_dir.exists()
+
+
+@pytest.mark.llm_model
+def test_seq_classification_fp16_low_memory_export_externalizes_initializers(tmp_path, monkeypatch):
+    monkeypatch.setenv("QEFF_LOW_MEMORY_ONNX_EXPORT", "1")
+    config = AutoConfig.for_model(
+        "bert",
+        hidden_size=8,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        intermediate_size=16,
+        vocab_size=17,
+        max_position_embeddings=64,
+        num_labels=2,
+    )
+    model_hf = AutoModelForSequenceClassification.from_config(config).to(torch.float16)
+    model_hf.eval()
+    qeff_model = QEFFAutoModelForSequenceClassification(model_hf)
+
+    onnx_path = _exported_onnx_path(qeff_model.export(tmp_path / "lowmem-fp16", offload_pt_weights=False))
+    graph_only_model = onnx.load(onnx_path, load_external_data=False)
+    external_initializers = [
+        initializer
+        for initializer in graph_only_model.graph.initializer
+        if initializer.data_location == onnx.TensorProto.EXTERNAL
+    ]
+
+    assert external_initializers
+    assert any(initializer.data_type == onnx.TensorProto.FLOAT16 for initializer in external_initializers)
+    assert all(len(initializer.raw_data) == 0 for initializer in external_initializers)
+    graph_input_names = {graph_input.name for graph_input in graph_only_model.graph.input}
+    initializer_names = {initializer.name for initializer in graph_only_model.graph.initializer}
+    assert graph_input_names.isdisjoint(initializer_names)
+
+    loaded_model = onnx.load(onnx_path, load_external_data=True)
+    assert sum(len(initializer.raw_data) for initializer in loaded_model.graph.initializer) > 0
 
 
 @pytest.mark.llm_model

--- a/tests/unit_test/models/test_vlm_cpu.py
+++ b/tests/unit_test/models/test_vlm_cpu.py
@@ -18,6 +18,7 @@ All tests run on CPU only. No actual model loading or QAIC hardware execution.
 
 import pytest
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 # ---------------------------------------------------------------------------
@@ -158,6 +159,123 @@ class TestQEffAutoModelForImageTextToTextDualQPCStructure:
         sig = inspect.signature(_QEffAutoModelForImageTextToTextDualQPC.compile)
         assert "skip_lang" in sig.parameters
         assert "skip_vision" in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# Tests: Qwen3-VL wrapper ownership
+# ---------------------------------------------------------------------------
+
+
+class _TinyQwen3VLInner(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.language_model = nn.Module()
+        self.language_model.embed_tokens = nn.Embedding(8, 4)
+        self.lm_head = nn.Linear(4, 8, bias=False)
+        self.visual = nn.Module()
+        self.visual.blocks = nn.ModuleList([nn.Linear(4, 4)])
+
+
+class _TinyQwen3VLParent(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = _TinyQwen3VLInner()
+        self.lm_head = self.model.lm_head
+        self.config = type("Config", (), {"image_token_id": 7})()
+
+
+class TestQwen3VLWrapperOwnership:
+    """Qwen3-VL dual-QPC wrappers must not register the full parent VLM."""
+
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "QEfficient.transformers.models.qwen3_vl.modeling_qwen3_vl",
+            "QEfficient.transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe",
+        ],
+    )
+    def test_decoder_wrapper_does_not_register_full_parent(self, module_path):
+        module = __import__(module_path, fromlist=["QEffQwen3VLDecoderWrapper"])
+        parent = _TinyQwen3VLParent()
+
+        wrapper = module.QEffQwen3VLDecoderWrapper(parent)
+
+        assert "model" not in dict(wrapper.named_children())
+        assert parent not in list(wrapper.modules())
+
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "QEfficient.transformers.models.qwen3_vl.modeling_qwen3_vl",
+            "QEfficient.transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe",
+        ],
+    )
+    def test_encoder_wrapper_does_not_register_full_inner_model(self, module_path):
+        module = __import__(module_path, fromlist=["QEffQwen3VLEncoderWrapper"])
+        parent = _TinyQwen3VLParent()
+
+        wrapper = module.QEffQwen3VLEncoderWrapper(parent)
+
+        assert "model" not in dict(wrapper.named_children())
+        assert parent.model not in list(wrapper.modules())
+
+
+# ---------------------------------------------------------------------------
+# Tests: Qwen3-VL-MoE expert projection layout
+# ---------------------------------------------------------------------------
+
+
+class TestQwen3VLMoeExpertProjectionLayout:
+    """Qwen3-VL-MoE export path must use transformed expert weights in-place."""
+
+    def test_sparse_moe_block_uses_export_weight_layout(self):
+        from types import SimpleNamespace
+
+        from QEfficient.transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import (
+            QEffQwen3VLMoeTextSparseMoeBlock,
+        )
+
+        batch_size, seq_len, hidden_size = 2, 3, 4
+        intermediate_size, num_experts, top_k = 5, 3, 2
+        hidden_states = torch.arange(batch_size * seq_len * hidden_size, dtype=torch.float32).reshape(
+            batch_size, seq_len, hidden_size
+        )
+        gate = SimpleNamespace(
+            hidden_dim=hidden_size,
+            top_k=top_k,
+            weight=torch.arange(num_experts * hidden_size, dtype=torch.float32).reshape(num_experts, hidden_size),
+        )
+        experts = SimpleNamespace(
+            gate_up_proj=torch.arange(num_experts * hidden_size * intermediate_size * 2, dtype=torch.float32).reshape(
+                num_experts, hidden_size, intermediate_size * 2
+            ),
+            down_proj=torch.arange(num_experts * intermediate_size * hidden_size, dtype=torch.float32).reshape(
+                num_experts, intermediate_size, hidden_size
+            ),
+            act_fn=F.silu,
+        )
+        block = SimpleNamespace(gate=gate, experts=experts)
+
+        output, router_logits = QEffQwen3VLMoeTextSparseMoeBlock.forward(block, hidden_states)
+
+        x = hidden_states.view(batch_size * seq_len, hidden_size)
+        expected_logits = F.linear(x, gate.weight)
+        top_w, top_i = torch.topk(expected_logits, top_k, dim=-1)
+        top_w = F.softmax(top_w, dim=-1, dtype=torch.float32)
+        expected_rows = []
+        for token_idx, token in enumerate(x):
+            token_rows = []
+            for expert_idx in top_i[token_idx]:
+                gate_up = token @ experts.gate_up_proj[expert_idx]
+                gate_part, up_part = gate_up.chunk(2, dim=-1)
+                token_rows.append((up_part * experts.act_fn(gate_part)) @ experts.down_proj[expert_idx])
+            expected_rows.append((torch.stack(token_rows) * top_w[token_idx].unsqueeze(-1)).sum(dim=0))
+        expected_output = torch.stack(expected_rows).view(batch_size, seq_len, hidden_size)
+
+        assert router_logits.shape == (batch_size * seq_len, num_experts)
+        assert output.shape == hidden_states.shape
+        assert torch.allclose(router_logits, expected_logits)
+        assert torch.allclose(output, expected_output)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_test/utils/test_safetensor_streaming.py
+++ b/tests/unit_test/utils/test_safetensor_streaming.py
@@ -1,0 +1,151 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+import json
+
+import torch
+from safetensors.torch import save_file
+
+from QEfficient.utils.safetensor_materializer import (
+    load_safetensor_checkpoint_into_model,
+    resolve_safetensor_checkpoint_for_streaming,
+)
+
+
+class TinyMetaModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.empty(2, 3))
+        self.register_buffer("scale", torch.empty(3))
+
+
+class TinyPackedExpertModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mlp = torch.nn.Module()
+        self.mlp.experts = torch.nn.Module()
+        self.mlp.experts.gate_up_proj = torch.nn.Parameter(torch.empty(2, 4, 3))
+        self.mlp.experts.down_proj = torch.nn.Parameter(torch.empty(2, 3, 2))
+
+
+def _write_checkpoint(path):
+    path.mkdir()
+    save_file(
+        {
+            "weight": torch.ones(2, 3, dtype=torch.bfloat16),
+            "scale": torch.arange(3, dtype=torch.float32),
+        },
+        path / "model.safetensors",
+        metadata={"format": "pt"},
+    )
+
+
+def _write_sharded_checkpoint(path):
+    path.mkdir()
+    save_file(
+        {"weight": torch.ones(2, 3, dtype=torch.bfloat16)},
+        path / "model-00001-of-00002.safetensors",
+        metadata={"format": "pt"},
+    )
+    save_file(
+        {"scale": torch.arange(3, dtype=torch.float32)},
+        path / "model-00002-of-00002.safetensors",
+        metadata={"format": "pt"},
+    )
+    with (path / "model.safetensors.index.json").open("w") as handle:
+        json.dump(
+            {
+                "metadata": {"total_size": 0},
+                "weight_map": {
+                    "weight": "model-00001-of-00002.safetensors",
+                    "scale": "model-00002-of-00002.safetensors",
+                },
+            },
+            handle,
+        )
+
+
+def test_resolve_streaming_checkpoint_uses_source_path_without_copy(tmp_path):
+    source_path = tmp_path / "source"
+    _write_checkpoint(source_path)
+
+    checkpoint = resolve_safetensor_checkpoint_for_streaming(source_path, torch.float16)
+
+    assert checkpoint.path == source_path.resolve()
+    assert checkpoint.target_dtype == torch.float16
+    assert checkpoint.dtype_aligned is False
+    assert list(tmp_path.iterdir()) == [source_path]
+
+
+def test_streaming_loader_casts_floating_tensors_to_fp16(tmp_path):
+    source_path = tmp_path / "source"
+    _write_checkpoint(source_path)
+
+    with torch.device("meta"):
+        model = TinyMetaModule()
+
+    result = load_safetensor_checkpoint_into_model(model, source_path, target_dtype=torch.float16)
+
+    assert result.loaded_tensor_count == 2
+    assert not result.missing_parameter_names
+    assert model.weight.device.type == "cpu"
+    assert model.weight.dtype == torch.float16
+    assert model.scale.dtype == torch.float16
+    assert torch.equal(model.weight, torch.ones(2, 3, dtype=torch.float16))
+
+
+def test_streaming_loader_casts_sharded_checkpoint_with_thread_pool(tmp_path, monkeypatch):
+    source_path = tmp_path / "source"
+    _write_sharded_checkpoint(source_path)
+    monkeypatch.setattr("QEfficient.utils.safetensor_materializer._SAFETENSOR_PARALLEL_WORKERS", 2)
+
+    with torch.device("meta"):
+        model = TinyMetaModule()
+
+    result = load_safetensor_checkpoint_into_model(model, source_path, target_dtype=torch.float16)
+
+    assert result.loaded_tensor_count == 2
+    assert not result.missing_parameter_names
+    assert model.weight.dtype == torch.float16
+    assert model.scale.dtype == torch.float16
+    assert torch.equal(model.scale, torch.arange(3, dtype=torch.float16))
+
+
+def test_streaming_loader_packs_legacy_expert_tensors(tmp_path):
+    source_path = tmp_path / "source"
+    source_path.mkdir()
+    save_file(
+        {
+            "mlp.experts.0.gate_proj.weight": torch.full((2, 3), 1, dtype=torch.bfloat16),
+            "mlp.experts.0.up_proj.weight": torch.full((2, 3), 2, dtype=torch.bfloat16),
+            "mlp.experts.0.down_proj.weight": torch.arange(6, dtype=torch.bfloat16).reshape(3, 2),
+            "mlp.experts.1.gate_proj.weight": torch.full((2, 3), 3, dtype=torch.bfloat16),
+            "mlp.experts.1.up_proj.weight": torch.full((2, 3), 4, dtype=torch.bfloat16),
+            "mlp.experts.1.down_proj.weight": torch.arange(6, 12, dtype=torch.bfloat16).reshape(3, 2),
+        },
+        source_path / "model.safetensors",
+        metadata={"format": "pt"},
+    )
+
+    with torch.device("meta"):
+        model = TinyPackedExpertModule()
+
+    result = load_safetensor_checkpoint_into_model(model, source_path, target_dtype=torch.float16)
+
+    assert result.loaded_tensor_count == 2
+    assert not result.missing_parameter_names
+    assert not result.unexpected_tensor_names
+    assert model.mlp.experts.gate_up_proj.dtype == torch.float16
+    assert torch.equal(
+        model.mlp.experts.gate_up_proj[0],
+        torch.tensor([[1, 1, 1], [1, 1, 1], [2, 2, 2], [2, 2, 2]], dtype=torch.float16),
+    )
+    assert torch.equal(
+        model.mlp.experts.gate_up_proj[1],
+        torch.tensor([[3, 3, 3], [3, 3, 3], [4, 4, 4], [4, 4, 4]], dtype=torch.float16),
+    )
+    assert torch.equal(model.mlp.experts.down_proj[1], torch.arange(6, 12, dtype=torch.float16).reshape(3, 2))


### PR DESCRIPTION
## Problem
CPU RAM utilization during ONNX exports peak well above parameter bytes. The extra RAM came from two places: load-time dtype materialization/casts from safetensors, and ONNX initializer payloads living in the in-memory ModelProto during export. Qwen VLM dual-QPC export also kept too much of the parent VLM registered in component wrappers.

## Changes
- Added low-memory ONNX export support that externalizes initializer payloads instead of keeping large raw tensors in the in-memory ModelProto.
- Added opt-in safetensor materialization and a custom streaming loader. The loader constructs the HF model on `meta`, then streams materialized safetensor shards directly into parameters/buffers without `accelerate` or new dependencies.
- Preserved default API behavior. If no precision/materialization option is provided, normal `from_pretrained` behavior is used.
- Added example-level precision toggles so users can set `QEFF_EXAMPLE_LOAD_EXPORT_PRECISION = "float16"` in scripts; `None` keeps existing defaults.
- Fixed Qwen3-VL/Qwen3-VL-MoE dual-QPC wrapper ownership so encoder/decoder wrappers do not register the original full parent VLM.
- Disabled public `layerwise=True` entry points on this branch so validation uses the whole-model path and cannot silently produce partial exports.
- Fixed Qwen3-VL-MoE expert projection layout in the non-layerwise export path. The transformed expert tensors are already in export layout, so the sparse MoE forward should not transpose them again.

## Memory results
- Llama-70B fp16 export:
  - baseline peak RSS: 263.30 GiB
  - materialized fp16 + low-memory ONNX peak RSS: 137.15 GiB
- Qwen3-VL-30B-A3B full VLM export, vision + language, no layerwise:
  - peak RSS: 62.77 GiB
  - ONNX external data total: 58.00 GiB
  - vision external data: 1.00 GiB
  - language external data: 57.00 GiB
  - vision initializers externalized: 351/351
  - language initializers externalized: 533/533

## Validation
- `python -m ruff format --check <PR python files>`: passed
- `python -m ruff check <PR python files>`: passed
- `python -m pytest tests/unit_test/models -q`: 564 passed, 8 skipped
- `python -m pytest tests/unit_test/models/test_vlm_cpu.py tests/base/test_safetensor_materializer.py tests/base/test_export_memory_offload.py::test_low_memory_export_externalizes_initializers -q`: 48 passed
