### PR TITLE
Add YAML-aware from_pretrained scaling + runtime transform 

### DIFF
--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -55,6 +55,7 @@ from QEfficient.transformers.models.pytorch_transforms import (
     PrefillOnlyChunkedTransform,
     PrefillOnlyExternalModuleMapperTransform,
     PrefillOnlyTransform,
+    Qwen3_5MoeLayerScaleMetadataTransform,
     RevertPrefillKeepAttentionTransform,
     RevertPrefillOnlyExternalModuleMapperTransform,
     RevertPrefillOnlyTransform,
@@ -1209,6 +1210,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
         FP8BlockWiseDequantLinearToLinearTransform,
         CustomOpsTransform,
         KVCacheTransform,
+        Qwen3_5MoeLayerScaleMetadataTransform,
         VlmKVOffloadTransform,
         SplitGateUpWeightsTransform,
     ]
@@ -2535,6 +2537,7 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         GPTQToMatmulNbitsTransform,
         CustomOpsTransform,
         KVCacheTransform,
+        Qwen3_5MoeLayerScaleMetadataTransform,
         KVCacheExternalModuleMapperTransform,
         VlmNoKVOffloadTransform,
         SplitGateUpWeightsTransform,
@@ -3368,6 +3371,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         Mxfp4GptOssExpertDequantizeTransform,
         CustomOpsTransform,
         KVCacheTransform,
+        Qwen3_5MoeLayerScaleMetadataTransform,
         SplitGateUpWeightsTransform,
         KVCacheExternalModuleMapperTransform,
     ]

--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -299,7 +299,7 @@ from transformers.models.whisper.modeling_whisper import (
 )
 from transformers.models.xlm_roberta.modeling_xlm_roberta import XLMRobertaModel
 
