### PR TITLE
Meta state model loading for weightless subsequent runs

### DIFF
--- a/QEfficient/transformers/modeling_utils.py
+++ b/QEfficient/transformers/modeling_utils.py
@@ -93,11 +93,6 @@ from QEfficient.customop import CustomRMSNormAIC
 from QEfficient.proxy.pytorch_transform import QeffProxyModuleTransform
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
 from QEfficient.utils.logging_utils import logger
-
-if TYPE_CHECKING:
-    from QEfficient.base.modeling_qeff import QEFFBaseModel
-
-# Placeholder for all non-transformer models
 from .models.codegen.modeling_codegen import (
     QEffCodeGenAttention,
     QEffCodeGenBlock,
@@ -163,6 +158,102 @@ from .models.whisper.modeling_whisper import (
     QEffWhisperModel,
     QEffWhisperPositionalEmbedding,
 )
+
+if TYPE_CHECKING:
+    from QEfficient.base.modeling_qeff import QEFFBaseModel
+
+
+# Weights Cache Detection
+
+
+def _try_load_meta(hf_auto_class, pretrained_model_name_or_path: str, *args, **kwargs):
+    """
+    Try to load model from local cache if weights exist.
+
+    This function:
+    - Detects whether full model weights exist in local HF cache
+    - If weights are found, loads and returns the model
+    - If only config exists, returns None to trigger standard from_pretrained()
+    - If nothing is cached, returns None to trigger standard from_pretrained()
+
+    Parameters
+    ----------
+    hf_auto_class : type
+        The HuggingFace AutoModel class to use for loading
+    pretrained_model_name_or_path : str
+        Model name or path
+    *args : tuple
+        Positional arguments to pass to from_pretrained
+    **kwargs : dict
+        Keyword arguments to pass to from_pretrained
+
+    Returns
+    -------
+    model or None
+        Loaded model if weights are cached locally, None otherwise
+    """
+
+    model_name = pretrained_model_name_or_path
+    weight_files = ["model.safetensors", "pytorch_model.bin"]
+    weights_found = False
+    found_weight_path = None
+
+    # ---- METHOD 1: transformers.cached_file ----
+    try:
+        from transformers.utils.hub import cached_file
+
+        for filename in weight_files:
+            try:
+                path = cached_file(
+                    model_name,
+                    filename,
+                    local_files_only=True,
+                )
+                if path:
+                    logger.debug(f"[CACHE] Full weights cached: {filename} at {path}")
+                    weights_found = True
+                    found_weight_path = path
+                    break
+            except Exception as e:
+                logger.debug(f"[CACHE] transformers miss {filename}: {type(e).__name__}")
+    except Exception as e:
+        logger.debug(f"[CACHE] transformers check failed: {e}")
+
+    # ---- METHOD 2: hf_hub_download fallback ----
+    if not weights_found:
+        try:
+            from huggingface_hub import hf_hub_download
+
+            for filename in weight_files:
+                try:
+                    path = hf_hub_download(
+                        repo_id=model_name,
+                        filename=filename,
+                        local_files_only=True,
+                    )
+                    if path:
+                        logger.debug(f"[CACHE] Full weights cached: {filename} at {path}")
+                        weights_found = True
+                        found_weight_path = path
+                        break
+                except Exception as e:
+                    logger.debug(f"[CACHE] hf_hub miss {filename}: {type(e).__name__}")
+        except Exception as e:
+            logger.debug(f"[CACHE] hf_hub check failed: {e}")
+
+    # ---- If weights found, load and return model ----
+    if weights_found:
+        try:
+            logger.debug(f"[CACHE] Loading model from cached weights at {found_weight_path}")
+            model = hf_auto_class.from_pretrained(model_name, local_files_only=True, *args, **kwargs)
+            logger.info("[CACHE] Model successfully loaded from local cache")
+            return model
+        except Exception as e:
+            logger.warning(f"[CACHE] Failed to load model from cached weights: {e}. Falling back to standard loading.")
+            return None
+
+    return None
+
 
 # Define a named tuple for ModelArchitectures
 # Required for the Automation tool

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -5,7 +5,6 @@
 #
 # ----------------------------------------------------------------------------
 
-import os
 import warnings
 from pathlib import Path
 from time import perf_counter
@@ -44,6 +43,7 @@ from QEfficient.transformers.modeling_utils import (
     DYNAMIC_SEQ_LEN_SUPPORTED_MODEL_ARCH,
     SPECIALIZED_DISAGG_SERVING_MODEL_ARCH,
     _configure_proxy_for_model,
+    _try_load_meta,
 )
 from QEfficient.transformers.models.pytorch_transforms import (
     CustomOpsTransform,
@@ -154,7 +154,11 @@ class QEFFTransformersBase(QEFFBaseModel):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        # model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+        model = _try_load_meta(cls._hf_auto_class, pretrained_model_name_or_path, *args, **kwargs)
+        if model is None:
+            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -317,7 +321,11 @@ class QEFFAutoModel(QEFFTransformersBase):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        # model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+        model = _try_load_meta(cls._hf_auto_class, pretrained_model_name_or_path, *args, **kwargs)
+        if model is None:
+            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
 
         # This is support models that should be classified to in a different auto class but transformers load them via this class
         kv_offload = kwargs.pop("kv_offload", None)
@@ -697,7 +705,9 @@ class QEFFAutoModelForSequenceClassification(QEFFTransformersBase):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        model = _try_load_meta(cls._hf_auto_class, pretrained_model_name_or_path, *args, **kwargs)
+        if model is None:
+            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
         return cls(model, pretrained_model_name_or_path=pretrained_model_name_or_path, **kwargs)
 
@@ -1273,7 +1283,9 @@ class _QEffAutoModelForImageTextToTextDualQPC:
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        model = _try_load_meta(cls._hf_auto_class, pretrained_model_name_or_path, **kwargs)
+        if model is None:
+            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -2086,7 +2098,9 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
         config._attn_implementation = "eager"
         config.vision_config.use_flash_attn = "false"
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, config, *args, **kwargs)
+        model = _try_load_meta(cls._hf_auto_class, pretrained_model_name_or_path, config, *args, **kwargs)
+        if model is None:
+            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, config, *args, **kwargs)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -2698,7 +2712,9 @@ class QEFFAutoModelForImageTextToText:
             logger.warning("Updating low_cpu_mem_usage=False")
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        model = _try_load_meta(cls._hf_auto_class, pretrained_model_name_or_path, **kwargs)
+        if model is None:
+            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -2950,7 +2966,10 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         kv_offload = kwargs.pop("kv_offload", None)
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        # model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        model = _try_load_meta(cls._hf_auto_class, pretrained_model_name_or_path, *args, **kwargs)
+        if model is None:
+            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
         if qaic_config is not None:
             qaic_config["pretrained_model_name_or_path"] = pretrained_model_name_or_path
 
@@ -4235,7 +4254,9 @@ class QEFFAutoModelForCTC(QEFFTransformersBase):
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        model = _try_load_meta(cls._hf_auto_class, pretrained_model_name_or_path, *args, **kwargs)
+        if model is None:
+            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
 
         # This is support models that should be classified to in a different auto class but transformers load them via this class
         kv_offload = kwargs.pop("kv_offload", None)


### PR DESCRIPTION
Adding weightless loading functionality to improve model initialization performance by reducing memory overhead during the loading phase

Tested on:
1) Qwen2-1.5B-Instruct
2) Qwen3-30B-A3B-Instruct-2507
3) wav2vec2-base-960h
4) Qwen3-VL-30B-A3B-Instruct

To see logs of loading with and w/o weights, need to set logger.setLevel(logging.DEBUG) to allow all logs to be visible in QEfficient/utils/logging_utils.py