### PR TITLE
Added pdb breakpoint check in git workflow

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -1,6 +1,32 @@
 name: Lint & Format
 on: [pull_request]
 jobs:
+  debug-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for debugger artifacts
+        run: |
+          set -euo pipefail
+
+          debugger_pattern='break[p]oints?[[:space:]]*\(|i[p]db|p[d]b[[:space:]]*\.[[:space:]]*set_trace|set_trace[[:space:]]*\('
+
+          set +e
+          matches="$(git grep -nIE "${debugger_pattern}" -- .)"
+          status=$?
+          set -e
+
+          if [ "${status}" -eq 0 ]; then
+            printf '%s\n' "${matches}"
+            debugger_names='breakpoint / pdb / i'"pdb"
+            echo "::error::Remove debugger artifacts before committing (${debugger_names} calls/imports, including commented-out lines)."
+            exit 1
+          fi
+
+          if [ "${status}" -ne 1 ]; then
+            exit "${status}"
+          fi
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/QEfficient/transformers/models/glm4_moe/modeling_glm4_moe.py
+++ b/QEfficient/transformers/models/glm4_moe/modeling_glm4_moe.py
@@ -595,8 +595,6 @@ class QEffGlm4MoeTopkRouter(nn.Module):
     def forward(self, hidden_states):
         # orig_i, orig_w = self.orig_forward(hidden_states)
         hidden_states = hidden_states.view(-1, self.config.hidden_size)
-        # import ipdb; ipdb.set_trace()c
-
         # router_logits = torch.nn.functional.linear(hidden_states.type(torch.float32), self.weight.type(torch.float32))
         router_logits = torch.nn.functional.linear(hidden_states, self.weight)
 

--- a/QEfficient/utils/layerwise_pipeline.py
+++ b/QEfficient/utils/layerwise_pipeline.py
@@ -113,7 +113,6 @@ def split_layer_graph(
     if shard_idx != total_shards - 1 and "position_ids" in graph_inputs and "position_ids" not in output_names:
         output_names.append("position_ids")
 
-    # import pdb; pdb.set_trace()
     model_ir.graph = onnx_ir.convenience.extract(
         model_ir.graph,
         input_names,


### PR DESCRIPTION
 Adds a debug-artifacts job to .github/workflows/lint-format.yml.
  - Fails CI when committed files contain debugger artifacts such as:
      - breakpoint() / breakpoints()
      - pdb.set_trace()
      - ipdb
      - set_trace()
  - Catches these patterns even when they are commented out.
  - Removes existing commented debugger leftovers from the repo.