-from QEfficient.base.pytorch_transforms import ExternalModuleMapperTransform, ModuleMappingTransform
+from QEfficient.base.pytorch_transforms import ExternalModuleMapperTransform, ModuleMappingTransform, PytorchTransform
 from QEfficient.customop import CustomRMSNormAIC, GemmaCustomRMSNormAIC
 from QEfficient.transformers.embeddings.embedding_utils import POOLING_MAP, PooledModel, validate_user_pooling_function
 from QEfficient.transformers.models.bert.modeling_bert import (
@@ -572,6 +572,7 @@ from QEfficient.transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import (
     QEffQwen3_5MoeTopKRouter,
     QEffQwen3_5MoeVisionAttention,
     QEffQwen3_5MoeVisionModel,
+    _resolve_layer_scale_runtime_config,
 )
 from QEfficient.transformers.models.qwen3_moe.modeling_qwen3_moe import (
     QEffPrefillChunkedQwen3MoeSparseMoeBlock,
@@ -911,6 +912,121 @@ class KVCacheTransform(ModuleMappingTransform):
     @classmethod
     def apply(cls, model: nn.Module) -> Tuple[nn.Module, bool]:
         model, transformed = super().apply(model)
+        return model, transformed
+
+
+class Qwen3_5MoeLayerScaleMetadataTransform(PytorchTransform):
+    """Sync Qwen3.5-MoE layer-scale metadata onto active text configs post-KV transform."""
+
+    _metadata_keys = (
+        "qeff_layer_scales",
+        "qeff_layer_scale_default",
+        "qeff_layer_scale_mode",
+        "qeff_layer_scale_recipe",
+        "qeff_layer_index_offset",
+    )
+
+    @classmethod
+    def _get_config_objects(cls, model: nn.Module) -> list:
+        configs = []
+        seen = set()
+
+        def _append(cfg):
+            if cfg is None:
+                return
+            cfg_id = id(cfg)
+            if cfg_id in seen:
+                return
+            seen.add(cfg_id)
+            configs.append(cfg)
+
+        root_cfg = getattr(model, "config", None)
+        _append(root_cfg)
+        _append(getattr(root_cfg, "text_config", None))
+
+        for module in model.modules():
+            _append(getattr(module, "config", None))
+
+        return configs
+
+    @classmethod
+    def _score_metadata_value(cls, key: str, value) -> int:
+        if value is None:
+            return -1
+        if key == "qeff_layer_scales":
+            if isinstance(value, dict):
+                return 3 if len(value) > 0 else 0
+            if isinstance(value, list):
+                return 3 if len(value) > 0 else 0
+            return 2
+        if key == "qeff_layer_scale_default":
+            try:
+                return 2 if float(value) != 1.0 else 0
+            except Exception:
+                return 1
+        if key == "qeff_layer_scale_mode":
+            return 1 if str(value) else 0
+        if key == "qeff_layer_scale_recipe":
+            return 2 if str(value) else 0
+        if key == "qeff_layer_index_offset":
+            try:
+                return 2 if int(value) != 0 else 0
+            except Exception:
+                return 1
+        return 0
+
+    @classmethod
+    def _collect_metadata(cls, configs: list) -> dict:
+        metadata = {}
+        for key in cls._metadata_keys:
+            best_value = None
+            best_score = -1
+            for cfg in configs:
+                value = getattr(cfg, key, None)
+                score = cls._score_metadata_value(key, value)
+                if score > best_score:
+                    best_score = score
+                    best_value = value
+            if best_score >= 0:
+                metadata[key] = best_value
+        return metadata
+
+    @classmethod
+    def apply(cls, model: nn.Module) -> Tuple[nn.Module, bool]:
+        text_models = [module for module in model.modules() if isinstance(module, QEffQwen3_5MoeTextModel)]
+        if len(text_models) == 0:
+            return model, False
+
+        transformed = False
+        configs = cls._get_config_objects(model)
+        metadata = cls._collect_metadata(configs)
+
+        # Broadcast the most informative metadata we found to all nested configs
+        # so text_model.config resolves scaling consistently in every Auto path.
+        for cfg in configs:
+            for key, value in metadata.items():
+                if getattr(cfg, key, None) != value:
+                    setattr(cfg, key, value)
+                    transformed = True
+
+        for text_model in text_models:
+            (
+                text_model._qeff_layer_scaling_enabled,
+                text_model._qeff_layer_scales,
+                text_model._qeff_layer_scale_default,
+                text_model._qeff_layer_scale_mode,
+            ) = _resolve_layer_scale_runtime_config(text_model.config)
+            text_model._qeff_layer_index_offset = int(getattr(text_model.config, "qeff_layer_index_offset", 0))
+
+            for layer in text_model.layers:
+                if not isinstance(layer, QEffQwen3_5MoeDecoderLayer):
+                    continue
+                layer._qeff_layer_scaling_enabled = text_model._qeff_layer_scaling_enabled
+                layer._qeff_layer_scales = text_model._qeff_layer_scales
+                layer._qeff_layer_scale_default = text_model._qeff_layer_scale_default
+                layer._qeff_layer_scale_mode = text_model._qeff_layer_scale_mode
+                layer._qeff_layer_index_offset = text_model._qeff_layer_index_offset
+
         return model, transformed
 
 

--- a/QEfficient/transformers/models/qwen3_5_moe/configs/fp32_nodes_qwen3_5_397b_pytorch.yaml
+++ b/QEfficient/transformers/models/qwen3_5_moe/configs/fp32_nodes_qwen3_5_397b_pytorch.yaml
@@ -1,0 +1,40 @@
+ModelID: Qwen/Qwen3.5-397B-A17B
+SourceArtifacts:
+ - scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_fp32_recovery_smoketest.json
+ - scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_fp32_recovery_full.json
+
+PromotedLayers:
+ - 22
+ - 26
+ - 30
+ - 54
+
+PromotedPatchSequence:
+ - sparse_moe_post_ops_fp32
+ - shared_expert_matmul_fp32_keep_fp32
+
+FP32NodeInstanceNames:
+ - model.language_model.layers.22.mlp.shared_expert.gate_proj
+ - model.language_model.layers.22.mlp.shared_expert.up_proj
+ - model.language_model.layers.22.mlp.shared_expert.down_proj
+ - model.language_model.layers.22.mlp::sigmoid(shared_expert_gate_output)
+ - model.language_model.layers.22.mlp::mul(sigmoid_gate,shared_expert_output)
+ - model.language_model.layers.22.mlp::add(experts_out,shared_expert_output)
+ - model.language_model.layers.26.mlp.shared_expert.gate_proj
+ - model.language_model.layers.26.mlp.shared_expert.up_proj
+ - model.language_model.layers.26.mlp.shared_expert.down_proj
+ - model.language_model.layers.26.mlp::sigmoid(shared_expert_gate_output)
+ - model.language_model.layers.26.mlp::mul(sigmoid_gate,shared_expert_output)
+ - model.language_model.layers.26.mlp::add(experts_out,shared_expert_output)
+ - model.language_model.layers.30.mlp.shared_expert.gate_proj
+ - model.language_model.layers.30.mlp.shared_expert.up_proj
+ - model.language_model.layers.30.mlp.shared_expert.down_proj
+ - model.language_model.layers.30.mlp::sigmoid(shared_expert_gate_output)
+ - model.language_model.layers.30.mlp::mul(sigmoid_gate,shared_expert_output)
+ - model.language_model.layers.30.mlp::add(experts_out,shared_expert_output)
+ - model.language_model.layers.54.mlp.shared_expert.gate_proj
+ - model.language_model.layers.54.mlp.shared_expert.up_proj
+ - model.language_model.layers.54.mlp.shared_expert.down_proj
+ - model.language_model.layers.54.mlp::sigmoid(shared_expert_gate_output)
+ - model.language_model.layers.54.mlp::mul(sigmoid_gate,shared_expert_output)
+ - model.language_model.layers.54.mlp::add(experts_out,shared_expert_output)

--- a/QEfficient/transformers/models/qwen3_5_moe/configs/layer_scales_qwen3_5_397b_mlp_equivalent.yaml
+++ b/QEfficient/transformers/models/qwen3_5_moe/configs/layer_scales_qwen3_5_397b_mlp_equivalent.yaml
@@ -1,0 +1,105 @@
+ModelID: Qwen/Qwen3.5-397B-A17B
+Method: branch_aware_mlp_scale_equivalent
+Description: >
+  Offline-scale selected MLP weights and apply matching residual scale/unscale
+  in decoder forward so end-to-end math remains equivalent to original model.
+
+LayerScales:
+  default_scale: 1.0
+  per_layer:
+    22: 0.125
+    26: 0.125
+    30: 0.5
+    54: 0.25
+
+TensorScalingRules:
+  - name: experts_gate_up_proj_up_half
+    tensor_template: model.language_model.layers.{layer_idx}.mlp.experts.gate_up_proj
+    operation: scale_second_half_dim1
+  - name: shared_expert_up_proj
+    tensor_template: model.language_model.layers.{layer_idx}.mlp.shared_expert.up_proj.weight
+    operation: scale_all
+
+RuntimeEquivalence:
+  mode: checkpoint_scaled_mlp_and_residual_branch
+  compensation_points:
+    - name: pre_input_inverse
+      module: QEffQwen3_5MoeDecoderLayer.forward
+      location: before input_layernorm
+      equation: "hidden_in = hidden_in / scale(layer_idx - 1)"
+    - name: scaled_residual_add
+      module: QEffQwen3_5MoeDecoderLayer.forward
+      location: final residual + mlp add
+      equation: "layer_out_scaled = scale(layer_idx) * residual + mlp_out_scaled"
+    - name: final_unscale_before_norm
+      module: QEffQwen3_5MoeTextModel.forward
+      location: before final norm on last layer window
+      equation: "hidden_before_norm = hidden_before_norm / scale(last_layer_idx)"
+  checkpoint_assumption:
+    mlp_out_scaled: "mlp_out_scaled = scale(layer_idx) * mlp_out_original"
+  decoder_adjustments:
+    pre_input_inverse: "hidden_in = hidden_in / scale(layer_idx - 1)"
+    scaled_residual_add: "layer_out_scaled = scale(layer_idx) * residual + mlp_out_scaled"
+
+ScaledTensorSpecs:
+  - layer_idx: 22
+    tensor_key: model.language_model.layers.22.mlp.experts.gate_up_proj
+    operation: scale_second_half_dim1
+    scale: 0.125
+    rule_name: experts_gate_up_proj_up_half
+  - layer_idx: 22
+    tensor_key: model.language_model.layers.22.mlp.shared_expert.up_proj.weight
+    operation: scale_all
+    scale: 0.125
+    rule_name: shared_expert_up_proj
+  - layer_idx: 26
+    tensor_key: model.language_model.layers.26.mlp.experts.gate_up_proj
+    operation: scale_second_half_dim1
+    scale: 0.125
+    rule_name: experts_gate_up_proj_up_half
+  - layer_idx: 26
+    tensor_key: model.language_model.layers.26.mlp.shared_expert.up_proj.weight
+    operation: scale_all
+    scale: 0.125
+    rule_name: shared_expert_up_proj
+  - layer_idx: 30
+    tensor_key: model.language_model.layers.30.mlp.experts.gate_up_proj
+    operation: scale_second_half_dim1
+    scale: 0.5
+    rule_name: experts_gate_up_proj_up_half
+  - layer_idx: 30
+    tensor_key: model.language_model.layers.30.mlp.shared_expert.up_proj.weight
+    operation: scale_all
+    scale: 0.5
+    rule_name: shared_expert_up_proj
+  - layer_idx: 54
+    tensor_key: model.language_model.layers.54.mlp.experts.gate_up_proj
+    operation: scale_second_half_dim1
+    scale: 0.25
+    rule_name: experts_gate_up_proj_up_half
+  - layer_idx: 54
+    tensor_key: model.language_model.layers.54.mlp.shared_expert.up_proj.weight
+    operation: scale_all
+    scale: 0.25
+    rule_name: shared_expert_up_proj
+
+ConfigMetadata:
+  layer_scale_key: qeff_layer_scales
+  default_scale_key: qeff_layer_scale_default
+  mode_key: qeff_layer_scale_mode
+  mode_value: checkpoint_scaled_mlp_and_residual_branch
+
+Artifacts:
+  - scripts/debug/artifacts/qwen3_5_moe_full_depth_mlp_scale_recovery_smoketest_v2.json
+  - scripts/debug/artifacts/qwen3_5_moe_full_depth_mlp_scale_recovery_full_v2.json
+
+FinalTokenParity:
+  hf_fp32:
+    pred_id: 198
+    pred_token: "\n"
+  hf_fp16_scaled:
+    pred_id: 198
+    pred_token: "\n"
+  qeff_fp16_scaled:
+    pred_id: 198
+    pred_token: "\n"

--- a/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -70,6 +70,102 @@ from QEfficient.utils.logging_utils import logger
 QWEN3_5_MOE_ROPE_CACHE_EXPORT_CAP = 76800
 
 
+def _parse_layer_scale_map(raw_layer_scales) -> dict[int, float]:
+    if raw_layer_scales is None:
+        return {}
+    if isinstance(raw_layer_scales, dict):
+        items = raw_layer_scales.items()
+    elif isinstance(raw_layer_scales, list):
+        items = []
+        for row in raw_layer_scales:
+            if not isinstance(row, dict):
+                raise ValueError(
+                    f"List-form layer scales must be dict rows with `layer_idx`/`scale`, got {type(row).__name__}."
+                )
+            if "layer_idx" not in row or "scale" not in row:
+                raise ValueError(f"Layer scale row missing required keys: {row}")
+            items.append((row["layer_idx"], row["scale"]))
+    else:
+        raise ValueError(
+            "`qeff_layer_scales` must be dict[layer_idx->scale] or "
+            f"list[{{layer_idx, scale}}]. Got {type(raw_layer_scales).__name__}."
+        )
+    out = {}
+    for key, value in items:
+        layer_idx = int(key)
+        scale = float(value)
+        if layer_idx < 0:
+            raise ValueError(f"Layer index must be >= 0. Got {layer_idx}")
+        if scale <= 0.0:
+            raise ValueError(f"Layer scale must be > 0. Got layer={layer_idx}, scale={scale}")
+        out[layer_idx] = scale
+    return out
+
+
+def _parse_optional_bool_env(var_name: str) -> Optional[bool]:
+    raw = os.environ.get(var_name, None)
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in {"1", "true", "yes", "y", "on"}:
+        return True
+    if value in {"0", "false", "no", "n", "off"}:
+        return False
+    raise ValueError(f"{var_name} must be one of [1/0,true/false,yes/no,on/off], got {raw!r}")
+
+
+def _load_layer_scale_recipe_from_yaml(recipe_yaml_path: str) -> tuple[dict[int, float], float, str]:
+    from QEfficient.utils.layer_scale_checkpoint import load_layer_scale_recipe
+
+    recipe = load_layer_scale_recipe(recipe_yaml_path)
+    return dict(recipe.layer_scales), float(recipe.default_scale), str(recipe.config_mode_value)
+
+
+def _resolve_layer_scale_runtime_config(config) -> tuple[bool, dict[int, float], float, str]:
+    expected_mode = "checkpoint_scaled_mlp_and_residual_branch"
+    enable_override = _parse_optional_bool_env("QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING")
+    recipe_yaml_path = os.environ.get("QEFF_QWEN3_5_MOE_LAYER_SCALE_YAML", "").strip()
+
+    config_scales = _parse_layer_scale_map(getattr(config, "qeff_layer_scales", None))
+    config_default = float(getattr(config, "qeff_layer_scale_default", 1.0))
+    config_mode = str(getattr(config, "qeff_layer_scale_mode", expected_mode))
+    if config_default <= 0.0:
+        raise ValueError(f"`qeff_layer_scale_default` must be > 0. Got {config_default}.")
+
+    has_scale_source = bool(recipe_yaml_path) or bool(config_scales) or (config_default != 1.0)
+    scaling_enabled = enable_override if enable_override is not None else has_scale_source
+    if not scaling_enabled:
+        return False, {}, 1.0, expected_mode
+
+    if recipe_yaml_path:
+        layer_scales, layer_scale_default, layer_scale_mode = _load_layer_scale_recipe_from_yaml(recipe_yaml_path)
+    else:
+        layer_scales = config_scales
+        layer_scale_default = config_default
+        layer_scale_mode = config_mode
+
+    if layer_scale_default <= 0.0:
+        raise ValueError(f"`qeff_layer_scale_default` must be > 0. Got {layer_scale_default}.")
+    if layer_scale_mode != expected_mode:
+        raise ValueError(
+            f"Unsupported qeff layer-scale mode={layer_scale_mode!r}. "
+            f"Supported mode is {expected_mode!r} for mathematical-equivalence guarantees."
+        )
+    return True, layer_scales, layer_scale_default, layer_scale_mode
+
+
+def _mul_by_scalar(tensor: torch.Tensor, scalar: float) -> torch.Tensor:
+    if scalar == 1.0:
+        return tensor
+    return tensor * tensor.new_tensor(scalar)
+
+
+def _div_by_scalar(tensor: torch.Tensor, scalar: float) -> torch.Tensor:
+    if scalar == 1.0:
+        return tensor
+    return tensor / tensor.new_tensor(scalar)
+
+
 class QEffQwen3_5MoeGatedDeltaNetCustomRMSNormAIC(nn.Module):
     """
     RMSNorm module that works by replacing the current module with compiler known custom-op.
@@ -963,6 +1059,14 @@ class QEffQwen3_5MoeDecoderLayer(Qwen3_5MoeDecoderLayer):
             self.self_attn.__class__ = QEffQwen3_5MoeAttention
             self.self_attn.__qeff_init__()
 
+        # Optional mathematically-equivalent recovery path for checkpoints that
+        # were offline-scaled at selected MLP layers.
+        self._qeff_layer_scaling_enabled = False
+        self._qeff_layer_scales = {}
+        self._qeff_layer_scale_default = 1.0
+        self._qeff_layer_scale_mode = "checkpoint_scaled_mlp_and_residual_branch"
+        self._qeff_layer_index_offset = 0
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -977,6 +1081,28 @@ class QEffQwen3_5MoeDecoderLayer(Qwen3_5MoeDecoderLayer):
         **kwargs,
     ) -> torch.FloatTensor:
         del use_cache
+        layer_scaling_enabled = bool(
+            kwargs.pop("qeff_layer_scaling_enabled", getattr(self, "_qeff_layer_scaling_enabled", False))
+        )
+        layer_scales = kwargs.pop("qeff_layer_scales", self._qeff_layer_scales)
+        layer_scale_default = float(kwargs.pop("qeff_layer_scale_default", self._qeff_layer_scale_default))
+        if not layer_scaling_enabled:
+            layer_scales = {}
+            layer_scale_default = 1.0
+        elif layer_scale_default <= 0.0:
+            raise ValueError(f"`qeff_layer_scale_default` must be > 0. Got {layer_scale_default}.")
+
+        global_layer_idx = kwargs.pop("qeff_global_layer_idx", None)
+        if global_layer_idx is None:
+            global_layer_idx = int(getattr(self, "layer_idx", 0)) + self._qeff_layer_index_offset
+        else:
+            global_layer_idx = int(global_layer_idx)
+
+        # Previous layer may have emitted a scaled residual/MLP sum. Undo here
+        # before this layer's input RMSNorm to keep exact model math.
+        prev_scale = layer_scales.get(global_layer_idx - 1, layer_scale_default)
+        hidden_states = _div_by_scalar(hidden_states, prev_scale)
+
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
 
@@ -1009,7 +1135,12 @@ class QEffQwen3_5MoeDecoderLayer(Qwen3_5MoeDecoderLayer):
         # For the MoE layers, we need to unpack
         if isinstance(hidden_states, tuple):
             hidden_states, _ = hidden_states
-        hidden_states = residual + hidden_states
+
+        # For scaled checkpoints, this layer's MLP output is pre-scaled by s.
+        # Multiply residual by s before add so output is s * (residual + mlp).
+        # The next layer divides by s at its input (see prev_scale block above).
+        layer_scale = layer_scales.get(global_layer_idx, layer_scale_default)
+        hidden_states = _mul_by_scalar(residual, layer_scale) + hidden_states
         return hidden_states
 
 
@@ -1027,6 +1158,13 @@ class QEffQwen3_5MoeTextModel(Qwen3_5MoeTextModel):
         self.cos_cached = torch.nn.Parameter(
             (self.rotary_emb.cos_cached[:rope_rows] * self.rotary_emb.attention_scaling).contiguous()
         )
+        (
+            self._qeff_layer_scaling_enabled,
+            self._qeff_layer_scales,
+            self._qeff_layer_scale_default,
+            self._qeff_layer_scale_mode,
+        ) = _resolve_layer_scale_runtime_config(self.config)
+        self._qeff_layer_index_offset = int(getattr(self.config, "qeff_layer_index_offset", 0))
 
     def forward(
         self,
@@ -1098,12 +1236,14 @@ class QEffQwen3_5MoeTextModel(Qwen3_5MoeTextModel):
         position_embeddings = (cos, sin)
         all_hidden_states = () if output_hidden_states else None
         layer_indices_to_run = kwargs.get("layer_indices_to_run", None)
+        last_layer_idx_ran = None
 
         for layer_idx, decoder_layer in enumerate(self.layers):
             if layer_idx < start or layer_idx >= end:
                 continue
             if layer_indices_to_run is not None and layer_idx not in layer_indices_to_run:
                 continue
+            last_layer_idx_ran = layer_idx
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
@@ -1118,12 +1258,20 @@ class QEffQwen3_5MoeTextModel(Qwen3_5MoeTextModel):
                 batch_index=batch_index,
                 use_cache=use_cache,
                 cache_position=cache_position,
+                qeff_global_layer_idx=self._qeff_layer_index_offset + layer_idx,
+                qeff_layer_scaling_enabled=self._qeff_layer_scaling_enabled,
+                qeff_layer_scales=self._qeff_layer_scales,
+                qeff_layer_scale_default=self._qeff_layer_scale_default,
                 **kwargs,
             )
 
             # break
 
         if is_last_layer_window(QEffQwen3_5MoeTextModel, len(self.layers)):
+            if self._qeff_layer_scaling_enabled and last_layer_idx_ran is not None:
+                final_global_layer_idx = self._qeff_layer_index_offset + int(last_layer_idx_ran)
+                final_scale = self._qeff_layer_scales.get(final_global_layer_idx, self._qeff_layer_scale_default)
+                hidden_states = _div_by_scalar(hidden_states, final_scale)
             hidden_states = self.norm(hidden_states)
         if output_hidden_states:
             all_hidden_states += (hidden_states,)

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -800,10 +800,33 @@ class QEffQwen3VLMoeTextExperts(Qwen3VLMoeTextExperts):
     def __qeff_init__(self):
         # HF 5.x keeps fused gate_up projections. Keep backward-compatible
         # aliases expected by QEff MoE execution paths.
-        self.expert_dim = getattr(self, "intermediate_size", self.gate_up_proj.shape[-2] // 2)
-        self.gate_proj = nn.Parameter(self.gate_up_proj[:, : self.expert_dim, :].detach().clone().transpose(1, 2))
-        self.up_proj = nn.Parameter(self.gate_up_proj[:, self.expert_dim :, :].detach().clone().transpose(1, 2))
-        self.down_proj_t = nn.Parameter(self.down_proj.detach().clone().transpose(1, 2))
+        gate_up_proj = self.gate_up_proj.detach().clone()
+        hidden_size = int(getattr(self, "hidden_size", min(gate_up_proj.shape[1], gate_up_proj.shape[2])))
+        if gate_up_proj.shape[1] == hidden_size:
+            gate_up_proj_h = gate_up_proj
+        elif gate_up_proj.shape[2] == hidden_size:
+            gate_up_proj_h = gate_up_proj.transpose(1, 2)
+        elif gate_up_proj.shape[1] < gate_up_proj.shape[2]:
+            gate_up_proj_h = gate_up_proj
+        else:
+            gate_up_proj_h = gate_up_proj.transpose(1, 2)
+
+        if gate_up_proj_h.shape[-1] % 2 != 0:
+            raise ValueError(f"gate_up_proj last dim must be even. Got shape={tuple(gate_up_proj_h.shape)}")
+        self.expert_dim = int(getattr(self, "intermediate_size", gate_up_proj_h.shape[-1] // 2))
+        self.gate_proj = nn.Parameter(gate_up_proj_h[:, :, : self.expert_dim].contiguous())
+        self.up_proj = nn.Parameter(gate_up_proj_h[:, :, self.expert_dim :].contiguous())
+
+        down_proj = self.down_proj.detach().clone()
+        if down_proj.shape[-1] == hidden_size:
+            down_proj_t = down_proj
+        elif down_proj.shape[1] == hidden_size:
+            down_proj_t = down_proj.transpose(1, 2)
+        elif down_proj.shape[1] > down_proj.shape[2]:
+            down_proj_t = down_proj
+        else:
+            down_proj_t = down_proj.transpose(1, 2)
+        self.down_proj_t = nn.Parameter(down_proj_t.contiguous())
 
 
 class QEffQwen3VLDecoderWrapper(nn.Module):
@@ -978,9 +1001,15 @@ class QEffQwen3VLMoeTextSparseMoeBlock(Qwen3VLMoeTextSparseMoeBlock):
         top_k = top_i.shape[-1]
         xk = x.unsqueeze(1).expand(-1, top_k, -1).contiguous()
         xk = xk.view(-1, 1, H)
+        if gate_proj.shape[1] != H:
+            gate_proj = gate_proj.transpose(1, 2)
+        if up_proj.shape[1] != H:
+            up_proj = up_proj.transpose(1, 2)
         gate = torch.bmm(xk, gate_proj)
         up = torch.bmm(xk, up_proj)
         intermediate = up * self.experts.act_fn(gate)
+        if w_dn.shape[1] != intermediate.shape[-1]:
+            w_dn = w_dn.transpose(1, 2)
         experts_out = torch.bmm(intermediate, w_dn)
         experts_out = experts_out.view(T, top_k, H) * top_w.unsqueeze(-1)
         experts_out = torch.einsum("bnd->bd", experts_out)

--- a/QEfficient/utils/__init__.py
+++ b/QEfficient/utils/__init__.py
@@ -59,6 +59,7 @@ from QEfficient.utils.layer_scale_checkpoint import (  # noqa: F401
     build_layer_scale_recipe_from_recovery_result,
     build_tensor_scale_specs,
     dump_layer_scale_recipe_yaml,
+    inject_layer_scale_metadata_to_loaded_model,
     load_layer_scale_recipe,
     serialize_layer_scale_recipe,
 )
@@ -78,6 +79,8 @@ from QEfficient.utils.precision_recovery_agent import (  # noqa: F401
     PrecisionRecoveryAgentRequest,
     needs_scale_search,
     parse_scale_candidate_schedules,
+    resolve_model_card_from_loaded_qeff_model,
     resolve_model_id_from_card,
     run_precision_recovery_agent,
+    run_precision_recovery_agent_from_loaded_qeff_model,
 )

--- a/QEfficient/utils/__init__.py
+++ b/QEfficient/utils/__init__.py
@@ -48,6 +48,36 @@ from QEfficient.utils.hash_utils import (  # noqa: F401
     create_export_hash,
     hash_dict_params,
 )
+from QEfficient.utils.layer_scale_checkpoint import (  # noqa: F401
+    SUPPORTED_RUNTIME_EQUIVALENCE_MODES,
+    LayerScaleRecipe,
+    TensorScaleSpec,
+    TensorScalingRule,
+    apply_layer_scale_recipe_to_loaded_model,
+    apply_layer_scale_recipe_to_snapshot,
+    build_layer_scale_recipe_from_recovery_json,
+    build_layer_scale_recipe_from_recovery_result,
+    build_tensor_scale_specs,
+    dump_layer_scale_recipe_yaml,
+    load_layer_scale_recipe,
+    serialize_layer_scale_recipe,
+)
 from QEfficient.utils.layerwise_pipeline import (  # noqa: F401
     layerwise_pipeline,
+)
+from QEfficient.utils.precision_recovery import (  # noqa: F401
+    DEFAULT_ITERATIVE_MLP_CANDIDATES,
+    PrecisionRecoveryRequest,
+    detect_precision_recovery_backend,
+    run_precision_recovery,
+    summarize_precision_recovery_result,
+)
+from QEfficient.utils.precision_recovery_agent import (  # noqa: F401
+    DEFAULT_SCALE_CANDIDATE_SCHEDULES,
+    PrecisionRecoveryAgent,
+    PrecisionRecoveryAgentRequest,
+    needs_scale_search,
+    parse_scale_candidate_schedules,
+    resolve_model_id_from_card,
+    run_precision_recovery_agent,
 )

--- a/QEfficient/utils/layer_scale_checkpoint.py
+++ b/QEfficient/utils/layer_scale_checkpoint.py
@@ -568,6 +568,17 @@ def _inject_scale_metadata_to_loaded_model(model: torch.nn.Module, recipe: Layer
         setattr(text_config, key, value)
 
 
+def inject_layer_scale_metadata_to_loaded_model(
+    *,
+    model: torch.nn.Module,
+    recipe_path: str | Path,
+) -> dict[str, Any]:
+    recipe_path = Path(recipe_path).expanduser().resolve()
+    recipe = load_layer_scale_recipe(recipe_path)
+    _inject_scale_metadata_to_loaded_model(model, recipe, recipe_path)
+    return _build_config_metadata_patch(recipe, recipe_path)
+
+
 def _collect_named_model_tensors(model: torch.nn.Module) -> dict[str, torch.Tensor]:
     tensor_map: dict[str, torch.Tensor] = {}
     for name, param in model.named_parameters():
@@ -600,7 +611,9 @@ def apply_layer_scale_recipe_to_loaded_model(
         matched.append((spec, tensor))
 
     if strict and missing_specs:
-        raise KeyError(f"{len(missing_specs)} recipe tensor keys missing in model tensors. First few: {missing_specs[:8]}")
+        raise KeyError(
+            f"{len(missing_specs)} recipe tensor keys missing in model tensors. First few: {missing_specs[:8]}"
+        )
 
     audit_rows: list[dict[str, Any]] = []
     for spec, tensor in matched:

--- a/QEfficient/utils/layer_scale_checkpoint.py
+++ b/QEfficient/utils/layer_scale_checkpoint.py
@@ -1,0 +1,804 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+import mmap
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import torch
+import yaml
+
+from QEfficient.utils._utils import load_yaml
+
+SUPPORTED_RUNTIME_EQUIVALENCE_MODES = {"checkpoint_scaled_mlp_and_residual_branch"}
+DEFAULT_RUNTIME_EQUIVALENCE_MODE = "checkpoint_scaled_mlp_and_residual_branch"
+
+
+@dataclass(frozen=True)
+class TensorScalingRule:
+    name: str
+    tensor_template: str
+    operation: str
+
+
+@dataclass(frozen=True)
+class LayerScaleRecipe:
+    model_id: str | None
+    default_scale: float
+    layer_scales: Dict[int, float]
+    rules: tuple[TensorScalingRule, ...]
+    runtime_equivalence_mode: str = DEFAULT_RUNTIME_EQUIVALENCE_MODE
+    runtime_equivalence: Dict[str, Any] | None = None
+    config_scale_key: str = "qeff_layer_scales"
+    config_default_key: str = "qeff_layer_scale_default"
+    config_mode_key: str = "qeff_layer_scale_mode"
+    config_mode_value: str = DEFAULT_RUNTIME_EQUIVALENCE_MODE
+
+
+@dataclass(frozen=True)
+class TensorScaleSpec:
+    layer_idx: int
+    tensor_key: str
+    operation: str
+    scale: float
+    rule_name: str
+
+
+_SUPPORTED_SCALING_OPS = {"scale_all", "scale_second_half_dim1"}
+
+_DTYPE_CODE_TO_TORCH = {
+    "F16": torch.float16,
+    "BF16": torch.bfloat16,
+    "F32": torch.float32,
+    "F64": torch.float64,
+}
+
+
+def _parse_layer_scale_map(raw: Any) -> Dict[int, float]:
+    if raw is None:
+        return {}
+    out: Dict[int, float] = {}
+    if isinstance(raw, dict):
+        items = raw.items()
+    elif isinstance(raw, list):
+        items = []
+        for row in raw:
+            if not isinstance(row, dict):
+                raise ValueError(f"Invalid layer scale entry: expected dict, got {type(row).__name__}")
+            if "layer_idx" not in row or "scale" not in row:
+                raise ValueError(f"Layer scale rows must include layer_idx and scale. Got: {row}")
+            items.append((row["layer_idx"], row["scale"]))
+    else:
+        raise ValueError(f"Unsupported layer scale format: {type(raw).__name__}")
+
+    for key, value in items:
+        layer_idx = int(key)
+        scale = float(value)
+        if layer_idx < 0:
+            raise ValueError(f"Layer index must be >= 0. Got {layer_idx}")
+        if scale <= 0.0:
+            raise ValueError(f"Scale must be > 0. Got layer={layer_idx} scale={scale}")
+        out[layer_idx] = scale
+    return out
+
+
+def _parse_scaling_rules(raw_rules: Any) -> tuple[TensorScalingRule, ...]:
+    if raw_rules is None:
+        return (
+            TensorScalingRule(
+                name="experts_gate_up_proj_up_half",
+                tensor_template="model.language_model.layers.{layer_idx}.mlp.experts.gate_up_proj",
+                operation="scale_second_half_dim1",
+            ),
+            TensorScalingRule(
+                name="shared_expert_up_proj",
+                tensor_template="model.language_model.layers.{layer_idx}.mlp.shared_expert.up_proj.weight",
+                operation="scale_all",
+            ),
+        )
+
+    if not isinstance(raw_rules, list):
+        raise ValueError(f"TensorScalingRules must be a list. Got {type(raw_rules).__name__}")
+
+    rules: list[TensorScalingRule] = []
+    for idx, row in enumerate(raw_rules):
+        if not isinstance(row, dict):
+            raise ValueError(f"TensorScalingRules[{idx}] must be a dict. Got {type(row).__name__}")
+        name = str(row.get("name", f"rule_{idx}"))
+        tensor_template = row.get("tensor_template")
+        operation = row.get("operation")
+        if not tensor_template or not operation:
+            raise ValueError(f"TensorScalingRules[{idx}] missing tensor_template/operation: {row}")
+        operation = str(operation)
+        if operation not in _SUPPORTED_SCALING_OPS:
+            raise ValueError(
+                f"TensorScalingRules[{idx}] has unsupported operation={operation!r}. "
+                f"Supported={sorted(_SUPPORTED_SCALING_OPS)}"
+            )
+        rules.append(
+            TensorScalingRule(
+                name=name,
+                tensor_template=str(tensor_template),
+                operation=operation,
+            )
+        )
+    return tuple(rules)
+
+
+def _default_runtime_equivalence() -> Dict[str, Any]:
+    return {
+        "mode": DEFAULT_RUNTIME_EQUIVALENCE_MODE,
+        "compensation_points": [
+            {
+                "name": "pre_input_inverse",
+                "module": "QEffQwen3_5MoeDecoderLayer.forward",
+                "location": "before input_layernorm",
+                "equation": "hidden_in = hidden_in / scale(layer_idx - 1)",
+            },
+            {
+                "name": "scaled_residual_add",
+                "module": "QEffQwen3_5MoeDecoderLayer.forward",
+                "location": "final residual + mlp add",
+                "equation": "layer_out_scaled = scale(layer_idx) * residual + mlp_out_scaled",
+            },
+            {
+                "name": "final_unscale_before_norm",
+                "module": "QEffQwen3_5MoeTextModel.forward",
+                "location": "before final norm on last layer window",
+                "equation": "hidden_before_norm = hidden_before_norm / scale(last_layer_idx)",
+            },
+        ],
+    }
+
+
+def _parse_runtime_equivalence(
+    raw_runtime_equivalence: Any,
+    mode_override: str | None,
+) -> tuple[str, Dict[str, Any]]:
+    runtime_equivalence = _default_runtime_equivalence()
+
+    if raw_runtime_equivalence is not None:
+        if not isinstance(raw_runtime_equivalence, dict):
+            raise ValueError(
+                f"RuntimeEquivalence must be a dict when provided. Got {type(raw_runtime_equivalence).__name__}"
+            )
+        runtime_equivalence.update(raw_runtime_equivalence)
+
+    runtime_mode = str(runtime_equivalence.get("mode", DEFAULT_RUNTIME_EQUIVALENCE_MODE))
+    if mode_override is not None and mode_override != runtime_mode:
+        raise ValueError(
+            "ConfigMetadata mode_value must match RuntimeEquivalence.mode for mathematical-equivalence safety. "
+            f"Got mode_value={mode_override!r}, RuntimeEquivalence.mode={runtime_mode!r}."
+        )
+    runtime_mode = str(mode_override if mode_override is not None else runtime_mode)
+    if runtime_mode not in SUPPORTED_RUNTIME_EQUIVALENCE_MODES:
+        raise ValueError(
+            f"Unsupported RuntimeEquivalence mode={runtime_mode!r}. "
+            f"Supported={sorted(SUPPORTED_RUNTIME_EQUIVALENCE_MODES)}"
+        )
+    runtime_equivalence["mode"] = runtime_mode
+    return runtime_mode, runtime_equivalence
+
+
+def load_layer_scale_recipe(recipe_path: str | Path) -> LayerScaleRecipe:
+    recipe_path = Path(recipe_path).expanduser().resolve()
+    raw = load_yaml(str(recipe_path))
+    if not isinstance(raw, dict):
+        raise ValueError(f"Recipe YAML must deserialize to a dict. Got {type(raw).__name__}")
+
+    model_id = raw.get("ModelID") or raw.get("model_id")
+
+    if "LayerScales" in raw:
+        layer_scales_block = raw["LayerScales"] or {}
+        default_scale = float(layer_scales_block.get("default_scale", 1.0))
+        per_layer = _parse_layer_scale_map(layer_scales_block.get("per_layer", {}))
+    elif "ScaleConfig" in raw:
+        scale_cfg = raw["ScaleConfig"] or {}
+        default_scale = float(scale_cfg.get("default_scale", 1.0))
+        per_layer = _parse_layer_scale_map(scale_cfg.get("non_unit_layer_scales", []))
+    else:
+        default_scale = 1.0
+        per_layer = _parse_layer_scale_map(raw.get("layer_scales", {}))
+
+    if default_scale <= 0.0:
+        raise ValueError(f"default_scale must be > 0. Got {default_scale}")
+
+    rules = _parse_scaling_rules(raw.get("TensorScalingRules"))
+
+    cfg_overrides = raw.get("ConfigMetadata", {}) or {}
+    if not isinstance(cfg_overrides, dict):
+        raise ValueError(f"ConfigMetadata must be a dict. Got {type(cfg_overrides).__name__}")
+
+    mode_override = cfg_overrides.get("mode_value", None)
+    runtime_mode, runtime_equivalence = _parse_runtime_equivalence(raw.get("RuntimeEquivalence"), mode_override)
+
+    return LayerScaleRecipe(
+        model_id=model_id,
+        default_scale=default_scale,
+        layer_scales=per_layer,
+        rules=rules,
+        runtime_equivalence_mode=runtime_mode,
+        runtime_equivalence=runtime_equivalence,
+        config_scale_key=str(cfg_overrides.get("layer_scale_key", "qeff_layer_scales")),
+        config_default_key=str(cfg_overrides.get("default_scale_key", "qeff_layer_scale_default")),
+        config_mode_key=str(cfg_overrides.get("mode_key", "qeff_layer_scale_mode")),
+        config_mode_value=runtime_mode,
+    )
+
+
+def build_tensor_scale_specs(recipe: LayerScaleRecipe) -> list[TensorScaleSpec]:
+    specs: list[TensorScaleSpec] = []
+    for layer_idx, scale in sorted(recipe.layer_scales.items()):
+        if scale == recipe.default_scale:
+            continue
+        for rule in recipe.rules:
+            specs.append(
+                TensorScaleSpec(
+                    layer_idx=layer_idx,
+                    tensor_key=rule.tensor_template.format(layer_idx=layer_idx),
+                    operation=rule.operation,
+                    scale=scale,
+                    rule_name=rule.name,
+                )
+            )
+    return specs
+
+
+def serialize_layer_scale_recipe(recipe: LayerScaleRecipe, include_expanded_specs: bool = False) -> Dict[str, Any]:
+    data: Dict[str, Any] = {
+        "ModelID": recipe.model_id,
+        "LayerScales": {
+            "default_scale": float(recipe.default_scale),
+            "per_layer": {int(k): float(v) for k, v in sorted(recipe.layer_scales.items())},
+        },
+        "TensorScalingRules": [
+            {
+                "name": rule.name,
+                "tensor_template": rule.tensor_template,
+                "operation": rule.operation,
+            }
+            for rule in recipe.rules
+        ],
+        "RuntimeEquivalence": recipe.runtime_equivalence
+        if recipe.runtime_equivalence
+        else _default_runtime_equivalence(),
+        "ConfigMetadata": {
+            "layer_scale_key": recipe.config_scale_key,
+            "default_scale_key": recipe.config_default_key,
+            "mode_key": recipe.config_mode_key,
+            "mode_value": recipe.config_mode_value,
+        },
+    }
+
+    if include_expanded_specs:
+        data["ScaledTensorSpecs"] = [
+            {
+                "layer_idx": int(spec.layer_idx),
+                "tensor_key": spec.tensor_key,
+                "operation": spec.operation,
+                "scale": float(spec.scale),
+                "rule_name": spec.rule_name,
+            }
+            for spec in build_tensor_scale_specs(recipe)
+        ]
+    return data
+
+
+def dump_layer_scale_recipe_yaml(
+    recipe: LayerScaleRecipe,
+    output_path: str | Path,
+    include_expanded_specs: bool = True,
+    extra_fields: Dict[str, Any] | None = None,
+) -> Path:
+    output_path = Path(output_path).expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = serialize_layer_scale_recipe(recipe, include_expanded_specs=include_expanded_specs)
+    if extra_fields:
+        payload.update(extra_fields)
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(payload, f, sort_keys=False, allow_unicode=False)
+    return output_path
+
+
+def build_layer_scale_recipe_from_recovery_result(
+    *,
+    recovery_result: Dict[str, Any],
+    model_id: str | None = None,
+    default_scale: float = 1.0,
+    rules: tuple[TensorScalingRule, ...] | None = None,
+) -> LayerScaleRecipe:
+    if default_scale <= 0.0:
+        raise ValueError(f"default_scale must be > 0. Got {default_scale}")
+
+    unresolved = recovery_result.get("unresolved")
+    if unresolved is not None:
+        raise ValueError("Cannot build mathematically-equivalent scale recipe: recovery result is unresolved.")
+
+    layer_rows = recovery_result.get("layers")
+    if not isinstance(layer_rows, list):
+        raise ValueError("Recovery result must contain a list under `layers`.")
+
+    per_layer: Dict[int, float] = {}
+    for row in layer_rows:
+        if not isinstance(row, dict):
+            continue
+        if not row.get("resolved", False):
+            continue
+        layer_idx = int(row["layer_idx"])
+        selected_scale = float(row.get("selected_scale", default_scale))
+        if selected_scale <= 0.0:
+            raise ValueError(f"Invalid selected_scale for layer {layer_idx}: {selected_scale}")
+        if selected_scale == default_scale:
+            continue
+
+        final_variant = row.get("final_variant", {}) or {}
+        finite_ratio = final_variant.get("layer_out_finite_ratio", {}) or {}
+        hf_fp16_finite = float(finite_ratio.get("hf_fp16", 0.0))
+        qeff_fp16_finite = float(finite_ratio.get("qeff_fp16", 0.0))
+        if hf_fp16_finite < 1.0 or qeff_fp16_finite < 1.0:
+            raise ValueError(
+                f"Layer {layer_idx} selected_scale={selected_scale} is not fully finite "
+                f"(hf_fp16={hf_fp16_finite}, qeff_fp16={qeff_fp16_finite})."
+            )
+        per_layer[layer_idx] = selected_scale
+
+    resolved_model_id = model_id
+    if resolved_model_id is None:
+        resolved_model_id = recovery_result.get("config", {}).get("model_id")
+
+    recipe_rules = rules if rules is not None else _parse_scaling_rules(None)
+    runtime_mode, runtime_equivalence = _parse_runtime_equivalence(
+        raw_runtime_equivalence=None,
+        mode_override=DEFAULT_RUNTIME_EQUIVALENCE_MODE,
+    )
+    return LayerScaleRecipe(
+        model_id=resolved_model_id,
+        default_scale=float(default_scale),
+        layer_scales=per_layer,
+        rules=recipe_rules,
+        runtime_equivalence_mode=runtime_mode,
+        runtime_equivalence=runtime_equivalence,
+        config_mode_value=runtime_mode,
+    )
+
+
+def build_layer_scale_recipe_from_recovery_json(
+    *,
+    recovery_json_path: str | Path,
+    model_id: str | None = None,
+    default_scale: float = 1.0,
+    rules: tuple[TensorScalingRule, ...] | None = None,
+) -> LayerScaleRecipe:
+    recovery_json_path = Path(recovery_json_path).expanduser().resolve()
+    with open(recovery_json_path, "r", encoding="utf-8") as f:
+        recovery_result = json.load(f)
+    if not isinstance(recovery_result, dict):
+        raise ValueError(f"Recovery JSON must deserialize to a dict. Got {type(recovery_result).__name__}")
+    return build_layer_scale_recipe_from_recovery_result(
+        recovery_result=recovery_result,
+        model_id=model_id,
+        default_scale=default_scale,
+        rules=rules,
+    )
+
+
+def _link_or_copy(src: Path, dst: Path, *, allow_hardlink: bool, allow_symlink: bool) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    if allow_hardlink:
+        try:
+            os.link(src, dst)
+            return
+        except OSError:
+            pass
+    if allow_symlink:
+        try:
+            os.symlink(src, dst)
+            return
+        except OSError:
+            pass
+    shutil.copy2(src, dst)
+
+
+def _collect_snapshot_files(root: Path) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        if path.is_file():
+            yield path
+
+
+def _safetensor_header(path: Path) -> tuple[int, dict[str, Any]]:
+    with open(path, "rb") as f:
+        header_len = int.from_bytes(f.read(8), "little")
+        header_data = f.read(header_len)
+    header = json.loads(header_data)
+    if not isinstance(header, dict):
+        raise ValueError(f"Invalid safetensor header in {path}")
+    return header_len, header
+
+
+def _apply_scale_op(tensor_view: torch.Tensor, operation: str, scale: float) -> None:
+    scalar = tensor_view.new_tensor(scale)
+    if operation == "scale_all":
+        tensor_view.mul_(scalar)
+        return
+    if operation == "scale_second_half_dim1":
+        if tensor_view.ndim < 2:
+            raise ValueError(f"scale_second_half_dim1 requires rank>=2. Got rank={tensor_view.ndim}")
+        dim1 = int(tensor_view.shape[1])
+        if dim1 % 2 != 0:
+            raise ValueError(f"scale_second_half_dim1 requires even dim1. Got dim1={dim1}")
+        half = dim1 // 2
+        index = (slice(None), slice(half, None), *([slice(None)] * (tensor_view.ndim - 2)))
+        tensor_view[index].mul_(scalar)
+        return
+    raise ValueError(f"Unsupported operation={operation!r}")
+
+
+def _tensor_summary(tensor: torch.Tensor, max_sample: int = 1_000_000) -> dict[str, float]:
+    flat = tensor.reshape(-1)
+    if flat.numel() > max_sample:
+        step = max(1, flat.numel() // max_sample)
+        flat = flat[::step]
+    as_float = flat.float()
+    finite = torch.isfinite(as_float)
+    finite_ratio = float(finite.float().mean().item())
+    if finite.any():
+        finite_vals = as_float[finite]
+        min_v = float(finite_vals.min().item())
+        max_v = float(finite_vals.max().item())
+        abs_max = float(finite_vals.abs().max().item())
+    else:
+        min_v = float("nan")
+        max_v = float("nan")
+        abs_max = float("nan")
+    return {"finite_ratio": finite_ratio, "min": min_v, "max": max_v, "abs_max": abs_max}
+
+
+def _patch_safetensor_file(
+    shard_path: Path,
+    specs: list[TensorScaleSpec],
+) -> list[dict[str, Any]]:
+    header_len, header = _safetensor_header(shard_path)
+    data_base = 8 + header_len
+    audit_rows: list[dict[str, Any]] = []
+
+    with open(shard_path, "r+b") as f:
+        mm = mmap.mmap(f.fileno(), 0)
+        try:
+            for spec in specs:
+                tensor_meta = header.get(spec.tensor_key)
+                if not isinstance(tensor_meta, dict):
+                    raise KeyError(f"Tensor key {spec.tensor_key!r} not found in shard {shard_path.name}")
+                dtype_code = tensor_meta.get("dtype")
+                if dtype_code not in _DTYPE_CODE_TO_TORCH:
+                    raise ValueError(
+                        f"Unsupported dtype={dtype_code!r} for tensor={spec.tensor_key}. "
+                        f"Supported={sorted(_DTYPE_CODE_TO_TORCH)}"
+                    )
+                shape = tuple(int(x) for x in tensor_meta.get("shape", []))
+                begin, end = tensor_meta.get("data_offsets", [None, None])
+                if begin is None or end is None:
+                    raise ValueError(f"Missing data_offsets for tensor={spec.tensor_key} in {shard_path.name}")
+                abs_begin = data_base + int(begin)
+                abs_end = data_base + int(end)
+                view = memoryview(mm)[abs_begin:abs_end]
+                tensor = torch.frombuffer(view, dtype=_DTYPE_CODE_TO_TORCH[dtype_code]).view(shape)
+                before = _tensor_summary(tensor)
+                _apply_scale_op(tensor, spec.operation, spec.scale)
+                after = _tensor_summary(tensor)
+
+                del tensor
+                del view
+
+                audit_rows.append(
+                    {
+                        "layer_idx": spec.layer_idx,
+                        "tensor_key": spec.tensor_key,
+                        "rule_name": spec.rule_name,
+                        "operation": spec.operation,
+                        "scale": spec.scale,
+                        "shard": shard_path.name,
+                        "dtype": dtype_code,
+                        "shape": list(shape),
+                        "before": before,
+                        "after": after,
+                    }
+                )
+        finally:
+            mm.close()
+
+    return audit_rows
+
+
+def _inject_scale_metadata(config_path: Path, recipe: LayerScaleRecipe, recipe_path: Path) -> None:
+    with open(config_path, "r", encoding="utf-8") as f:
+        config_data = json.load(f)
+    if not isinstance(config_data, dict):
+        raise ValueError(f"{config_path} must contain a JSON object.")
+
+    metadata_patch = _build_config_metadata_patch(recipe, recipe_path)
+
+    config_data.update(metadata_patch)
+
+    text_cfg = config_data.get("text_config")
+    if isinstance(text_cfg, dict):
+        text_cfg.update(metadata_patch)
+
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(config_data, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def _build_config_metadata_patch(recipe: LayerScaleRecipe, recipe_path: Path) -> dict[str, Any]:
+    scale_map_str = {str(k): float(v) for k, v in sorted(recipe.layer_scales.items()) if v != recipe.default_scale}
+    metadata_patch: dict[str, Any] = {
+        "qeff_layer_scales": scale_map_str,
+        "qeff_layer_scale_default": float(recipe.default_scale),
+        "qeff_layer_scale_mode": recipe.config_mode_value,
+        "qeff_layer_scale_recipe": str(recipe_path),
+    }
+    metadata_patch[recipe.config_scale_key] = scale_map_str
+    metadata_patch[recipe.config_default_key] = float(recipe.default_scale)
+    metadata_patch[recipe.config_mode_key] = recipe.config_mode_value
+    return metadata_patch
+
+
+def _inject_scale_metadata_to_loaded_model(model: torch.nn.Module, recipe: LayerScaleRecipe, recipe_path: Path) -> None:
+    metadata_patch = _build_config_metadata_patch(recipe, recipe_path)
+    config = getattr(model, "config", None)
+    if config is None:
+        return
+    for key, value in metadata_patch.items():
+        setattr(config, key, value)
+    text_config = getattr(config, "text_config", None)
+    if text_config is None:
+        return
+    for key, value in metadata_patch.items():
+        setattr(text_config, key, value)
+
+
+def _collect_named_model_tensors(model: torch.nn.Module) -> dict[str, torch.Tensor]:
+    tensor_map: dict[str, torch.Tensor] = {}
+    for name, param in model.named_parameters():
+        tensor_map[name] = param
+    for name, buffer in model.named_buffers():
+        if name not in tensor_map:
+            tensor_map[name] = buffer
+    return tensor_map
+
+
+def apply_layer_scale_recipe_to_loaded_model(
+    *,
+    model: torch.nn.Module,
+    recipe_path: str | Path,
+    strict: bool = True,
+    inject_config_metadata: bool = True,
+) -> dict[str, Any]:
+    recipe_path = Path(recipe_path).expanduser().resolve()
+    recipe = load_layer_scale_recipe(recipe_path)
+    specs = build_tensor_scale_specs(recipe)
+    tensor_map = _collect_named_model_tensors(model)
+
+    missing_specs: list[str] = []
+    matched: list[tuple[TensorScaleSpec, torch.Tensor]] = []
+    for spec in specs:
+        tensor = tensor_map.get(spec.tensor_key)
+        if tensor is None:
+            missing_specs.append(spec.tensor_key)
+            continue
+        matched.append((spec, tensor))
+
+    if strict and missing_specs:
+        raise KeyError(f"{len(missing_specs)} recipe tensor keys missing in model tensors. First few: {missing_specs[:8]}")
+
+    audit_rows: list[dict[str, Any]] = []
+    for spec, tensor in matched:
+        before = _tensor_summary(tensor)
+        with torch.no_grad():
+            _apply_scale_op(tensor, spec.operation, spec.scale)
+        after = _tensor_summary(tensor)
+        audit_rows.append(
+            {
+                "layer_idx": int(spec.layer_idx),
+                "tensor_key": spec.tensor_key,
+                "rule_name": spec.rule_name,
+                "operation": spec.operation,
+                "scale": float(spec.scale),
+                "dtype": str(tensor.dtype),
+                "shape": [int(x) for x in tensor.shape],
+                "before": before,
+                "after": after,
+            }
+        )
+
+    if inject_config_metadata:
+        _inject_scale_metadata_to_loaded_model(model, recipe, recipe_path)
+
+    return {
+        "recipe_path": str(recipe_path),
+        "model_id": recipe.model_id,
+        "default_scale": float(recipe.default_scale),
+        "layer_scales": {str(k): float(v) for k, v in sorted(recipe.layer_scales.items())},
+        "scaled_tensor_count": len(audit_rows),
+        "scaled_unique_keys": len({row["tensor_key"] for row in audit_rows}),
+        "missing_recipe_keys": missing_specs,
+        "entries": audit_rows,
+    }
+
+
+def _prepare_output_dir(output_dir: Path) -> None:
+    if output_dir.exists():
+        if any(output_dir.iterdir()):
+            raise ValueError(f"output_dir exists and is not empty: {output_dir}")
+        return
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _load_safetensor_weight_map(index_path: Path) -> dict[str, str]:
+    with open(index_path, "r", encoding="utf-8") as handle:
+        index_data = json.load(handle)
+    if not isinstance(index_data, dict) or "weight_map" not in index_data:
+        raise ValueError(f"Invalid safetensor index format: {index_path}")
+    weight_map = index_data["weight_map"]
+    if not isinstance(weight_map, dict):
+        raise ValueError("model.safetensors.index.json: weight_map must be a dict")
+    return {str(key): str(value) for key, value in weight_map.items()}
+
+
+def _group_specs_by_shard(
+    specs: list[TensorScaleSpec],
+    weight_map: dict[str, str],
+) -> tuple[dict[str, list[TensorScaleSpec]], list[str]]:
+    missing_specs: list[str] = []
+    shard_to_specs: dict[str, list[TensorScaleSpec]] = {}
+
+    for spec in specs:
+        shard_name = weight_map.get(spec.tensor_key)
+        if shard_name is None:
+            missing_specs.append(spec.tensor_key)
+            continue
+        shard_to_specs.setdefault(shard_name, []).append(spec)
+    return shard_to_specs, missing_specs
+
+
+def _copy_snapshot_with_patch_targets(
+    source_dir: Path,
+    output_dir: Path,
+    patched_shards: set[str],
+    *,
+    allow_hardlink_unchanged: bool,
+    allow_symlink_unchanged: bool,
+) -> None:
+    for src_file in _collect_snapshot_files(source_dir):
+        rel_path = src_file.relative_to(source_dir)
+        dst_file = output_dir / rel_path
+        must_copy = src_file.name in patched_shards or src_file.name in {"config.json", "model.safetensors.index.json"}
+        _link_or_copy(
+            src_file,
+            dst_file,
+            allow_hardlink=allow_hardlink_unchanged and not must_copy,
+            allow_symlink=allow_symlink_unchanged and not must_copy,
+        )
+
+
+def _patch_shards(
+    output_dir: Path,
+    shard_to_specs: dict[str, list[TensorScaleSpec]],
+) -> list[dict[str, Any]]:
+    audit_rows: list[dict[str, Any]] = []
+    for shard_name, shard_specs in sorted(shard_to_specs.items()):
+        shard_path = output_dir / shard_name
+        if not shard_path.is_file():
+            raise FileNotFoundError(f"Missing copied shard in output snapshot: {shard_path}")
+        audit_rows.extend(_patch_safetensor_file(shard_path, shard_specs))
+    return audit_rows
+
+
+def _resolve_audit_json_path(output_dir: Path, audit_json_path: str | Path | None) -> Path:
+    if audit_json_path is None:
+        return output_dir / "qeff_layer_scale_audit.json"
+    path = Path(audit_json_path).expanduser().resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _build_snapshot_scale_audit(
+    *,
+    source_dir: Path,
+    output_dir: Path,
+    recipe_path: Path,
+    recipe: LayerScaleRecipe,
+    patched_shards: set[str],
+    missing_specs: list[str],
+    audit_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    touched_layers = sorted({int(row["layer_idx"]) for row in audit_rows})
+    touched_keys = sorted({str(row["tensor_key"]) for row in audit_rows})
+    return {
+        "source_dir": str(source_dir),
+        "output_dir": str(output_dir),
+        "recipe_path": str(recipe_path),
+        "model_id": recipe.model_id,
+        "default_scale": recipe.default_scale,
+        "layer_scales": {str(k): float(v) for k, v in sorted(recipe.layer_scales.items())},
+        "touched_layers": touched_layers,
+        "patched_shards": sorted(patched_shards),
+        "scaled_tensor_count": len(audit_rows),
+        "scaled_unique_keys": len(touched_keys),
+        "missing_recipe_keys": missing_specs,
+        "entries": audit_rows,
+    }
+
+
+def apply_layer_scale_recipe_to_snapshot(
+    *,
+    source_dir: str | Path,
+    output_dir: str | Path,
+    recipe_path: str | Path,
+    strict: bool = True,
+    allow_hardlink_unchanged: bool = True,
+    allow_symlink_unchanged: bool = True,
+    inject_config_metadata: bool = True,
+    audit_json_path: str | Path | None = None,
+) -> dict[str, Any]:
+    source_dir = Path(source_dir).expanduser().resolve()
+    output_dir = Path(output_dir).expanduser().resolve()
+    recipe_path = Path(recipe_path).expanduser().resolve()
+
+    if not source_dir.is_dir():
+        raise ValueError(f"source_dir does not exist: {source_dir}")
+
+    index_path = source_dir / "model.safetensors.index.json"
+    if not index_path.is_file():
+        raise ValueError(f"Missing model.safetensors.index.json under {source_dir}")
+
+    _prepare_output_dir(output_dir)
+
+    recipe = load_layer_scale_recipe(recipe_path)
+    specs = build_tensor_scale_specs(recipe)
+    weight_map = _load_safetensor_weight_map(index_path)
+    shard_to_specs, missing_specs = _group_specs_by_shard(specs, weight_map)
+    patched_shards = set(shard_to_specs)
+
+    if strict and missing_specs:
+        raise KeyError(f"{len(missing_specs)} recipe tensor keys missing in weight_map. First few: {missing_specs[:8]}")
+
+    _copy_snapshot_with_patch_targets(
+        source_dir,
+        output_dir,
+        patched_shards,
+        allow_hardlink_unchanged=allow_hardlink_unchanged,
+        allow_symlink_unchanged=allow_symlink_unchanged,
+    )
+    audit_rows = _patch_shards(output_dir, shard_to_specs)
+
+    config_path = output_dir / "config.json"
+    if inject_config_metadata and config_path.is_file():
+        _inject_scale_metadata(config_path, recipe, recipe_path)
+
+    audit_path = _resolve_audit_json_path(output_dir, audit_json_path)
+    audit = _build_snapshot_scale_audit(
+        source_dir=source_dir,
+        output_dir=output_dir,
+        recipe_path=recipe_path,
+        recipe=recipe,
+        patched_shards=patched_shards,
+        missing_specs=missing_specs,
+        audit_rows=audit_rows,
+    )
+    with open(audit_path, "w", encoding="utf-8") as f:
+        json.dump(audit, f, indent=2)
+        f.write("\n")
+
+    return audit

--- a/QEfficient/utils/precision_recovery.py
+++ b/QEfficient/utils/precision_recovery.py
@@ -1,0 +1,122 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from transformers import AutoConfig
+
+DEFAULT_ITERATIVE_MLP_CANDIDATES = (
+    "sparse_moe_post_ops_fp32,"
+    "shared_expert_matmul_fp32_keep_fp32,"
+    "shared_expert_matmul_fp32,"
+    "shared_expert_gate_matmul_fp32,"
+    "experts_matmul_fp32,"
+    "mlp_full_fp32"
+)
+
+
+@dataclass
+class PrecisionRecoveryRequest:
+    model_id: str
+    prompt: str = "Tell me about yourself."
+    max_input_tokens: int = 64
+    start_layer: int = 22
+    max_layers: int = 0
+    boundary_cache_dir: str = "scripts/debug/artifacts/qwen3_5_moe_window23_cache"
+    continuation_cache_dir: str = "scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_cache"
+    no_continuation_cache: bool = False
+    iterative_mlp_candidates: str = DEFAULT_ITERATIVE_MLP_CANDIDATES
+    output_json: str = "scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_fp32_recovery.json"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _load_qwen35_moe_runner_module():
+    script_path = _repo_root() / "scripts" / "debug" / "qwen3_5_moe_full_depth_iterative_fp32_recovery.py"
+    spec = importlib.util.spec_from_file_location("qwen3_5_moe_full_depth_recovery", script_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load precision recovery runner module at {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def detect_precision_recovery_backend(model_id: str) -> str:
+    cfg = AutoConfig.from_pretrained(model_id, trust_remote_code=True)
+    text_cfg = getattr(cfg, "text_config", cfg)
+    model_type = str(getattr(text_cfg, "model_type", getattr(cfg, "model_type", "")))
+    arch = [str(x) for x in getattr(cfg, "architectures", [])]
+    if model_type == "qwen3_5_moe" or any("Qwen3_5Moe" in x for x in arch):
+        return "qwen3_5_moe"
+    raise ValueError(
+        f"No precision-recovery backend registered for model_id={model_id!r} "
+        f"(detected model_type={model_type!r}, architectures={arch})."
+    )
+
+
+def run_precision_recovery(request: PrecisionRecoveryRequest) -> dict[str, Any]:
+    backend = detect_precision_recovery_backend(request.model_id)
+    if backend != "qwen3_5_moe":
+        raise ValueError(f"Unsupported precision-recovery backend: {backend}")
+
+    module = _load_qwen35_moe_runner_module()
+    args = argparse.Namespace(**asdict(request))
+    return module.run_recovery(args)
+
+
+def summarize_precision_recovery_result(result: dict[str, Any]) -> dict[str, Any]:
+    layers = result.get("layers", [])
+    promoted_layers = []
+    max_hf_mad = None
+    max_qeff_mad = None
+    max_hf_layer = None
+    max_qeff_layer = None
+
+    for row in layers:
+        layer_idx = row["layer_idx"]
+        baseline = row.get("final_variant", row.get("baseline", {}))
+        hf_mad = baseline.get("layer_out_mad_vs_hf_fp32", {}).get("hf_fp16")
+        qeff_mad = baseline.get("layer_out_mad_vs_hf_fp32", {}).get("qeff_fp16")
+        if hf_mad is not None and (max_hf_mad is None or hf_mad > max_hf_mad):
+            max_hf_mad = hf_mad
+            max_hf_layer = layer_idx
+        if qeff_mad is not None and (max_qeff_mad is None or qeff_mad > max_qeff_mad):
+            max_qeff_mad = qeff_mad
+            max_qeff_layer = layer_idx
+        selected_patches = row.get("selected_patches", [])
+        if selected_patches:
+            promoted_layers.append({"layer_idx": layer_idx, "selected_patches": selected_patches})
+
+    final = result.get("final", {})
+    predictions = final.get("predictions", {})
+    return {
+        "completed_boundary": result.get("resume", {}).get("completed_boundary"),
+        "unresolved": result.get("unresolved") is not None,
+        "promoted_layers": promoted_layers,
+        "max_layer_out_mad_vs_hf_fp32": {
+            "hf_fp16": {"layer_idx": max_hf_layer, "mad": max_hf_mad},
+            "qeff_fp16": {"layer_idx": max_qeff_layer, "mad": max_qeff_mad},
+        },
+        "final_token_prediction": {
+            "hf_fp32": predictions.get("hf_fp32"),
+            "hf_fp16_recovered": predictions.get("hf_fp16_recovered"),
+            "qeff_fp16_recovered": predictions.get("qeff_fp16_recovered"),
+        },
+        "final_logits_mad": {
+            "hf_fp16_vs_hf_fp32": final.get("logits_hf_fp16_vs_hf_fp32", {}).get("mad"),
+            "qeff_fp16_vs_hf_fp32": final.get("logits_qeff_fp16_vs_hf_fp32", {}).get("mad"),
+            "qeff_fp16_vs_hf_fp16": final.get("logits_qeff_fp16_vs_hf_fp16", {}).get("mad"),
+        },
+    }

--- a/QEfficient/utils/precision_recovery_agent.py
+++ b/QEfficient/utils/precision_recovery_agent.py
@@ -31,6 +31,13 @@ from QEfficient.utils.precision_recovery import (
 MODEL_ID_KEYS = ("model_id", "model_name", "hf_model_id", "repo_id")
 DEFAULT_SCALE_CANDIDATES = "1.0,0.5,0.25,0.125,0.0625,0.03125,0.015625,0.0078125,0.00390625,0.001953125"
 DEFAULT_SCALE_CANDIDATE_SCHEDULES = (DEFAULT_SCALE_CANDIDATES,)
+_MODEL_CARD_CANDIDATE_ATTRS = (
+    "_pretrained_model_name_or_path",
+    "pretrained_model_name_or_path",
+    "pretrained_path",
+    "_name_or_path",
+    "name_or_path",
+)
 
 
 def parse_scale_candidate_schedules(raw: str | None) -> tuple[str, ...]:
@@ -97,6 +104,95 @@ def resolve_model_id_from_card(model_card: str) -> str:
             f"Expected one of keys {MODEL_ID_KEYS} or a '<org>/<name>' token."
         )
     return model_id
+
+
+def _non_empty_str(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if value else None
+
+
+def _append_model_card_candidate(candidates: list[str], value: Any) -> None:
+    candidate = _non_empty_str(value)
+    if candidate is None:
+        return
+    candidates.append(candidate)
+
+
+def _collect_model_card_candidates_from_object(obj: Any, candidates: list[str]) -> None:
+    if obj is None:
+        return
+
+    for attr_name in _MODEL_CARD_CANDIDATE_ATTRS:
+        _append_model_card_candidate(candidates, getattr(obj, attr_name, None))
+
+    hash_params = getattr(obj, "hash_params", None)
+    if isinstance(hash_params, dict):
+        _append_model_card_candidate(candidates, hash_params.get("pretrained_model_name_or_path"))
+
+    config = getattr(obj, "config", None)
+    if config is not None and config is not obj:
+        for attr_name in ("_name_or_path", "name_or_path"):
+            _append_model_card_candidate(candidates, getattr(config, attr_name, None))
+
+
+def resolve_model_card_from_loaded_qeff_model(qeff_model: Any) -> str:
+    candidates: list[str] = []
+    _collect_model_card_candidates_from_object(qeff_model, candidates)
+    _collect_model_card_candidates_from_object(getattr(qeff_model, "model", None), candidates)
+    _collect_model_card_candidates_from_object(getattr(qeff_model, "lang_model", None), candidates)
+    _collect_model_card_candidates_from_object(
+        getattr(getattr(qeff_model, "lang_model", None), "model", None), candidates
+    )
+    _collect_model_card_candidates_from_object(getattr(qeff_model, "vision_model", None), candidates)
+    _collect_model_card_candidates_from_object(
+        getattr(getattr(qeff_model, "vision_model", None), "model", None), candidates
+    )
+
+    seen = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        candidate_path = Path(candidate).expanduser()
+        if candidate_path.exists():
+            return str(candidate_path.resolve())
+        return candidate
+
+    raise ValueError(
+        "Could not resolve model card/model id from loaded QEff model. "
+        "Pass model_card explicitly to run_precision_recovery_agent_from_loaded_qeff_model(...)."
+    )
+
+
+def run_precision_recovery_agent_from_loaded_qeff_model(
+    qeff_model: Any,
+    *,
+    model_card: str | None = None,
+    **request_kwargs: Any,
+) -> dict[str, Any]:
+    """
+    Run the precision-recovery agent starting from a loaded QEff wrapper.
+
+    Parameters
+    ----------
+    qeff_model:
+        A loaded QEff auto-wrapper instance (for example, `QEFFAutoModelForCausalLM.from_pretrained(...)`).
+    model_card:
+        Optional explicit model card/model id override. When not provided, it is inferred from the loaded wrapper.
+    **request_kwargs:
+        Additional `PrecisionRecoveryAgentRequest` fields.
+    """
+
+    if "model_card" in request_kwargs:
+        if model_card is not None:
+            raise ValueError("Pass model_card either as an explicit argument or in request_kwargs, not both.")
+        model_card = request_kwargs.pop("model_card")
+
+    resolved_model_card = model_card or resolve_model_card_from_loaded_qeff_model(qeff_model)
+    request = PrecisionRecoveryAgentRequest(model_card=resolved_model_card, **request_kwargs)
+    return run_precision_recovery_agent(request)
 
 
 def needs_scale_search(analysis_summary: dict[str, Any]) -> bool:

--- a/QEfficient/utils/precision_recovery_agent.py
+++ b/QEfficient/utils/precision_recovery_agent.py
@@ -1,0 +1,313 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from QEfficient.utils.layer_scale_checkpoint import (
+    build_layer_scale_recipe_from_recovery_result,
+    dump_layer_scale_recipe_yaml,
+)
+from QEfficient.utils.precision_recovery import (
+    DEFAULT_ITERATIVE_MLP_CANDIDATES,
+    PrecisionRecoveryRequest,
+    run_precision_recovery,
+    summarize_precision_recovery_result,
+)
+
+MODEL_ID_KEYS = ("model_id", "model_name", "hf_model_id", "repo_id")
+DEFAULT_SCALE_CANDIDATES = "1.0,0.5,0.25,0.125,0.0625,0.03125,0.015625,0.0078125,0.00390625,0.001953125"
+DEFAULT_SCALE_CANDIDATE_SCHEDULES = (DEFAULT_SCALE_CANDIDATES,)
+
+
+def parse_scale_candidate_schedules(raw: str | None) -> tuple[str, ...]:
+    if raw is None:
+        return DEFAULT_SCALE_CANDIDATE_SCHEDULES
+    values = tuple(part.strip() for part in raw.split(";") if part.strip())
+    if not values:
+        raise ValueError("scale candidate schedules must be a non-empty ';'-separated string.")
+    return values
+
+
+def _extract_model_id_from_mapping(mapping: dict[str, Any]) -> str | None:
+    for key in MODEL_ID_KEYS:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _extract_model_id_from_text(text: str) -> str | None:
+    for line in text.splitlines():
+        lower = line.lower().strip()
+        for key in MODEL_ID_KEYS:
+            prefix = f"{key}:"
+            if lower.startswith(prefix):
+                value = line.split(":", 1)[1].strip()
+                if value:
+                    return value
+
+    match = re.search(r"\b([A-Za-z0-9][A-Za-z0-9_.-]*/[A-Za-z0-9][A-Za-z0-9_.-]*)\b", text)
+    if match:
+        return match.group(1)
+    return None
+
+
+def resolve_model_id_from_card(model_card: str) -> str:
+    path = Path(model_card).expanduser()
+    if not path.is_file():
+        return model_card
+
+    suffix = path.suffix.lower()
+    text = path.read_text(encoding="utf-8")
+    if suffix == ".json":
+        payload = json.loads(text)
+        if not isinstance(payload, dict):
+            raise ValueError(f"{path} must contain a JSON object.")
+        model_id = _extract_model_id_from_mapping(payload)
+        if model_id is None:
+            raise ValueError(f"Could not resolve model id from {path}. Expected one of keys: {MODEL_ID_KEYS}")
+        return model_id
+
+    if suffix in {".yaml", ".yml"}:
+        payload = yaml.safe_load(text)
+        if isinstance(payload, dict):
+            model_id = _extract_model_id_from_mapping(payload)
+            if model_id is not None:
+                return model_id
+        raise ValueError(f"Could not resolve model id from {path}. Expected one of keys: {MODEL_ID_KEYS}")
+
+    model_id = _extract_model_id_from_text(text)
+    if model_id is None:
+        raise ValueError(
+            f"Could not resolve model id from model card text at {path}. "
+            f"Expected one of keys {MODEL_ID_KEYS} or a '<org>/<name>' token."
+        )
+    return model_id
+
+
+def needs_scale_search(analysis_summary: dict[str, Any]) -> bool:
+    promoted = analysis_summary.get("promoted_layers", [])
+    for layer in promoted:
+        for patch in layer.get("selected_patches", []):
+            if "matmul_fp32" in patch or patch == "mlp_full_fp32":
+                return True
+    return False
+
+
+@dataclass
+class PrecisionRecoveryAgentRequest:
+    model_card: str
+    prompt: str = "Tell me about yourself."
+    max_input_tokens: int = 64
+    start_layer: int = 22
+    max_layers: int = 0
+    boundary_cache_dir: str = "scripts/debug/artifacts/qwen3_5_moe_window23_cache"
+    analysis_continuation_cache_dir: str = "scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_cache"
+    scale_continuation_cache_dir: str = "scripts/debug/artifacts/qwen3_5_moe_full_depth_mlp_scale_cache"
+    no_continuation_cache: bool = False
+    iterative_mlp_candidates: str = DEFAULT_ITERATIVE_MLP_CANDIDATES
+    scale_candidate_schedules: tuple[str, ...] = DEFAULT_SCALE_CANDIDATE_SCHEDULES
+    default_scale: float = 1.0
+    output_dir: str = "scripts/debug/artifacts/precision_recovery_agent"
+    analysis_output_json: str | None = None
+    recipe_yaml: str | None = None
+    report_json: str | None = None
+
+
+class PrecisionRecoveryAgent:
+    def __init__(self, request: PrecisionRecoveryAgentRequest):
+        self.request = request
+        self.model_id = resolve_model_id_from_card(request.model_card)
+        self.output_dir = Path(request.output_dir).expanduser().resolve()
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def _analysis_output_path(self) -> Path:
+        if self.request.analysis_output_json:
+            return Path(self.request.analysis_output_json).expanduser().resolve()
+        return self.output_dir / "analysis_fp32_recovery.json"
+
+    def _report_path(self) -> Path:
+        if self.request.report_json:
+            return Path(self.request.report_json).expanduser().resolve()
+        return self.output_dir / "agent_report.json"
+
+    def _recipe_path(self) -> Path:
+        if self.request.recipe_yaml:
+            return Path(self.request.recipe_yaml).expanduser().resolve()
+        return self.output_dir / "layer_scales_recipe.yaml"
+
+    def _scale_run_output_path(self, run_idx: int) -> Path:
+        return self.output_dir / f"scale_recovery_run_{run_idx:02d}.json"
+
+    def _write_json(self, path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+
+    def _run_analysis(self) -> dict[str, Any]:
+        request = PrecisionRecoveryRequest(
+            model_id=self.model_id,
+            prompt=self.request.prompt,
+            max_input_tokens=self.request.max_input_tokens,
+            start_layer=self.request.start_layer,
+            max_layers=self.request.max_layers,
+            boundary_cache_dir=self.request.boundary_cache_dir,
+            continuation_cache_dir=self.request.analysis_continuation_cache_dir,
+            no_continuation_cache=self.request.no_continuation_cache,
+            iterative_mlp_candidates=self.request.iterative_mlp_candidates,
+            output_json=str(self._analysis_output_path()),
+        )
+        return run_precision_recovery(request)
+
+    def _scale_recovery_script(self) -> Path:
+        return (
+            Path(__file__).resolve().parents[2] / "scripts" / "debug" / "qwen3_5_moe_full_depth_mlp_scale_recovery.py"
+        )
+
+    def _run_scale_search_once(self, schedule: str, output_json: Path) -> dict[str, Any]:
+        cmd = [
+            sys.executable,
+            str(self._scale_recovery_script()),
+            "--model-id",
+            self.model_id,
+            "--prompt",
+            self.request.prompt,
+            "--max-input-tokens",
+            str(self.request.max_input_tokens),
+            "--start-layer",
+            str(self.request.start_layer),
+            "--max-layers",
+            str(self.request.max_layers),
+            "--boundary-cache-dir",
+            str(Path(self.request.boundary_cache_dir).expanduser().resolve()),
+            "--continuation-cache-dir",
+            str(Path(self.request.scale_continuation_cache_dir).expanduser().resolve()),
+            "--scale-candidates",
+            schedule,
+            "--output-json",
+            str(output_json),
+        ]
+        if self.request.no_continuation_cache:
+            cmd.append("--no-continuation-cache")
+        subprocess.run(cmd, check=True)
+        with open(output_json, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, dict):
+            raise ValueError(f"Scale recovery output must be a JSON object: {output_json}")
+        return payload
+
+    def _run_scale_search_loop(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        runs = []
+        last_result = None
+        for idx, schedule in enumerate(self.request.scale_candidate_schedules, start=1):
+            output_path = self._scale_run_output_path(idx)
+            result = self._run_scale_search_once(schedule=schedule, output_json=output_path)
+            unresolved = result.get("unresolved") is not None
+            runs.append(
+                {
+                    "run_idx": idx,
+                    "scale_candidates": schedule,
+                    "output_json": str(output_path),
+                    "resolved": not unresolved,
+                }
+            )
+            last_result = result
+            if not unresolved:
+                break
+        if last_result is None:
+            raise RuntimeError("Scale search loop did not execute any runs.")
+        return last_result, runs
+
+    def _emit_recipe_yaml(self, scale_recovery_result: dict[str, Any]) -> Path:
+        recipe = build_layer_scale_recipe_from_recovery_result(
+            recovery_result=scale_recovery_result,
+            model_id=self.model_id,
+            default_scale=self.request.default_scale,
+        )
+        return dump_layer_scale_recipe_yaml(
+            recipe=recipe,
+            output_path=self._recipe_path(),
+            include_expanded_specs=True,
+            extra_fields={
+                "Method": "agentic_precision_recovery",
+                "Description": (
+                    "Generated by PrecisionRecoveryAgent. Use with Qwen3.5-MoE post-KV metadata transform runtime."
+                ),
+            },
+        )
+
+    def _runtime_integration_status(self, recipe_yaml: Path | None) -> dict[str, bool]:
+        from QEfficient.transformers.models.modeling_auto import (
+            QEFFAutoModelForCausalLM,
+            QEffCausalLMForTextImageToTextModel,
+            _QEFFAutoModelForImageTextToTextSingleQPC,
+        )
+        from QEfficient.transformers.models.pytorch_transforms import (
+            Qwen3_5MoeLayerScaleMetadataTransform,
+        )
+
+        return {
+            "causal_lm_pipeline_has_transform": (
+                Qwen3_5MoeLayerScaleMetadataTransform in QEFFAutoModelForCausalLM._pytorch_transforms
+            ),
+            "image_text_dual_pipeline_has_transform": (
+                Qwen3_5MoeLayerScaleMetadataTransform in QEffCausalLMForTextImageToTextModel._pytorch_transforms
+            ),
+            "image_text_single_pipeline_has_transform": (
+                Qwen3_5MoeLayerScaleMetadataTransform in _QEFFAutoModelForImageTextToTextSingleQPC._pytorch_transforms
+            ),
+            "recipe_yaml_emitted": recipe_yaml is not None and recipe_yaml.is_file(),
+        }
+
+    def run(self) -> dict[str, Any]:
+        analysis_result = self._run_analysis()
+        analysis_summary = summarize_precision_recovery_result(analysis_result)
+        run_scale_search = needs_scale_search(analysis_summary)
+
+        scale_recovery_result = None
+        scale_search_runs = []
+        recipe_yaml = None
+
+        if run_scale_search:
+            scale_recovery_result, scale_search_runs = self._run_scale_search_loop()
+            if scale_recovery_result.get("unresolved") is None:
+                recipe_yaml = self._emit_recipe_yaml(scale_recovery_result)
+
+        report = {
+            "model_card": self.request.model_card,
+            "model_id": self.model_id,
+            "analysis": {
+                "output_json": str(self._analysis_output_path()),
+                "summary": analysis_summary,
+            },
+            "scale_search": {
+                "required": run_scale_search,
+                "runs": scale_search_runs,
+                "resolved": (scale_recovery_result is not None and scale_recovery_result.get("unresolved") is None),
+            },
+            "recipe_yaml": str(recipe_yaml) if recipe_yaml else None,
+            "runtime_integration": self._runtime_integration_status(recipe_yaml),
+        }
+
+        report_path = self._report_path()
+        self._write_json(report_path, report)
+        report["report_json"] = str(report_path)
+        return report
+
+
+def run_precision_recovery_agent(request: PrecisionRecoveryAgentRequest) -> dict[str, Any]:
+    return PrecisionRecoveryAgent(request).run()

--- a/QEfficient/utils/safetensor_materializer.py
+++ b/QEfficient/utils/safetensor_materializer.py
@@ -24,6 +24,13 @@ from transformers import AutoConfig
 
 from QEfficient.utils import constants
 from QEfficient.utils.constants import QEFF_MODELS_DIR
+from QEfficient.utils.layer_scale_checkpoint import (
+    TensorScaleSpec,
+    apply_layer_scale_recipe_to_loaded_model,
+    build_tensor_scale_specs,
+    inject_layer_scale_metadata_to_loaded_model,
+    load_layer_scale_recipe,
+)
 from QEfficient.utils.logging_utils import logger
 
 QEFF_MATERIALIZED_CHECKPOINT_DIR_ENV = "QEFF_MATERIALIZED_CHECKPOINT_DIR"
@@ -35,6 +42,7 @@ _MARKER_FILE = "qeff_materialized_checkpoint.json"
 _WEIGHT_SUFFIXES = (".safetensors", ".bin", ".pt", ".pth", ".ckpt", ".h5", ".msgpack")
 _QEFF_STREAMING_CHECKPOINT_PATH_KWARG = "_qeff_streaming_checkpoint_path"
 _QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG = "_qeff_streaming_checkpoint_dtype"
+_QEFF_LAYER_SCALE_YAML_KWARG = "qeff_layer_scale_yaml"
 
 _TORCH_DTYPE_TO_CONFIG = {
     torch.float16: "float16",
@@ -255,14 +263,46 @@ def load_hf_model_with_optional_safetensor_streaming(
 ):
     """Load a Hugging Face model, streaming safetensors into a meta model when prepared."""
 
+    layer_scale_recipe_path = kwargs.pop(_QEFF_LAYER_SCALE_YAML_KWARG, None)
+    if layer_scale_recipe_path is not None:
+        layer_scale_recipe_path = str(Path(layer_scale_recipe_path).expanduser().resolve())
+
     streaming_checkpoint_path = kwargs.pop(_QEFF_STREAMING_CHECKPOINT_PATH_KWARG, None)
     streaming_dtype = kwargs.pop(_QEFF_STREAMING_CHECKPOINT_DTYPE_KWARG, None)
     if streaming_checkpoint_path is None:
-        return auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        model = auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        if layer_scale_recipe_path is not None:
+            scale_audit = apply_layer_scale_recipe_to_loaded_model(
+                model=model,
+                recipe_path=layer_scale_recipe_path,
+                strict=True,
+                inject_config_metadata=True,
+            )
+            logger.info(
+                "Applied layer-scale recipe %s to loaded model tensors: scaled=%d missing=%d",
+                layer_scale_recipe_path,
+                scale_audit["scaled_tensor_count"],
+                len(scale_audit["missing_recipe_keys"]),
+            )
+        return model
 
     if args:
         logger.warning("QEfficient streaming checkpoint load does not support positional model args; using HF loader.")
-        return auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        model = auto_class.from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        if layer_scale_recipe_path is not None:
+            scale_audit = apply_layer_scale_recipe_to_loaded_model(
+                model=model,
+                recipe_path=layer_scale_recipe_path,
+                strict=True,
+                inject_config_metadata=True,
+            )
+            logger.info(
+                "Applied layer-scale recipe %s to loaded model tensors: scaled=%d missing=%d",
+                layer_scale_recipe_path,
+                scale_audit["scaled_tensor_count"],
+                len(scale_audit["missing_recipe_keys"]),
+            )
+        return model
 
     config = kwargs.get("config")
     if config is None:
@@ -286,7 +326,14 @@ def load_hf_model_with_optional_safetensor_streaming(
         model = auto_class.from_config(config, **constructor_kwargs)
     if normalized_streaming_dtype is not None:
         _set_config_torch_dtype(getattr(model, "config", None), normalized_streaming_dtype)
-    load_summary = load_safetensor_checkpoint_into_model(model, streaming_checkpoint_path, target_dtype=streaming_dtype)
+    load_summary = load_safetensor_checkpoint_into_model(
+        model,
+        streaming_checkpoint_path,
+        target_dtype=streaming_dtype,
+        layer_scale_recipe_path=layer_scale_recipe_path,
+    )
+    if layer_scale_recipe_path is not None:
+        inject_layer_scale_metadata_to_loaded_model(model=model, recipe_path=layer_scale_recipe_path)
     logger.info(
         "Loaded %s tensors (%s bytes) through QEfficient streaming safetensor loader",
         load_summary.loaded_tensor_count,
@@ -323,16 +370,24 @@ def load_safetensor_checkpoint_into_model(
     model: torch.nn.Module,
     checkpoint_path: Union[str, os.PathLike],
     target_dtype: Any = None,
+    layer_scale_recipe_path: Union[str, os.PathLike, None] = None,
 ) -> StreamingLoadResult:
     """Stream safetensor shards into matching parameters and buffers on CPU."""
 
     checkpoint_path = Path(checkpoint_path).expanduser().resolve()
     layout = _load_safetensor_layout(checkpoint_path)
     normalized_dtype = _normalize_torch_dtype(target_dtype)
+    layer_scale_specs = _load_layer_scale_specs(layer_scale_recipe_path)
 
     expected_parameters = dict(model.named_parameters())
     expected_buffers = dict(model.named_buffers())
     expected_names = set(expected_parameters) | set(expected_buffers)
+    missing_scale_keys = sorted(name for name in layer_scale_specs if name not in expected_names)
+    if missing_scale_keys:
+        raise KeyError(
+            "Layer-scale recipe keys missing from model tensors. "
+            f"Missing={missing_scale_keys[:8]} total_missing={len(missing_scale_keys)}"
+        )
     checkpoint_name_to_shard = _index_safetensor_names(checkpoint_path, layout["shards"])
     legacy_expert_source_names = _collect_legacy_expert_source_names(expected_parameters, checkpoint_name_to_shard)
     loaded_names = set()
@@ -352,6 +407,7 @@ def load_safetensor_checkpoint_into_model(
                 tensor = reader.get_tensor(name)
                 if normalized_dtype is not None and tensor.is_floating_point() and tensor.dtype != normalized_dtype:
                     tensor = tensor.to(dtype=normalized_dtype)
+                tensor = _maybe_apply_layer_scale(tensor, layer_scale_specs.get(name))
                 loaded_tensors.append((name, tensor))
         return loaded_tensors, shard_unexpected_names
 
@@ -372,6 +428,7 @@ def load_safetensor_checkpoint_into_model(
         checkpoint_path,
         checkpoint_name_to_shard,
         normalized_dtype,
+        layer_scale_specs,
     )
     loaded_tensor_count += packed_count
     loaded_tensor_bytes += packed_bytes
@@ -461,6 +518,7 @@ def _materialize_legacy_expert_parameters(
     checkpoint_path: Path,
     checkpoint_name_to_shard: Dict[str, str],
     target_dtype: Optional[torch.dtype],
+    layer_scale_specs: Dict[str, TensorScaleSpec],
 ) -> tuple[int, int, set[str]]:
     loaded_tensor_count = 0
     loaded_tensor_bytes = 0
@@ -481,6 +539,7 @@ def _materialize_legacy_expert_parameters(
             continue
         if tensor is None:
             continue
+        tensor = _maybe_apply_layer_scale(tensor, layer_scale_specs.get(target_name))
         _set_module_tensor(model, target_name, tensor)
         packed_names.add(target_name)
         loaded_tensor_count += 1
@@ -489,6 +548,36 @@ def _materialize_legacy_expert_parameters(
         gc.collect()
 
     return loaded_tensor_count, loaded_tensor_bytes, packed_names
+
+
+def _load_layer_scale_specs(
+    recipe_path: Union[str, os.PathLike, None],
+) -> Dict[str, TensorScaleSpec]:
+    if recipe_path is None:
+        return {}
+    recipe = load_layer_scale_recipe(Path(recipe_path).expanduser().resolve())
+    return {spec.tensor_key: spec for spec in build_tensor_scale_specs(recipe)}
+
+
+def _maybe_apply_layer_scale(tensor: torch.Tensor, spec: Optional[TensorScaleSpec]) -> torch.Tensor:
+    if spec is None:
+        return tensor
+    out = tensor.clone()
+    scalar = out.new_tensor(float(spec.scale))
+    if spec.operation == "scale_all":
+        out.mul_(scalar)
+        return out
+    if spec.operation == "scale_second_half_dim1":
+        if out.ndim < 2:
+            raise ValueError(f"scale_second_half_dim1 requires rank>=2. Got rank={out.ndim}")
+        dim1 = int(out.shape[1])
+        if dim1 % 2 != 0:
+            raise ValueError(f"scale_second_half_dim1 requires even dim1. Got dim1={dim1}")
+        half = dim1 // 2
+        index = (slice(None), slice(half, None), *([slice(None)] * (out.ndim - 2)))
+        out[index].mul_(scalar)
+        return out
+    raise ValueError(f"Unsupported layer-scale operation={spec.operation!r}")
 
 
 def _load_legacy_gate_up_experts(

--- a/examples/image_text_to_text/README.md
+++ b/examples/image_text_to_text/README.md
@@ -110,6 +110,21 @@ Some models have specialized examples demonstrating advanced features:
 
 For reranker examples, see [../reranker/](../reranker/).
 
+### Qwen3.5-MoE YAML Scaling + Layerwise Decode Export
+
+Use this when you want to scale checkpoint shards from a YAML recipe first, then
+load through `QEFFAutoModelForImageTextToText` and export decode-only layerwise ONNX:
+
+```bash
+python models/qwen3_5_moe/qwen3_5_moe_scale_yaml_then_layerwise_decode.py \
+    --model-name Qwen/Qwen3.5-397B-A17B \
+    --recipe-yaml ../../QEfficient/transformers/models/qwen3_5_moe/configs/layer_scales_qwen3_5_397b_mlp_equivalent.yaml \
+    --scaled-dir ../../scripts/debug/artifacts/qwen3_5_397b_scaled_snapshot_v3 \
+    --reuse-scaled-dir \
+    --prefill-seq-len 1 \
+    --layerwise-window-size 1
+```
+
 
 ## Documentation
 - **Full Guide**: [VLM Documentation](../../docs/source/quick_start.md#vision-language-models)

--- a/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe_scale_yaml_then_layerwise_decode.py
+++ b/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe_scale_yaml_then_layerwise_decode.py
@@ -1,0 +1,228 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from huggingface_hub import snapshot_download
+from huggingface_hub.errors import LocalEntryNotFoundError
+from transformers import AutoConfig
+
+from QEfficient import QEFFAutoModelForImageTextToText
+from QEfficient.utils.layer_scale_checkpoint import apply_layer_scale_recipe_to_snapshot
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def _default_recipe_path() -> Path:
+    return (
+        _repo_root()
+        / "QEfficient"
+        / "transformers"
+        / "models"
+        / "qwen3_5_moe"
+        / "configs"
+        / "layer_scales_qwen3_5_397b_mlp_equivalent.yaml"
+    )
+
+
+def _default_scaled_dir() -> Path:
+    return _repo_root() / "scripts" / "debug" / "artifacts" / "qwen3_5_397b_scaled_snapshot"
+
+
+def _default_export_dir() -> Path:
+    return _repo_root() / "scripts" / "debug" / "artifacts" / "qwen3_5_397b_layerwise_decode_onnx"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Scale checkpoint from YAML, load via QEFFAutoModelForImageTextToText, "
+            "and export decode-only layerwise ONNX."
+        )
+    )
+    parser.add_argument("--model-name", default="Qwen/Qwen3.5-397B-A17B")
+    parser.add_argument(
+        "--source-dir",
+        default=None,
+        help="Optional local source snapshot. If not set, resolves --model-name from local cache.",
+    )
+    parser.add_argument(
+        "--allow-download",
+        action="store_true",
+        help="Allow hub download when cache is missing.",
+    )
+    parser.add_argument("--recipe-yaml", default=str(_default_recipe_path()))
+    parser.add_argument("--scaled-dir", default=str(_default_scaled_dir()))
+    parser.add_argument("--export-dir", default=str(_default_export_dir()))
+    parser.add_argument("--reuse-scaled-dir", action="store_true")
+    parser.add_argument("--skip-scaling", action="store_true")
+    parser.add_argument("--layerwise-window-size", type=int, default=1)
+    parser.add_argument("--prefill-seq-len", type=int, default=1)
+    parser.add_argument(
+        "--kv-offload",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use dual-QPC language decoder path when true.",
+    )
+    parser.add_argument("--use-onnx-subfunctions", action="store_true")
+    parser.add_argument("--dtype", choices=["float16", "float32"], default="float16")
+    return parser
+
+
+def _resolve_source_dir(source_dir: str | None, model_name: str, allow_download: bool) -> Path:
+    if source_dir:
+        return Path(source_dir).expanduser().resolve()
+    try:
+        snapshot_path = snapshot_download(
+            repo_id=model_name,
+            allow_patterns=["*.safetensors", "*.json", "*.txt"],
+            local_files_only=not allow_download,
+        )
+    except LocalEntryNotFoundError as exc:
+        raise ValueError(
+            f"Model snapshot for {model_name!r} not found in local cache. "
+            "Pass --source-dir or rerun with --allow-download."
+        ) from exc
+    return Path(snapshot_path).resolve()
+
+
+def _metadata_exists(snapshot_dir: Path) -> bool:
+    config_path = snapshot_dir / "config.json"
+    if not config_path.is_file():
+        return False
+    with open(config_path, "r", encoding="utf-8") as handle:
+        config = json.load(handle)
+    scales = config.get("qeff_layer_scales")
+    if isinstance(scales, dict) and scales:
+        return True
+    text_scales = (config.get("text_config") or {}).get("qeff_layer_scales")
+    return isinstance(text_scales, dict) and bool(text_scales)
+
+
+def _prepare_scaled_snapshot(
+    *,
+    source_dir: Path | None,
+    scaled_dir: Path,
+    recipe_yaml: Path,
+    reuse_scaled_dir: bool,
+    skip_scaling: bool,
+) -> Path:
+    if skip_scaling:
+        if not scaled_dir.is_dir():
+            raise ValueError(f"--skip-scaling set, but scaled snapshot does not exist: {scaled_dir}")
+        return scaled_dir
+
+    if scaled_dir.exists() and any(scaled_dir.iterdir()):
+        if not reuse_scaled_dir:
+            raise ValueError(
+                f"Scaled dir exists and is non-empty: {scaled_dir}. "
+                "Use --reuse-scaled-dir or choose a new --scaled-dir."
+            )
+        return scaled_dir
+
+    if source_dir is None:
+        raise ValueError("source_dir is required when --skip-scaling is not set.")
+
+    scaled_dir.mkdir(parents=True, exist_ok=True)
+    apply_layer_scale_recipe_to_snapshot(
+        source_dir=source_dir,
+        output_dir=scaled_dir,
+        recipe_path=recipe_yaml,
+        strict=True,
+        allow_hardlink_unchanged=True,
+        allow_symlink_unchanged=True,
+        inject_config_metadata=True,
+        audit_json_path=None,
+    )
+    return scaled_dir
+
+
+def _resolve_torch_dtype(dtype_name: str) -> torch.dtype:
+    return torch.float16 if dtype_name == "float16" else torch.float32
+
+
+def _find_qeff_text_model(module):
+    for child in module.modules():
+        if hasattr(child, "_qeff_layer_scaling_enabled") and hasattr(child, "_qeff_layer_scales"):
+            return child
+    raise RuntimeError("Could not find QEff text model with runtime scaling metadata fields.")
+
+
+def _print_runtime_scaling_state(model_wrapper) -> None:
+    text_model = _find_qeff_text_model(model_wrapper.model)
+    layer_scales = getattr(text_model, "_qeff_layer_scales", {})
+    print(f"[runtime_scaling_enabled] {bool(getattr(text_model, '_qeff_layer_scaling_enabled', False))}")
+    print(f"[runtime_scale_default] {float(getattr(text_model, '_qeff_layer_scale_default', 1.0))}")
+    print(f"[runtime_scale_layer22] {layer_scales.get(22)}")
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    dtype = _resolve_torch_dtype(args.dtype)
+
+    source_dir = None
+    if not args.skip_scaling:
+        source_dir = _resolve_source_dir(args.source_dir, args.model_name, args.allow_download)
+    recipe_yaml = Path(args.recipe_yaml).expanduser().resolve()
+    scaled_dir = Path(args.scaled_dir).expanduser().resolve()
+    export_dir = Path(args.export_dir).expanduser().resolve()
+
+    print(f"[source] {source_dir if source_dir else '<unused (skip-scaling)>'}")
+    print(f"[recipe] {recipe_yaml}")
+    print(f"[scaled] {scaled_dir}")
+    print(f"[export_dir] {export_dir}")
+
+    snapshot_dir = _prepare_scaled_snapshot(
+        source_dir=source_dir,
+        scaled_dir=scaled_dir,
+        recipe_yaml=recipe_yaml,
+        reuse_scaled_dir=args.reuse_scaled_dir,
+        skip_scaling=args.skip_scaling,
+    )
+
+    if not _metadata_exists(snapshot_dir):
+        raise RuntimeError(
+            "Scaled snapshot is missing qeff_layer_scales metadata in config.json. "
+            "Regenerate the snapshot from YAML or point to a valid scaled snapshot."
+        )
+
+    config = AutoConfig.from_pretrained(snapshot_dir, local_files_only=True)
+    config.torch_dtype = dtype
+
+    qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
+        str(snapshot_dir),
+        config=config,
+        local_files_only=True,
+        attn_implementation="eager",
+        kv_offload=args.kv_offload,
+        low_cpu_mem_usage=True,
+        dtype=dtype,
+        layerwise=True,
+    )
+
+    _print_runtime_scaling_state(qeff_model)
+
+    onnx_path = qeff_model.export(
+        export_dir=str(export_dir),
+        skip_vision=True,
+        prefill_seq_len=args.prefill_seq_len,
+        layerwise=True,
+        layerwise_window_size=args.layerwise_window_size,
+        use_onnx_subfunctions=args.use_onnx_subfunctions,
+    )
+    print(f"[layerwise_decode_onnx] {onnx_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/text_generation/README.md
+++ b/examples/text_generation/README.md
@@ -159,6 +159,16 @@ Runtime scaling behavior:
 - can be forced with `QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING=1`,
 - can be force-disabled with `QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING=0`,
 - optional external recipe override via `QEFF_QWEN3_5_MOE_LAYER_SCALE_YAML=/path/to/layer_scales.yaml`.
+- for direct inference loading, you can pass `qeff_layer_scale_yaml` into `from_pretrained(...)`:
+```python
+from QEfficient import QEFFAutoModelForCausalLM
+
+qeff_model = QEFFAutoModelForCausalLM.from_pretrained(
+    "/path/to/model_or_hf_id",
+    torch_dtype="float16",
+    qeff_layer_scale_yaml="/path/to/layer_scales.yaml",
+)
+```
 
 ### generate_layer_scale_recipe.py
 Generate a mathematically-equivalent layer-scale recipe YAML from recovery JSON.
@@ -214,6 +224,21 @@ This example:
 - starts an iterative scale-search loop when matmul/MLP fp32 promotions are required,
 - emits a mathematically-equivalent layer-scale YAML recipe when scaling resolves precision issues,
 - records runtime-transform wiring status (causal + image-text auto pipelines) in the final agent report.
+
+Loaded-wrapper API:
+```python
+from QEfficient import QEFFAutoModelForCausalLM
+from QEfficient.utils import run_precision_recovery_agent_from_loaded_qeff_model
+
+qeff_model = QEFFAutoModelForCausalLM.from_pretrained("Qwen/Qwen3.5-397B-A17B")
+report = run_precision_recovery_agent_from_loaded_qeff_model(
+    qeff_model,
+    start_layer=22,
+    max_layers=60,
+    output_dir="scripts/debug/artifacts/precision_recovery_agent",
+)
+print(report["recipe_yaml"])
+```
 
 
 ## CLI Workflow

--- a/examples/text_generation/README.md
+++ b/examples/text_generation/README.md
@@ -117,6 +117,104 @@ This example:
 - Works with Qwen, Mixtral, and other MoE models
 - Supports explicit ONNX subfunction enablement with `--use-onnx-subfunctions`
 
+### precision_recovery_analysis.py
+Layerwise fp16 to fp32 iterative recovery analysis for MoE debugging.
+
+**Usage:**
+```bash
+python precision_recovery_analysis.py \
+    --model-name Qwen/Qwen3.5-397B-A17B \
+    --prompt "Tell me about yourself." \
+    --start-layer 22 \
+    --max-layers 60 \
+    --output-json scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_fp32_recovery_from_api.json
+```
+
+This example:
+- Runs full-depth layerwise comparison: HF fp32 vs HF fp16 vs QEff fp16
+- Detects non-finite layer outputs and applies minimal cumulative fp32 promotions
+- Prioritizes non-matmul fp32 candidates before matmul/full-MLP fallbacks
+- Reports per-layer MAD drift and final next-token predictions for fp32 vs recovered paths
+
+### apply_layer_scales_to_safetensors.py
+Offline checkpoint scaling for mathematically-equivalent fp16 recovery runs.
+
+**Usage:**
+```bash
+python apply_layer_scales_to_safetensors.py \
+    --source-dir /path/to/original_qwen397_snapshot \
+    --output-dir /path/to/scaled_qwen397_snapshot \
+    --recipe-yaml ../../QEfficient/transformers/models/qwen3_5_moe/configs/layer_scales_qwen3_5_397b_mlp_equivalent.yaml
+```
+
+This example:
+- Applies per-layer scale factors to configured safetensor keys only
+- Leaves unchanged shards hard-linked by default for low disk usage
+- Writes `qeff_layer_scale_audit.json` with exact tensors, shards, and before/after stats
+- Injects `qeff_layer_scales` metadata into output `config.json` so QEff decoder runtime applies matching residual scale/unscale
+
+Runtime scaling behavior:
+- default is no-op when no scaling metadata is present,
+- auto-enables when `qeff_layer_scales` exists in model `config.json`,
+- can be forced with `QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING=1`,
+- can be force-disabled with `QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING=0`,
+- optional external recipe override via `QEFF_QWEN3_5_MOE_LAYER_SCALE_YAML=/path/to/layer_scales.yaml`.
+
+### generate_layer_scale_recipe.py
+Generate a mathematically-equivalent layer-scale recipe YAML from recovery JSON.
+
+**Usage:**
+```bash
+python generate_layer_scale_recipe.py \
+    --recovery-json ../../scripts/debug/artifacts/qwen3_5_moe_full_depth_mlp_scale_recovery_full_v2.json \
+    --output-yaml ../../QEfficient/transformers/models/qwen3_5_moe/configs/layer_scales_qwen3_5_397b_mlp_equivalent.yaml \
+    --model-name Qwen/Qwen3.5-397B-A17B
+```
+
+This example:
+- converts selected per-layer scales from recovery output into a reusable YAML recipe,
+- emits explicit `ScaledTensorSpecs` (tensor keys + operations + factors),
+- emits `RuntimeEquivalence` compensation points consumed by runtime guards.
+
+### qwen3_5_397b_scale_and_verify.py
+One-shot Qwen3.5-397B workflow: scale checkpoint and verify full-depth token parity.
+
+**Usage:**
+```bash
+python qwen3_5_397b_scale_and_verify.py \
+    --model-name Qwen/Qwen3.5-397B-A17B \
+    --scaled-dir ../../scripts/debug/artifacts/qwen3_5_397b_scaled_snapshot \
+    --recipe-yaml ../../QEfficient/transformers/models/qwen3_5_moe/configs/layer_scales_qwen3_5_397b_mlp_equivalent.yaml \
+    --compare-output-json ../../scripts/debug/artifacts/qwen3_5_397b_scaled_chunked_compare.json \
+    --strict-token-check
+```
+
+This example:
+- Applies scaling recipe to safetensors (or reuses existing scaled snapshot)
+- Runs full-depth chunked compare over all layers on scaled weights
+- Reports final tokens for HF fp32 / HF fp16 / QEff fp16 and validates expected token id
+- Supports optional runtime YAML override with `--runtime-layer-scale-yaml`
+- Supports forcing no-op scaling path with `--disable-runtime-layer-scaling`
+
+### agentic_precision_recovery.py
+Agent-driven precision-debug pipeline from model card to YAML recipe.
+
+**Usage:**
+```bash
+python agentic_precision_recovery.py \
+    --model-card Qwen/Qwen3.5-397B-A17B \
+    --start-layer 22 \
+    --max-layers 60 \
+    --output-dir ../../scripts/debug/artifacts/precision_recovery_agent_qwen397
+```
+
+This example:
+- accepts either a model card file (`.json/.yaml/.md/.txt`) or direct model id,
+- runs fp32/fp16 layerwise analysis to identify fp32 promotions,
+- starts an iterative scale-search loop when matmul/MLP fp32 promotions are required,
+- emits a mathematically-equivalent layer-scale YAML recipe when scaling resolves precision issues,
+- records runtime-transform wiring status (causal + image-text auto pipelines) in the final agent report.
+
 
 ## CLI Workflow
 

--- a/examples/text_generation/agentic_precision_recovery.py
+++ b/examples/text_generation/agentic_precision_recovery.py
@@ -1,0 +1,120 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Ensure local workspace imports resolve to this repo without requiring PYTHONPATH.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from QEfficient.utils.precision_recovery import DEFAULT_ITERATIVE_MLP_CANDIDATES  # noqa: E402
+from QEfficient.utils.precision_recovery_agent import (  # noqa: E402
+    DEFAULT_SCALE_CANDIDATE_SCHEDULES,
+    PrecisionRecoveryAgentRequest,
+    parse_scale_candidate_schedules,
+    run_precision_recovery_agent,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Agent-driven precision recovery: model card -> fp32/fp16 analysis -> "
+            "conditional scale-search -> YAML recipe emission."
+        )
+    )
+    parser.add_argument(
+        "--model-card",
+        required=True,
+        help=(
+            "Model card path (.json/.yaml/.md/.txt) or direct Hugging Face model id. "
+            "When a card path is provided, model_id/model_name/hf_model_id/repo_id is resolved from it."
+        ),
+    )
+    parser.add_argument("--prompt", default="Tell me about yourself.")
+    parser.add_argument("--max-input-tokens", type=int, default=64)
+    parser.add_argument("--start-layer", type=int, default=22)
+    parser.add_argument("--max-layers", type=int, default=0, help="0 means full model depth")
+    parser.add_argument(
+        "--boundary-cache-dir",
+        default="scripts/debug/artifacts/qwen3_5_moe_window23_cache",
+    )
+    parser.add_argument(
+        "--analysis-continuation-cache-dir",
+        default="scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_cache",
+    )
+    parser.add_argument(
+        "--scale-continuation-cache-dir",
+        default="scripts/debug/artifacts/qwen3_5_moe_full_depth_mlp_scale_cache",
+    )
+    parser.add_argument("--no-continuation-cache", action="store_true")
+    parser.add_argument(
+        "--iterative-mlp-candidates",
+        default=DEFAULT_ITERATIVE_MLP_CANDIDATES,
+        help="Comma-separated fp32 promotion candidates for analysis stage",
+    )
+    parser.add_argument(
+        "--scale-candidate-schedules",
+        default=";".join(DEFAULT_SCALE_CANDIDATE_SCHEDULES),
+        help=(
+            "Semicolon-separated list of scale-candidate schedules. Each schedule is a comma-separated list of floats."
+        ),
+    )
+    parser.add_argument("--default-scale", type=float, default=1.0)
+    parser.add_argument(
+        "--output-dir",
+        default="scripts/debug/artifacts/precision_recovery_agent",
+    )
+    parser.add_argument("--analysis-output-json", default=None)
+    parser.add_argument("--recipe-yaml", default=None)
+    parser.add_argument("--report-json", default=None)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    schedules = parse_scale_candidate_schedules(args.scale_candidate_schedules)
+
+    request = PrecisionRecoveryAgentRequest(
+        model_card=args.model_card,
+        prompt=args.prompt,
+        max_input_tokens=args.max_input_tokens,
+        start_layer=args.start_layer,
+        max_layers=args.max_layers,
+        boundary_cache_dir=args.boundary_cache_dir,
+        analysis_continuation_cache_dir=args.analysis_continuation_cache_dir,
+        scale_continuation_cache_dir=args.scale_continuation_cache_dir,
+        no_continuation_cache=args.no_continuation_cache,
+        iterative_mlp_candidates=args.iterative_mlp_candidates,
+        scale_candidate_schedules=schedules,
+        default_scale=args.default_scale,
+        output_dir=args.output_dir,
+        analysis_output_json=args.analysis_output_json,
+        recipe_yaml=args.recipe_yaml,
+        report_json=args.report_json,
+    )
+
+    report = run_precision_recovery_agent(request)
+    print(f"[model_id] {report['model_id']}")
+    print(f"[analysis_json] {report['analysis']['output_json']}")
+    print(f"[scale_search_required] {report['scale_search']['required']}")
+    print(f"[scale_search_resolved] {report['scale_search']['resolved']}")
+    print(f"[recipe_yaml] {report['recipe_yaml']}")
+    print(f"[report_json] {report['report_json']}")
+
+    summary = report["analysis"]["summary"]
+    print("[promoted_layers]", json.dumps(summary.get("promoted_layers", []), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/text_generation/apply_layer_scales_to_safetensors.py
+++ b/examples/text_generation/apply_layer_scales_to_safetensors.py
@@ -1,0 +1,133 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+from huggingface_hub.errors import LocalEntryNotFoundError
+
+# Ensure local workspace imports resolve to this repo without requiring PYTHONPATH.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from QEfficient.utils.layer_scale_checkpoint import apply_layer_scale_recipe_to_snapshot  # noqa: E402
+
+
+def _default_recipe_path() -> str:
+    return str(
+        Path(__file__).resolve().parents[2]
+        / "QEfficient"
+        / "transformers"
+        / "models"
+        / "qwen3_5_moe"
+        / "configs"
+        / "layer_scales_qwen3_5_397b_mlp_equivalent.yaml"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Apply layer-scale recipe to safetensor snapshots and emit a scaled checkpoint clone.",
+    )
+    parser.add_argument("--output-dir", required=True, help="Destination directory for scaled snapshot")
+    parser.add_argument(
+        "--recipe-yaml",
+        default=_default_recipe_path(),
+        help="Layer scale recipe YAML",
+    )
+    parser.add_argument(
+        "--source-dir",
+        default=None,
+        help="Local source snapshot directory (if omitted, --model-name is used)",
+    )
+    parser.add_argument(
+        "--model-name",
+        default=None,
+        help="Hugging Face model id to resolve snapshot from local cache when --source-dir is not passed",
+    )
+    parser.add_argument(
+        "--allow-download",
+        action="store_true",
+        help="Allow downloading from Hugging Face Hub when model snapshot is not present in local cache.",
+    )
+    parser.add_argument(
+        "--allow-missing-recipe-keys",
+        action="store_true",
+        help="Do not fail if some recipe keys are missing from checkpoint weight_map",
+    )
+    parser.add_argument(
+        "--copy-unchanged",
+        action="store_true",
+        help="Copy unchanged files instead of creating hardlinks",
+    )
+    parser.add_argument(
+        "--no-config-metadata",
+        action="store_true",
+        help="Do not inject qeff layer-scale metadata into output config.json",
+    )
+    parser.add_argument(
+        "--audit-json",
+        default=None,
+        help="Optional custom audit JSON path (default: <output-dir>/qeff_layer_scale_audit.json)",
+    )
+    return parser
+
+
+def _resolve_source_dir(source_dir: str | None, model_name: str | None, allow_download: bool) -> Path:
+    if source_dir:
+        return Path(source_dir).expanduser().resolve()
+    if not model_name:
+        raise ValueError("Pass either --source-dir or --model-name")
+    try:
+        snapshot_path = snapshot_download(
+            repo_id=model_name,
+            allow_patterns=["*.safetensors", "*.json"],
+            local_files_only=not allow_download,
+        )
+    except LocalEntryNotFoundError as exc:
+        raise ValueError(
+            f"Model snapshot for {model_name!r} not found in local cache. "
+            "Pass --source-dir or rerun with --allow-download."
+        ) from exc
+    return Path(snapshot_path).resolve()
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    source_dir = _resolve_source_dir(args.source_dir, args.model_name, args.allow_download)
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    recipe_yaml = Path(args.recipe_yaml).expanduser().resolve()
+
+    print(f"[source] {source_dir}")
+    print(f"[output] {output_dir}")
+    print(f"[recipe] {recipe_yaml}")
+
+    audit = apply_layer_scale_recipe_to_snapshot(
+        source_dir=source_dir,
+        output_dir=output_dir,
+        recipe_path=recipe_yaml,
+        strict=not args.allow_missing_recipe_keys,
+        allow_hardlink_unchanged=not args.copy_unchanged,
+        allow_symlink_unchanged=not args.copy_unchanged,
+        inject_config_metadata=not args.no_config_metadata,
+        audit_json_path=args.audit_json,
+    )
+
+    print(
+        "[summary] "
+        f"layers={audit['touched_layers']} patched_shards={len(audit['patched_shards'])} "
+        f"scaled_tensors={audit['scaled_tensor_count']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/text_generation/generate_layer_scale_recipe.py
+++ b/examples/text_generation/generate_layer_scale_recipe.py
@@ -1,0 +1,78 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Ensure local workspace imports resolve to this repo without requiring PYTHONPATH.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from QEfficient.utils.layer_scale_checkpoint import (  # noqa: E402
+    build_layer_scale_recipe_from_recovery_json,
+    dump_layer_scale_recipe_yaml,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a mathematically-equivalent layer-scale recipe YAML from MLP-scale recovery JSON output."
+        )
+    )
+    parser.add_argument("--recovery-json", required=True, help="Path to recovery JSON (mlp-scale recovery output)")
+    parser.add_argument("--output-yaml", required=True, help="Destination layer-scale recipe YAML")
+    parser.add_argument("--model-name", default=None, help="Optional model id override")
+    parser.add_argument("--default-scale", type=float, default=1.0, help="Default layer scale")
+    parser.add_argument(
+        "--method",
+        default="branch_aware_mlp_scale_equivalent",
+        help="Recipe method field for traceability",
+    )
+    parser.add_argument(
+        "--description",
+        default=(
+            "Auto-generated from recovery JSON. This recipe is valid only for "
+            "checkpoint_scaled_mlp_and_residual_branch runtime equivalence mode."
+        ),
+        help="Recipe description field",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+
+    recipe = build_layer_scale_recipe_from_recovery_json(
+        recovery_json_path=args.recovery_json,
+        model_id=args.model_name,
+        default_scale=args.default_scale,
+    )
+    output_yaml = dump_layer_scale_recipe_yaml(
+        recipe,
+        args.output_yaml,
+        include_expanded_specs=True,
+        extra_fields={
+            "Method": args.method,
+            "Description": args.description,
+            "GeneratedFrom": {
+                "recovery_json": str(Path(args.recovery_json).expanduser().resolve()),
+            },
+        },
+    )
+
+    non_unit_layers = sorted(k for k, v in recipe.layer_scales.items() if float(v) != float(recipe.default_scale))
+    print(f"[write] recipe yaml: {output_yaml}")
+    print(f"[summary] model={recipe.model_id} default_scale={recipe.default_scale} non_unit_layers={non_unit_layers}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/text_generation/precision_recovery_analysis.py
+++ b/examples/text_generation/precision_recovery_analysis.py
@@ -1,0 +1,97 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Ensure local workspace imports resolve to this repo without requiring PYTHONPATH.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from QEfficient.utils.precision_recovery import (  # noqa: E402
+    DEFAULT_ITERATIVE_MLP_CANDIDATES,
+    PrecisionRecoveryRequest,
+    run_precision_recovery,
+    summarize_precision_recovery_result,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Layerwise fp16->fp32 iterative recovery analysis (MAD + token parity).",
+    )
+    parser.add_argument("--model-name", required=True, help="Hugging Face model id")
+    parser.add_argument("--prompt", default="Tell me about yourself.")
+    parser.add_argument("--max-input-tokens", type=int, default=64)
+    parser.add_argument("--start-layer", type=int, default=22)
+    parser.add_argument("--max-layers", type=int, default=0, help="0 means full model depth")
+    parser.add_argument("--boundary-cache-dir", default="scripts/debug/artifacts/qwen3_5_moe_window23_cache")
+    parser.add_argument(
+        "--continuation-cache-dir",
+        default="scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_cache",
+    )
+    parser.add_argument("--no-continuation-cache", action="store_true")
+    parser.add_argument("--iterative-mlp-candidates", default=DEFAULT_ITERATIVE_MLP_CANDIDATES)
+    parser.add_argument(
+        "--output-json",
+        default="scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_fp32_recovery_from_api.json",
+    )
+    parser.add_argument(
+        "--summary-json",
+        default="scripts/debug/artifacts/qwen3_5_moe_full_depth_iterative_fp32_recovery_from_api_summary.json",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    request = PrecisionRecoveryRequest(
+        model_id=args.model_name,
+        prompt=args.prompt,
+        max_input_tokens=args.max_input_tokens,
+        start_layer=args.start_layer,
+        max_layers=args.max_layers,
+        boundary_cache_dir=args.boundary_cache_dir,
+        continuation_cache_dir=args.continuation_cache_dir,
+        no_continuation_cache=args.no_continuation_cache,
+        iterative_mlp_candidates=args.iterative_mlp_candidates,
+        output_json=args.output_json,
+    )
+
+    result = run_precision_recovery(request)
+    summary = summarize_precision_recovery_result(result)
+
+    summary_path = Path(args.summary_json).resolve()
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(summary_path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)
+
+    print(f"[write] summary json: {summary_path}")
+    final_tokens = summary["final_token_prediction"]
+    print(
+        "[tokens] "
+        f"hf_fp32={final_tokens['hf_fp32']['pred_id']}({final_tokens['hf_fp32']['pred_token']!r}) "
+        f"hf_fp16_recovered={final_tokens['hf_fp16_recovered']['pred_id']}({final_tokens['hf_fp16_recovered']['pred_token']!r}) "
+        f"qeff_fp16_recovered={final_tokens['qeff_fp16_recovered']['pred_id']}({final_tokens['qeff_fp16_recovered']['pred_token']!r})"
+    )
+    logits_mad = summary["final_logits_mad"]
+    print(
+        "[final logits mad] "
+        f"hf_fp16_vs_hf_fp32={logits_mad['hf_fp16_vs_hf_fp32']:.6e} "
+        f"qeff_fp16_vs_hf_fp32={logits_mad['qeff_fp16_vs_hf_fp32']:.6e} "
+        f"qeff_fp16_vs_hf_fp16={logits_mad['qeff_fp16_vs_hf_fp16']:.6e}"
+    )
+    print(f"[promoted layers] {summary['promoted_layers']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/text_generation/qwen3_5_397b_scale_and_verify.py
+++ b/examples/text_generation/qwen3_5_397b_scale_and_verify.py
@@ -1,0 +1,282 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+from huggingface_hub.errors import LocalEntryNotFoundError
+
+# Ensure local workspace imports resolve to this repo without requiring PYTHONPATH.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from QEfficient.utils.layer_scale_checkpoint import apply_layer_scale_recipe_to_snapshot  # noqa: E402
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _default_recipe_path() -> Path:
+    return (
+        _repo_root()
+        / "QEfficient"
+        / "transformers"
+        / "models"
+        / "qwen3_5_moe"
+        / "configs"
+        / "layer_scales_qwen3_5_397b_mlp_equivalent.yaml"
+    )
+
+
+def _default_scaled_dir() -> Path:
+    return _repo_root() / "scripts" / "debug" / "artifacts" / "qwen3_5_397b_scaled_snapshot"
+
+
+def _default_compare_json() -> Path:
+    return _repo_root() / "scripts" / "debug" / "artifacts" / "qwen3_5_397b_scaled_chunked_compare.json"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Qwen3.5-397B end-to-end precision recovery verification:\n"
+            "1) apply layer-scale recipe to checkpoint\n"
+            "2) run full-depth chunked compare (HF fp32 / HF fp16 / QEff fp16)\n"
+            "3) validate final token parity"
+        )
+    )
+    parser.add_argument("--model-name", default="Qwen/Qwen3.5-397B-A17B")
+    parser.add_argument(
+        "--source-dir",
+        default=None,
+        help="Local source snapshot path. If omitted, resolves from local Hugging Face cache by --model-name.",
+    )
+    parser.add_argument(
+        "--allow-download",
+        action="store_true",
+        help="Allow downloading from Hugging Face Hub when model snapshot is not present in local cache.",
+    )
+    parser.add_argument("--scaled-dir", default=str(_default_scaled_dir()))
+    parser.add_argument(
+        "--recipe-yaml",
+        default=None,
+        help="Scale recipe YAML used for offline checkpoint scaling. Optional when --skip-scaling is set.",
+    )
+    parser.add_argument("--audit-json", default=None)
+    parser.add_argument("--reuse-scaled-dir", action="store_true")
+    parser.add_argument("--skip-scaling", action="store_true")
+    parser.add_argument(
+        "--runtime-layer-scale-yaml",
+        default=None,
+        help="Optional runtime recipe YAML for model-layer scale metadata (env-driven).",
+    )
+    parser.add_argument(
+        "--disable-runtime-layer-scaling",
+        action="store_true",
+        help="Force-disable runtime layer scaling even if config metadata exists.",
+    )
+    parser.add_argument("--prompt", default="Tell me about yourself.")
+    parser.add_argument("--max-input-tokens", type=int, default=64)
+    parser.add_argument("--chunk-size", type=int, default=4)
+    parser.add_argument("--max-layers", type=int, default=0, help="0 means full depth")
+    parser.add_argument("--compare-output-json", default=str(_default_compare_json()))
+    parser.add_argument("--expected-token-id", type=int, default=198)
+    parser.add_argument("--strict-token-check", action="store_true")
+    return parser
+
+
+def _resolve_source_dir(source_dir: str | None, model_name: str, allow_download: bool) -> Path:
+    if source_dir:
+        return Path(source_dir).expanduser().resolve()
+    try:
+        return Path(
+            snapshot_download(
+                repo_id=model_name,
+                allow_patterns=["*.safetensors", "*.json", "*.txt"],
+                local_files_only=not allow_download,
+            )
+        )
+    except LocalEntryNotFoundError as exc:
+        raise ValueError(
+            f"Model snapshot for {model_name!r} not found in local cache. "
+            "Pass --source-dir or rerun with --allow-download."
+        ) from exc
+
+
+def _has_layer_scale_metadata(model_dir: Path) -> bool:
+    config_path = model_dir / "config.json"
+    if not config_path.is_file():
+        return False
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = json.load(f)
+    if not isinstance(config, dict):
+        return False
+
+    scales = config.get("qeff_layer_scales")
+    if isinstance(scales, dict) and len(scales) > 0:
+        return True
+
+    text_cfg = config.get("text_config")
+    if isinstance(text_cfg, dict):
+        text_scales = text_cfg.get("qeff_layer_scales")
+        if isinstance(text_scales, dict) and len(text_scales) > 0:
+            return True
+
+    return False
+
+
+def _run_chunked_compare(
+    *,
+    model_path: Path,
+    prompt: str,
+    max_input_tokens: int,
+    chunk_size: int,
+    max_layers: int,
+    output_json: Path,
+    runtime_layer_scale_yaml: str | None,
+    disable_runtime_layer_scaling: bool,
+) -> None:
+    script_path = _repo_root() / "scripts" / "debug" / "qwen3_5_moe_chunked_precision_compare.py"
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--model-id",
+        str(model_path),
+        "--prompt",
+        prompt,
+        "--max-input-tokens",
+        str(max_input_tokens),
+        "--chunk-size",
+        str(chunk_size),
+        "--output-json",
+        str(output_json),
+    ]
+    if max_layers > 0:
+        cmd.extend(["--max-layers", str(max_layers)])
+
+    env = dict(os.environ)
+    if disable_runtime_layer_scaling:
+        env["QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING"] = "0"
+        env.pop("QEFF_QWEN3_5_MOE_LAYER_SCALE_YAML", None)
+    elif runtime_layer_scale_yaml:
+        env["QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING"] = "1"
+        env["QEFF_QWEN3_5_MOE_LAYER_SCALE_YAML"] = runtime_layer_scale_yaml
+    subprocess.run(cmd, check=True, env=env)
+
+
+def _extract_final_tokens(compare_json_path: Path) -> dict[str, dict]:
+    with open(compare_json_path, "r", encoding="utf-8") as f:
+        result = json.load(f)
+    preds = result["final"]["predictions"]
+    return {
+        "hf_fp32": preds["hf_fp32"],
+        "hf_fp16": preds["hf_fp16"],
+        "qeff_fp16": preds["qeff_fp16"],
+    }
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+
+    source_dir: Path | None = None
+    scaled_dir = Path(args.scaled_dir).expanduser().resolve()
+    recipe_yaml = Path(args.recipe_yaml).expanduser().resolve() if args.recipe_yaml else _default_recipe_path()
+    runtime_layer_scale_yaml = (
+        str(Path(args.runtime_layer_scale_yaml).expanduser().resolve()) if args.runtime_layer_scale_yaml else None
+    )
+    compare_output_json = Path(args.compare_output_json).expanduser().resolve()
+
+    if not args.skip_scaling:
+        source_dir = _resolve_source_dir(args.source_dir, args.model_name, args.allow_download)
+        print(f"[source] {source_dir}")
+    else:
+        print("[source] <unused (skip-scaling)>")
+    print(f"[scaled] {scaled_dir}")
+    print(f"[recipe] {recipe_yaml if not args.skip_scaling else '<unused (skip-scaling)>'}")
+    if runtime_layer_scale_yaml:
+        print(f"[runtime-layer-scale-yaml] {runtime_layer_scale_yaml}")
+    if args.disable_runtime_layer_scaling:
+        print("[runtime-layer-scaling] disabled")
+
+    if not args.skip_scaling:
+        if scaled_dir.exists() and any(scaled_dir.iterdir()):
+            if not args.reuse_scaled_dir:
+                raise ValueError(
+                    f"Scaled dir already exists and is non-empty: {scaled_dir}. "
+                    "Pass --reuse-scaled-dir or choose a new --scaled-dir."
+                )
+        else:
+            scaled_dir.mkdir(parents=True, exist_ok=True)
+            apply_layer_scale_recipe_to_snapshot(
+                source_dir=source_dir,
+                output_dir=scaled_dir,
+                recipe_path=recipe_yaml,
+                strict=True,
+                allow_hardlink_unchanged=True,
+                allow_symlink_unchanged=True,
+                inject_config_metadata=True,
+                audit_json_path=args.audit_json,
+            )
+    elif not scaled_dir.exists():
+        raise ValueError(f"--skip-scaling was set, but scaled snapshot path does not exist: {scaled_dir}")
+
+    if not args.disable_runtime_layer_scaling and runtime_layer_scale_yaml is None:
+        if not _has_layer_scale_metadata(scaled_dir):
+            raise ValueError(
+                "Scaled snapshot is missing qeff_layer_scales metadata in config.json. "
+                "This usually means the path points to an old/unscaled snapshot. "
+                "Regenerate the scaled snapshot, choose a scaled snapshot directory with metadata, "
+                "or pass --runtime-layer-scale-yaml explicitly."
+            )
+
+    compare_output_json.parent.mkdir(parents=True, exist_ok=True)
+    _run_chunked_compare(
+        model_path=scaled_dir,
+        prompt=args.prompt,
+        max_input_tokens=args.max_input_tokens,
+        chunk_size=args.chunk_size,
+        max_layers=args.max_layers,
+        output_json=compare_output_json,
+        runtime_layer_scale_yaml=runtime_layer_scale_yaml,
+        disable_runtime_layer_scaling=args.disable_runtime_layer_scaling,
+    )
+
+    preds = _extract_final_tokens(compare_output_json)
+    print(
+        "[tokens] "
+        f"hf_fp32={preds['hf_fp32']['pred_id']}({preds['hf_fp32']['pred_token']!r}) "
+        f"hf_fp16={preds['hf_fp16']['pred_id']}({preds['hf_fp16']['pred_token']!r}) "
+        f"qeff_fp16={preds['qeff_fp16']['pred_id']}({preds['qeff_fp16']['pred_token']!r})"
+    )
+    expected = int(args.expected_token_id)
+    all_match = (
+        int(preds["hf_fp32"]["pred_id"]) == expected
+        and int(preds["hf_fp16"]["pred_id"]) == expected
+        and int(preds["qeff_fp16"]["pred_id"]) == expected
+    )
+    print(f"[expected-token] id={expected} all_paths_match={all_match}")
+
+    if args.strict_token_check and not all_match:
+        raise RuntimeError(
+            f"Token mismatch against expected id={expected}: "
+            f"hf_fp32={preds['hf_fp32']['pred_id']} "
+            f"hf_fp16={preds['hf_fp16']['pred_id']} "
+            f"qeff_fp16={preds['qeff_fp16']['pred_id']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/base/test_safetensor_materializer.py
+++ b/tests/base/test_safetensor_materializer.py
@@ -82,6 +82,25 @@ def _write_sharded_tiny_safetensor_checkpoint(path):
         )
 
 
+def _write_embedding_scale_recipe(path, scale=0.5):
+    path.write_text(
+        "\n".join(
+            [
+                "ModelID: tiny-gpt2",
+                "LayerScales:",
+                "  default_scale: 1.0",
+                "  per_layer:",
+                f"    0: {scale}",
+                "TensorScalingRules:",
+                "  - name: token_embedding",
+                "    tensor_template: transformer.wte.weight",
+                "    operation: scale_all",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
 def test_materialize_safetensor_checkpoint_converts_floating_tensors(tmp_path):
     source_path = tmp_path / "source"
     _write_tiny_safetensor_checkpoint(source_path)
@@ -212,3 +231,67 @@ def test_from_pretrained_streams_fp16_checkpoint_without_materialized_copy(tmp_p
 
     assert next(qeff_model.model.parameters()).dtype == torch.float16
     assert not materialized_dir.exists()
+
+
+def test_from_pretrained_applies_layer_scale_yaml_without_streaming(tmp_path):
+    source_path = tmp_path / "source"
+    config = AutoConfig.for_model(
+        "gpt2",
+        n_layer=1,
+        n_head=2,
+        n_embd=8,
+        vocab_size=17,
+        n_positions=16,
+        n_ctx=16,
+    )
+    source_model = AutoModelForCausalLM.from_config(config, attn_implementation="eager").to(torch.float32)
+    source_model.save_pretrained(source_path, safe_serialization=True)
+    expected_wte = source_model.transformer.wte.weight.detach().cpu() * 0.5
+
+    recipe_path = tmp_path / "layer_scales.yaml"
+    _write_embedding_scale_recipe(recipe_path, scale=0.5)
+
+    qeff_model = QEFFAutoModelForCausalLM.from_pretrained(
+        str(source_path),
+        qeff_layer_scale_yaml=str(recipe_path),
+    )
+
+    scaled_wte = qeff_model.model.transformer.wte.weight.detach().cpu()
+    assert torch.allclose(scaled_wte, expected_wte, atol=1e-6, rtol=1e-5)
+    assert qeff_model.model.config.qeff_layer_scales == {"0": 0.5}
+    assert qeff_model.model.config.qeff_layer_scale_default == 1.0
+    assert qeff_model.model.config.qeff_layer_scale_mode == "checkpoint_scaled_mlp_and_residual_branch"
+    assert qeff_model.model.config.qeff_layer_scale_recipe == str(recipe_path.resolve())
+
+
+def test_from_pretrained_streaming_applies_layer_scale_yaml(tmp_path):
+    source_path = tmp_path / "source"
+    config = AutoConfig.for_model(
+        "gpt2",
+        n_layer=1,
+        n_head=2,
+        n_embd=8,
+        vocab_size=17,
+        n_positions=16,
+        n_ctx=16,
+    )
+    source_model = AutoModelForCausalLM.from_config(config, attn_implementation="eager").to(torch.bfloat16)
+    source_model.save_pretrained(source_path, safe_serialization=True)
+    expected_wte = source_model.transformer.wte.weight.detach().cpu().to(torch.float16) * 0.5
+
+    recipe_path = tmp_path / "layer_scales.yaml"
+    _write_embedding_scale_recipe(recipe_path, scale=0.5)
+
+    qeff_model = QEFFAutoModelForCausalLM.from_pretrained(
+        str(source_path),
+        torch_dtype=torch.float16,
+        qeff_layer_scale_yaml=str(recipe_path),
+    )
+
+    scaled_wte = qeff_model.model.transformer.wte.weight.detach().cpu()
+    assert scaled_wte.dtype == torch.float16
+    assert torch.allclose(scaled_wte, expected_wte, atol=1e-3, rtol=1e-3)
+    assert qeff_model.model.config.qeff_layer_scales == {"0": 0.5}
+    assert qeff_model.model.config.qeff_layer_scale_default == 1.0
+    assert qeff_model.model.config.qeff_layer_scale_mode == "checkpoint_scaled_mlp_and_residual_branch"
+    assert qeff_model.model.config.qeff_layer_scale_recipe == str(recipe_path.resolve())

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -1682,6 +1682,35 @@ LAYERWISE_TINY_MODEL_IDS = {
 }
 
 
+def _write_qwen3_5_moe_layer_scale_recipe(path: Path, scale: float = 0.5) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "ModelID: tiny-random/qwen3.5-moe",
+                "LayerScales:",
+                "  default_scale: 1.0",
+                "  per_layer:",
+                f"    0: {scale}",
+                "RuntimeEquivalence:",
+                "  mode: checkpoint_scaled_mlp_and_residual_branch",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _find_qwen3_5_moe_text_model_with_scaling(module):
+    for child in module.modules():
+        if not hasattr(child, "_qeff_layer_scaling_enabled"):
+            continue
+        if not hasattr(child, "_qeff_layer_scales"):
+            continue
+        if not hasattr(child, "layers"):
+            continue
+        return child
+    raise AssertionError("Qwen3.5-MoE text model with runtime scaling metadata was not found")
+
+
 @pytest.mark.llm_model
 def test_layerwise_window_helpers():
     """Pure-Python coverage of the windowing helpers - no model load required."""
@@ -1875,6 +1904,50 @@ def test_layerwise_matches_default_path_for_qwen3_5_moe():
         _layerwise._reset_layer_windows()
 
     assert torch.equal(default_out[0], hidden_states), "Qwen3.5-MoE layerwise logits diverged from default logits"
+
+
+@pytest.mark.llm_model
+def test_qwen3_5_moe_from_pretrained_yaml_invokes_runtime_scaling_transform(tmp_path):
+    """YAML-driven scaling metadata must reach QEff decoder transform wiring."""
+    import QEfficient
+
+    model_id = LAYERWISE_TINY_MODEL_IDS["qwen3_5_moe"]
+    recipe_path = tmp_path / "qwen3_5_moe_layer_scale_recipe.yaml"
+    _write_qwen3_5_moe_layer_scale_recipe(recipe_path, scale=0.5)
+
+    try:
+        config = AutoConfig.from_pretrained(model_id)
+    except Exception as exc:
+        _skip_on_model_fetch_error(exc, model_id)
+    config.torch_dtype = "float32"
+
+    try:
+        qeff_model = QEfficient.QEFFAutoModelForImageTextToText.from_pretrained(
+            model_id,
+            attn_implementation="eager",
+            kv_offload=True,
+            config=config,
+            dtype=torch.float32,
+            qeff_layer_scale_yaml=str(recipe_path),
+            layerwise=False,
+        )
+    except Exception as exc:
+        _skip_on_model_fetch_error(exc, model_id)
+
+    language_decoder = qeff_model.model.get_qeff_language_decoder().model
+    text_model = _find_qwen3_5_moe_text_model_with_scaling(language_decoder)
+    decoder_layer = text_model.layers[0]
+
+    assert text_model._qeff_layer_scaling_enabled is True
+    assert text_model._qeff_layer_scales.get(0) == pytest.approx(0.5)
+    assert text_model._qeff_layer_scale_default == pytest.approx(1.0)
+    assert text_model._qeff_layer_scale_mode == "checkpoint_scaled_mlp_and_residual_branch"
+    assert text_model.config.qeff_layer_scale_recipe == str(recipe_path.resolve())
+
+    assert decoder_layer._qeff_layer_scaling_enabled is True
+    assert decoder_layer._qeff_layer_scales.get(0) == pytest.approx(0.5)
+    assert decoder_layer._qeff_layer_scale_default == pytest.approx(1.0)
+    assert decoder_layer._qeff_layer_scale_mode == "checkpoint_scaled_mlp_and_residual_branch"
 
 
 @pytest.mark.llm_model

--- a/tests/utils/test_layer_scale_checkpoint.py
+++ b/tests/utils/test_layer_scale_checkpoint.py
@@ -1,0 +1,159 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+import json
+
+import pytest
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from QEfficient.utils.layer_scale_checkpoint import (
+    apply_layer_scale_recipe_to_snapshot,
+    build_layer_scale_recipe_from_recovery_result,
+    dump_layer_scale_recipe_yaml,
+    load_layer_scale_recipe,
+)
+
+
+def _write_recipe(recipe_path):
+    recipe_path.write_text(
+        "\n".join(
+            [
+                "ModelID: Qwen/Qwen3.5-397B-A17B",
+                "LayerScales:",
+                "  default_scale: 1.0",
+                "  per_layer:",
+                "    22: 0.5",
+                "TensorScalingRules:",
+                "  - name: experts_gate_up_proj_up_half",
+                "    tensor_template: model.language_model.layers.{layer_idx}.mlp.experts.gate_up_proj",
+                "    operation: scale_second_half_dim1",
+                "  - name: shared_expert_up_proj",
+                "    tensor_template: model.language_model.layers.{layer_idx}.mlp.shared_expert.up_proj.weight",
+                "    operation: scale_all",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_apply_layer_scale_recipe_to_snapshot(tmp_path):
+    source_dir = tmp_path / "src_snapshot"
+    source_dir.mkdir(parents=True)
+
+    gate_up = torch.arange(2 * 6 * 4, dtype=torch.float16).view(2, 6, 4)
+    shared_up = torch.arange(12, dtype=torch.float16).view(3, 4)
+    save_file(
+        {
+            "model.language_model.layers.22.mlp.experts.gate_up_proj": gate_up,
+            "model.language_model.layers.22.mlp.shared_expert.up_proj.weight": shared_up,
+            "untouched.tensor": torch.ones(5, dtype=torch.float16),
+        },
+        str(source_dir / "model-00001-of-00001.safetensors"),
+    )
+
+    index = {
+        "metadata": {"total_size": 0},
+        "weight_map": {
+            "model.language_model.layers.22.mlp.experts.gate_up_proj": "model-00001-of-00001.safetensors",
+            "model.language_model.layers.22.mlp.shared_expert.up_proj.weight": "model-00001-of-00001.safetensors",
+            "untouched.tensor": "model-00001-of-00001.safetensors",
+        },
+    }
+    (source_dir / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+    (source_dir / "config.json").write_text(
+        json.dumps({"model_type": "qwen3_5_moe", "text_config": {"model_type": "qwen3_5_moe_text"}}),
+        encoding="utf-8",
+    )
+
+    recipe_path = tmp_path / "recipe.yaml"
+    _write_recipe(recipe_path)
+
+    out_dir = tmp_path / "scaled_snapshot"
+    audit = apply_layer_scale_recipe_to_snapshot(
+        source_dir=source_dir,
+        output_dir=out_dir,
+        recipe_path=recipe_path,
+        allow_hardlink_unchanged=False,
+    )
+
+    assert audit["scaled_tensor_count"] == 2
+    assert audit["patched_shards"] == ["model-00001-of-00001.safetensors"]
+    assert audit["touched_layers"] == [22]
+
+    with safe_open(str(out_dir / "model-00001-of-00001.safetensors"), framework="pt", device="cpu") as sf:
+        scaled_gate_up = sf.get_tensor("model.language_model.layers.22.mlp.experts.gate_up_proj")
+        scaled_shared_up = sf.get_tensor("model.language_model.layers.22.mlp.shared_expert.up_proj.weight")
+        untouched = sf.get_tensor("untouched.tensor")
+
+    assert torch.equal(scaled_gate_up[:, :3, :], gate_up[:, :3, :])
+    assert torch.equal(scaled_gate_up[:, 3:, :], gate_up[:, 3:, :] * 0.5)
+    assert torch.equal(scaled_shared_up, shared_up * 0.5)
+    assert torch.equal(untouched, torch.ones(5, dtype=torch.float16))
+
+    cfg = json.loads((out_dir / "config.json").read_text(encoding="utf-8"))
+    assert cfg["qeff_layer_scales"] == {"22": 0.5}
+    assert cfg["qeff_layer_scale_default"] == 1.0
+    assert cfg["text_config"]["qeff_layer_scales"] == {"22": 0.5}
+
+
+def test_load_layer_scale_recipe_rejects_mode_mismatch(tmp_path):
+    recipe_path = tmp_path / "bad_recipe.yaml"
+    recipe_path.write_text(
+        "\n".join(
+            [
+                "ModelID: Qwen/Qwen3.5-397B-A17B",
+                "LayerScales:",
+                "  default_scale: 1.0",
+                "  per_layer:",
+                "    22: 0.5",
+                "RuntimeEquivalence:",
+                "  mode: checkpoint_scaled_mlp_and_residual_branch",
+                "ConfigMetadata:",
+                "  mode_value: some_other_mode",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="mode_value must match RuntimeEquivalence.mode"):
+        load_layer_scale_recipe(recipe_path)
+
+
+def test_build_layer_scale_recipe_from_recovery_result(tmp_path):
+    recovery_result = {
+        "config": {"model_id": "Qwen/Qwen3.5-397B-A17B"},
+        "unresolved": None,
+        "layers": [
+            {
+                "layer_idx": 22,
+                "resolved": True,
+                "selected_scale": 0.125,
+                "final_variant": {"layer_out_finite_ratio": {"hf_fp16": 1.0, "qeff_fp16": 1.0}},
+            },
+            {
+                "layer_idx": 23,
+                "resolved": True,
+                "selected_scale": 1.0,
+                "final_variant": {"layer_out_finite_ratio": {"hf_fp16": 1.0, "qeff_fp16": 1.0}},
+            },
+        ],
+    }
+
+    recipe = build_layer_scale_recipe_from_recovery_result(
+        recovery_result=recovery_result,
+        default_scale=1.0,
+    )
+    assert recipe.model_id == "Qwen/Qwen3.5-397B-A17B"
+    assert recipe.layer_scales == {22: 0.125}
+    assert recipe.config_mode_value == "checkpoint_scaled_mlp_and_residual_branch"
+
+    out_yaml = tmp_path / "generated_recipe.yaml"
+    dump_layer_scale_recipe_yaml(recipe, out_yaml, include_expanded_specs=True)
+    loaded = load_layer_scale_recipe(out_yaml)
+    assert loaded.layer_scales == {22: 0.125}

--- a/tests/utils/test_precision_recovery_agent.py
+++ b/tests/utils/test_precision_recovery_agent.py
@@ -6,13 +6,17 @@
 # -----------------------------------------------------------------------------
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
 from QEfficient.utils.precision_recovery_agent import (
+    PrecisionRecoveryAgentRequest,
     needs_scale_search,
     parse_scale_candidate_schedules,
+    resolve_model_card_from_loaded_qeff_model,
     resolve_model_id_from_card,
+    run_precision_recovery_agent_from_loaded_qeff_model,
 )
 
 
@@ -76,3 +80,51 @@ def test_needs_scale_search_true_when_matmul_or_mlp_promoted():
         ]
     }
     assert needs_scale_search(summary) is True
+
+
+def test_resolve_model_card_from_loaded_qeff_model_uses_wrapper_attr(tmp_path):
+    model_dir = tmp_path / "cached_model"
+    model_dir.mkdir()
+    qeff_model = SimpleNamespace(_pretrained_model_name_or_path=str(model_dir))
+
+    resolved = resolve_model_card_from_loaded_qeff_model(qeff_model)
+
+    assert resolved == str(model_dir.resolve())
+
+
+def test_resolve_model_card_from_loaded_qeff_model_uses_nested_model_attr():
+    qeff_model = SimpleNamespace(model=SimpleNamespace(pretrained_path="Qwen/Qwen3.5-397B-A17B"))
+
+    resolved = resolve_model_card_from_loaded_qeff_model(qeff_model)
+
+    assert resolved == "Qwen/Qwen3.5-397B-A17B"
+
+
+def test_resolve_model_card_from_loaded_qeff_model_errors_when_unavailable():
+    with pytest.raises(ValueError, match="Could not resolve model card/model id"):
+        resolve_model_card_from_loaded_qeff_model(SimpleNamespace())
+
+
+def test_run_precision_recovery_agent_from_loaded_qeff_model_builds_request(monkeypatch):
+    captured = {}
+
+    def _fake_runner(request):
+        captured["request"] = request
+        return {"ok": True, "model_id": "Qwen/Qwen3.5-397B-A17B"}
+
+    monkeypatch.setattr("QEfficient.utils.precision_recovery_agent.run_precision_recovery_agent", _fake_runner)
+    qeff_model = SimpleNamespace(model=SimpleNamespace(pretrained_path="Qwen/Qwen3.5-397B-A17B"))
+
+    report = run_precision_recovery_agent_from_loaded_qeff_model(
+        qeff_model,
+        prompt="Hello",
+        max_layers=2,
+        output_dir="scripts/debug/artifacts/agent_test",
+    )
+
+    assert report["ok"] is True
+    request = captured["request"]
+    assert isinstance(request, PrecisionRecoveryAgentRequest)
+    assert request.model_card == "Qwen/Qwen3.5-397B-A17B"
+    assert request.prompt == "Hello"
+    assert request.max_layers == 2

--- a/tests/utils/test_precision_recovery_agent.py
+++ b/tests/utils/test_precision_recovery_agent.py
@@ -1,0 +1,78 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+import json
+
+import pytest
+
+from QEfficient.utils.precision_recovery_agent import (
+    needs_scale_search,
+    parse_scale_candidate_schedules,
+    resolve_model_id_from_card,
+)
+
+
+def test_parse_scale_candidate_schedules_defaults():
+    schedules = parse_scale_candidate_schedules(None)
+    assert len(schedules) == 1
+    assert schedules[0].startswith("1.0")
+
+
+def test_parse_scale_candidate_schedules_semicolon_separated():
+    schedules = parse_scale_candidate_schedules("1.0,0.5;1.0,0.25")
+    assert schedules == ("1.0,0.5", "1.0,0.25")
+
+
+def test_parse_scale_candidate_schedules_rejects_empty():
+    with pytest.raises(ValueError, match="non-empty"):
+        parse_scale_candidate_schedules(" ; ")
+
+
+def test_resolve_model_id_from_card_direct_id_passthrough():
+    assert resolve_model_id_from_card("Qwen/Qwen3.5-397B-A17B") == "Qwen/Qwen3.5-397B-A17B"
+
+
+def test_resolve_model_id_from_card_json(tmp_path):
+    card_path = tmp_path / "model_card.json"
+    card_path.write_text(json.dumps({"model_id": "Qwen/Qwen3.5-397B-A17B"}), encoding="utf-8")
+    assert resolve_model_id_from_card(str(card_path)) == "Qwen/Qwen3.5-397B-A17B"
+
+
+def test_resolve_model_id_from_card_yaml(tmp_path):
+    card_path = tmp_path / "model_card.yaml"
+    card_path.write_text("model_name: Qwen/Qwen3.5-397B-A17B\n", encoding="utf-8")
+    assert resolve_model_id_from_card(str(card_path)) == "Qwen/Qwen3.5-397B-A17B"
+
+
+def test_resolve_model_id_from_card_markdown(tmp_path):
+    card_path = tmp_path / "README.md"
+    card_path.write_text("This card targets Qwen/Qwen3.5-397B-A17B for eval.\n", encoding="utf-8")
+    assert resolve_model_id_from_card(str(card_path)) == "Qwen/Qwen3.5-397B-A17B"
+
+
+def test_needs_scale_search_false_when_no_matmul_or_mlp_promotions():
+    summary = {
+        "promoted_layers": [
+            {
+                "layer_idx": 22,
+                "selected_patches": ["sparse_moe_post_ops_fp32"],
+            }
+        ]
+    }
+    assert needs_scale_search(summary) is False
+
+
+def test_needs_scale_search_true_when_matmul_or_mlp_promoted():
+    summary = {
+        "promoted_layers": [
+            {
+                "layer_idx": 22,
+                "selected_patches": ["shared_expert_matmul_fp32_keep_fp32"],
+            }
+        ]
+    }
+    assert needs_scale_search(summary) is True

--- a/tests/utils/test_qwen3_5_moe_layer_scale_transform_wiring.py
+++ b/tests/utils/test_qwen3_5_moe_layer_scale_transform_wiring.py
@@ -1,0 +1,34 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from QEfficient.transformers.models.modeling_auto import (
+    QEFFAutoModelForCausalLM,
+    QEffCausalLMForTextImageToTextModel,
+    _QEFFAutoModelForImageTextToTextSingleQPC,
+)
+from QEfficient.transformers.models.pytorch_transforms import (
+    KVCacheTransform,
+    Qwen3_5MoeLayerScaleMetadataTransform,
+)
+
+
+def _assert_transform_after_kvcache(pipeline):
+    kv_idx = pipeline.index(KVCacheTransform)
+    scale_idx = pipeline.index(Qwen3_5MoeLayerScaleMetadataTransform)
+    assert scale_idx == kv_idx + 1
+
+
+def test_qwen3_5_moe_scale_transform_wired_for_causal_lm():
+    _assert_transform_after_kvcache(QEFFAutoModelForCausalLM._pytorch_transforms)
+
+
+def test_qwen3_5_moe_scale_transform_wired_for_image_text_dual_lang_path():
+    _assert_transform_after_kvcache(QEffCausalLMForTextImageToTextModel._pytorch_transforms)
+
+
+def test_qwen3_5_moe_scale_transform_wired_for_image_text_single_path():
+    _assert_transform_after_kvcache(_QEFFAutoModelForImageTextToTextSingleQPC._pytorch_transforms)

--- a/tests/utils/test_qwen3_5_moe_layer_scaling_runtime.py
+++ b/tests/utils/test_qwen3_5_moe_layer_scaling_runtime.py
@@ -1,0 +1,64 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from types import SimpleNamespace
+
+import pytest
+
+from QEfficient.transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import _resolve_layer_scale_runtime_config
+
+
+def test_qwen3_5_moe_runtime_scaling_default_noop(monkeypatch):
+    monkeypatch.delenv("QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING", raising=False)
+    monkeypatch.delenv("QEFF_QWEN3_5_MOE_LAYER_SCALE_YAML", raising=False)
+    enabled, scales, default_scale, mode = _resolve_layer_scale_runtime_config(SimpleNamespace())
+    assert enabled is False
+    assert scales == {}
+    assert default_scale == 1.0
+    assert mode == "checkpoint_scaled_mlp_and_residual_branch"
+
+
+def test_qwen3_5_moe_runtime_scaling_from_config(monkeypatch):
+    monkeypatch.delenv("QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING", raising=False)
+    monkeypatch.delenv("QEFF_QWEN3_5_MOE_LAYER_SCALE_YAML", raising=False)
+    cfg = SimpleNamespace(
+        qeff_layer_scales={"22": 0.125},
+        qeff_layer_scale_default=1.0,
+        qeff_layer_scale_mode="checkpoint_scaled_mlp_and_residual_branch",
+    )
+    enabled, scales, default_scale, mode = _resolve_layer_scale_runtime_config(cfg)
+    assert enabled is True
+    assert scales == {22: 0.125}
+    assert default_scale == 1.0
+    assert mode == "checkpoint_scaled_mlp_and_residual_branch"
+
+
+def test_qwen3_5_moe_runtime_scaling_rejects_unknown_mode(monkeypatch):
+    monkeypatch.delenv("QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING", raising=False)
+    monkeypatch.delenv("QEFF_QWEN3_5_MOE_LAYER_SCALE_YAML", raising=False)
+    cfg = SimpleNamespace(
+        qeff_layer_scales={"22": 0.125},
+        qeff_layer_scale_default=1.0,
+        qeff_layer_scale_mode="unsupported_mode",
+    )
+    with pytest.raises(ValueError, match="Unsupported qeff layer-scale mode"):
+        _resolve_layer_scale_runtime_config(cfg)
+
+
+def test_qwen3_5_moe_runtime_scaling_env_disable_forces_noop(monkeypatch):
+    monkeypatch.setenv("QEFF_QWEN3_5_MOE_ENABLE_LAYER_SCALING", "0")
+    monkeypatch.delenv("QEFF_QWEN3_5_MOE_LAYER_SCALE_YAML", raising=False)
+    cfg = SimpleNamespace(
+        qeff_layer_scales={"22": 0.125},
+        qeff_layer_scale_default=1.0,
+        qeff_layer_scale_mode="checkpoint_scaled_mlp_and_residual_branch",
+    )
+    enabled, scales, default_scale, mode = _resolve_layer_scale_runtime_config(cfg)
+    assert enabled is False
+    assert scales == {}
+    assert default_scale == 1.0
+    assert mode == "checkpoint_scaled_mlp_and_residual_branch"


### PR DESCRIPTION
## Summary
- add `qeff_layer_scale_yaml` handling in the safetensor materialization/load path so `from_pretrained(...)` can apply YAML tensor scaling for both standard and streaming checkpoint loads
- inject layer-scale metadata onto loaded configs so runtime transforms pick up scaling/descaling placement without requiring pre-scaled snapshots
- add helper APIs for loaded-wrapper precision-recovery workflows (`resolve_model_card_from_loaded_qeff_model`, `run_precision_recovery_agent_from_loaded_qeff_model`)
- add regression coverage for:
  - YAML scaling on non-streaming and streaming `from_pretrained`
  - runtime transform wiring for Qwen3.5-MoE from YAML-loaded models
  - loaded-wrapper model-card resolution for precision-recovery agent
- keep Qwen3-VL-MoE tensor orientation compatibility fix required by quickcheck parity

## Validation
- `/home/anujgupt/qeff_env2/bin/python -m ruff format --check QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py QEfficient/utils/__init__.py QEfficient/utils/layer_scale_checkpoint.py QEfficient/utils/precision_recovery_agent.py QEfficient/utils/safetensor_materializer.py tests/base/test_safetensor_materializer.py tests/unit_test/models/test_model_quickcheck.py tests/utils/test_precision_recovery_agent.py`
- `/home/anujgupt/qeff_env2/bin/python -m ruff check QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py QEfficient/utils/__init__.py QEfficient/utils/layer_scale_checkpoint.py QEfficient/utils/precision_recovery_agent.py QEfficient/utils/safetensor_materializer.py tests/base/test_safetensor_materializer.py tests/unit_test/models/test_model_quickcheck.py tests/utils/test_precision_recovery_agent.py`
- `/home/anujgupt/qeff_env2/bin/python -m pytest tests/base/test_safetensor_materializer.py -q`
- `/home/anujgupt/qeff_env2/bin/python -m pytest tests/utils/test_precision_recovery_agent.py -q`
- `HF_HUB_CACHE=/home/anujgupt/.cache/hf_hub /home/anujgupt/qeff_env2/bin/python -m pytest tests/unit_test/models/test_model_quickcheck.py -q`

## Notes
- Full quickcheck is green with a user-writable HF cache (`176 passed, 3 skipped`).
- This PR is based on PR1052 branch (`debug/whole-model-memory-pr1047`) per dependency on materialization infrastructure.
