### PR TITLE
Bug fixes for missing kv_cache_buffer

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -36,6 +36,7 @@ from QEfficient.transformers.models.pytorch_transforms import (
 )
 from QEfficient.utils import (
     align_kv_input_names_to_retained_outputs,
+    apply_kv_cache_prefix,
     constants,
     create_json,
     create_model_params,
@@ -505,6 +506,7 @@ class QEFFBaseModel(ABC):
         export_dir: Optional[str] = None,
         offload_pt_weights: bool = True,
         prefill_only: Optional[bool] = False,
+        kv_cache_prefix: Optional[str] = None,
         **export_kwargs,
     ) -> str:
         cache_probe = export_kwargs.pop("_layerwise_cache_probe", False)
@@ -590,47 +592,24 @@ class QEFFBaseModel(ABC):
         retained_state_suffix = (
             "_InternalRetainedState" if export_kwargs.get("use_onnx_subfunctions", False) else "_RetainedState"
         )
-        # Build a lookup from plain default retained-state names to the caller-supplied names so that
-        # any KV-cache prefix injected by the caller (e.g. "past_key.3_vllmKvCache_RetainedState")
-        # is preserved in the per-window ONNX and therefore in the final stitched merged ONNX.
-        # Key: "past_key.3_RetainedState" (or _InternalRetainedState), Value: caller's prefixed name.
-        _kv_stems = ("past_key.", "past_value.", "compressed_kv.", "k_pe.")
-        _caller_retained_map: dict = {}
-        for _name in output_names:
-            for _sfx in ("_InternalRetainedState", "_RetainedState"):
-                if not _name.endswith(_sfx):
-                    continue
-                _stem = _name[: -len(_sfx)]  # e.g. "past_key.3_vllmKvCache"
-                if not any(_stem.startswith(_ks) for _ks in _kv_stems):
-                    break
-                # Derive the plain stem (without any infix) by keeping only "prefix.N".
-                # "past_key.3_vllmKvCache" → dot-split gives ["past_key", "3_vllmKvCache"];
-                # strip everything after the first "_" in the layer part.
-                _parts = _stem.split(".", 1)
-                if len(_parts) == 2:
-                    _layer_part = _parts[1].split("_", 1)[0]  # "3" from "3_vllmKvCache"
-                    _plain_stem = f"{_parts[0]}.{_layer_part}"  # "past_key.3"
-                else:
-                    _plain_stem = _stem
-                # Register under both suffix forms so the lookup succeeds regardless of
-                # whether the caller used _RetainedState or _InternalRetainedState.
-                for _reg_sfx in ("_RetainedState", "_InternalRetainedState"):
-                    _key = f"{_plain_stem}{_reg_sfx}"
-                    # Rewrite the stored name's suffix to match retained_state_suffix at lookup time.
-                    _stored = f"{_stem}{retained_state_suffix}"
-                    _caller_retained_map[_key] = _stored
-                break
-
         for layer_idx in range(idx, end_idx):
             layer_states = _resolve_pkv_layers(example_inputs.get("past_key_values"))
             if layer_states is None:
-                for _stem in (f"past_key.{layer_idx}", f"past_value.{layer_idx}"):
-                    _default = f"{_stem}{retained_state_suffix}"
-                    output_name.append(_caller_retained_map.get(_default, _default))
+                output_name.append(f"past_key.{layer_idx}{retained_state_suffix}")
+                output_name.append(f"past_value.{layer_idx}{retained_state_suffix}")
             else:
-                for _stem_name in _resolve_pkv_names(layer_idx, layer_states[layer_idx]):
-                    _default = f"{_stem_name}{retained_state_suffix}"
-                    output_name.append(_caller_retained_map.get(_default, _default))
+                output_name.extend(
+                    [
+                        f"{name}{retained_state_suffix}"
+                        for name in _resolve_pkv_names(layer_idx, layer_states[layer_idx])
+                    ]
+                )
+
+        # Inject the optional vLLM KV-cache prefix into the freshly built per-window output names
+        # (past_key.3_RetainedState -> past_key.3_<prefix>_RetainedState), using the same helper the
+        # non-layerwise paths use. The matching input buffers are renamed to pair with these outputs
+        # just below via align_kv_input_names_to_retained_outputs. No-op when kv_cache_prefix is falsy.
+        output_name = apply_kv_cache_prefix(output_name, kv_cache_prefix)
 
         # For some decoder wrappers (e.g. VLM language wrappers), forward does not accept
         # `inputs_embeds`; keep `input_ids` in those cases.

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -590,18 +590,47 @@ class QEFFBaseModel(ABC):
         retained_state_suffix = (
             "_InternalRetainedState" if export_kwargs.get("use_onnx_subfunctions", False) else "_RetainedState"
         )
+        # Build a lookup from plain default retained-state names to the caller-supplied names so that
+        # any KV-cache prefix injected by the caller (e.g. "past_key.3_vllmKvCache_RetainedState")
+        # is preserved in the per-window ONNX and therefore in the final stitched merged ONNX.
+        # Key: "past_key.3_RetainedState" (or _InternalRetainedState), Value: caller's prefixed name.
+        _kv_stems = ("past_key.", "past_value.", "compressed_kv.", "k_pe.")
+        _caller_retained_map: dict = {}
+        for _name in output_names:
+            for _sfx in ("_InternalRetainedState", "_RetainedState"):
+                if not _name.endswith(_sfx):
+                    continue
+                _stem = _name[: -len(_sfx)]  # e.g. "past_key.3_vllmKvCache"
+                if not any(_stem.startswith(_ks) for _ks in _kv_stems):
+                    break
+                # Derive the plain stem (without any infix) by keeping only "prefix.N".
+                # "past_key.3_vllmKvCache" → dot-split gives ["past_key", "3_vllmKvCache"];
+                # strip everything after the first "_" in the layer part.
+                _parts = _stem.split(".", 1)
+                if len(_parts) == 2:
+                    _layer_part = _parts[1].split("_", 1)[0]  # "3" from "3_vllmKvCache"
+                    _plain_stem = f"{_parts[0]}.{_layer_part}"  # "past_key.3"
+                else:
+                    _plain_stem = _stem
+                # Register under both suffix forms so the lookup succeeds regardless of
+                # whether the caller used _RetainedState or _InternalRetainedState.
+                for _reg_sfx in ("_RetainedState", "_InternalRetainedState"):
+                    _key = f"{_plain_stem}{_reg_sfx}"
+                    # Rewrite the stored name's suffix to match retained_state_suffix at lookup time.
+                    _stored = f"{_stem}{retained_state_suffix}"
+                    _caller_retained_map[_key] = _stored
+                break
+
         for layer_idx in range(idx, end_idx):
             layer_states = _resolve_pkv_layers(example_inputs.get("past_key_values"))
             if layer_states is None:
-                output_name.append(f"past_key.{layer_idx}{retained_state_suffix}")
-                output_name.append(f"past_value.{layer_idx}{retained_state_suffix}")
+                for _stem in (f"past_key.{layer_idx}", f"past_value.{layer_idx}"):
+                    _default = f"{_stem}{retained_state_suffix}"
+                    output_name.append(_caller_retained_map.get(_default, _default))
             else:
-                output_name.extend(
-                    [
-                        f"{name}{retained_state_suffix}"
-                        for name in _resolve_pkv_names(layer_idx, layer_states[layer_idx])
-                    ]
-                )
+                for _stem_name in _resolve_pkv_names(layer_idx, layer_states[layer_idx]):
+                    _default = f"{_stem_name}{retained_state_suffix}"
+                    output_name.append(_caller_retained_map.get(_default, _default))
 
         # For some decoder wrappers (e.g. VLM language wrappers), forward does not accept
         # `inputs_embeds`; keep `input_ids` in those cases.
@@ -677,6 +706,13 @@ class QEFFBaseModel(ABC):
         layer_onnx_path = str(current_layer_dir / f"{self.model_name}_layer_{idx}_{end_idx}.onnx")
         layer_onnx_path_tmp = str(current_layer_dir / f"{self.model_name}_layer_tmp_{idx}_{end_idx}.onnx")
         output_names = output_name
+        # Align KV input names to match any prefix injected into the retained-state output names
+        # (e.g. past_key.3 → past_key.3_vllmKvCache when output is past_key.3_vllmKvCache_RetainedState).
+        aligned_input_names = align_kv_input_names_to_retained_outputs(input_names, output_names)
+        if aligned_input_names != input_names:
+            rename_map = {old: new for old, new in zip(input_names, aligned_input_names) if old != new}
+            dynamic_axes = {rename_map.get(k, k): v for k, v in dynamic_axes.items()}
+            input_names = aligned_input_names
         if not os.path.isfile(layer_onnx_path):
             torch.onnx.export(
                 self.model,

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1246,6 +1246,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
         prefill_seq_len: Optional[int] = None,
         prefill_only: bool = False,
         enable_chunking: bool = False,
+        kv_cache_prefix: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -1292,6 +1293,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
                 offload_pt_weights=offload_pt_weights,
                 use_onnx_subfunctions=kwargs.get("use_onnx_subfunctions", False),
                 _layerwise_cache_probe=kwargs.get("_layerwise_cache_probe", False),
+                kv_cache_prefix=kv_cache_prefix,
             )
         else:
             return self._export(
@@ -1608,6 +1610,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 enable_chunking=enable_chunking,
                 prefill_seq_len=prefill_seq_len,
                 _layerwise_cache_probe=layerwise_cache_probe,
+                kv_cache_prefix=kv_cache_prefix,
             )
         return self.onnx_path
 
@@ -4001,6 +4004,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                 use_onnx_subfunctions=kwargs.get("use_onnx_subfunctions", False),
                 offload_pt_weights=kwargs.get("offload_pt_weights", True),
                 prefill_only=prefill_only,
+                kv_cache_prefix=kv_cache_prefix,
             )
         else:
             return self._export(

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1529,6 +1529,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 prefill_only=prefill_only,
                 enable_chunking=enable_chunking,
                 layerwise_window_size=layerwise_window_size,
+                kv_cache_prefix=kv_cache_prefix,
                 **kwargs,
             )
         dummy_inputs_kwargs = {}
@@ -1874,6 +1875,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                     prefill_only=prefill_only,
                     enable_chunking=enable_chunking,
                     qaic_config=qaic_config,
+                    kv_cache_prefix=kv_cache_prefix,
                     **compiler_options,
                 )
                 self.vision_model.onnx_path = vision_wrapper.vision_model.onnx_path
@@ -1903,6 +1905,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 enable_chunking=enable_chunking,
                 qaic_config=qaic_config,
                 layerwise_window_size=layerwise_window_size,
+                kv_cache_prefix=kv_cache_prefix,
                 **compiler_options,
             )
 

--- a/QEfficient/utils/_utils.py
+++ b/QEfficient/utils/_utils.py
@@ -35,6 +35,7 @@ from QEfficient.utils.logging_utils import logger
 # image_idx, deepstack_features, ...) are intentionally excluded.
 _KV_RETAINED_STEMS = ("past_key.", "past_value.", "compressed_kv.", "k_pe.")
 _RETAINED_STATE_SUFFIX = "_RetainedState"
+_RETAINED_STATE_SUFFIXES = ("_InternalRetainedState", "_RetainedState")
 
 
 def validate_kv_cache_prefix(kv_cache_prefix: Optional[str]) -> Optional[str]:
@@ -59,13 +60,18 @@ def validate_kv_cache_prefix(kv_cache_prefix: Optional[str]) -> Optional[str]:
 
 
 def _infix_kv_prefix(name: str, kv_cache_prefix: str) -> str:
-    """Insert ``_<prefix>`` before the ``_RetainedState`` suffix for LLM KV-cache buffers only."""
-    if not name.endswith(_RETAINED_STATE_SUFFIX):
-        return name
-    stem = name[: -len(_RETAINED_STATE_SUFFIX)]
-    if not any(stem.startswith(kv_stem) for kv_stem in _KV_RETAINED_STEMS):
-        return name
-    return f"{stem}_{kv_cache_prefix}{_RETAINED_STATE_SUFFIX}"
+    """Insert ``_<prefix>`` before the retained-state suffix for LLM KV-cache buffers only.
+
+    Handles both ``_RetainedState`` (standard) and ``_InternalRetainedState`` (subfunction exports)
+    so that ``apply_kv_cache_prefix`` works correctly regardless of which suffix form is in use.
+    """
+    for suffix in _RETAINED_STATE_SUFFIXES:
+        if name.endswith(suffix):
+            stem = name[: -len(suffix)]
+            if not any(stem.startswith(kv_stem) for kv_stem in _KV_RETAINED_STEMS):
+                return name
+            return f"{stem}_{kv_cache_prefix}{suffix}"
+    return name
 
 
 def apply_kv_cache_prefix(output_names, kv_cache_prefix: Optional[str]):

--- a/QEfficient/utils/_utils.py
+++ b/QEfficient/utils/_utils.py
@@ -35,7 +35,6 @@ from QEfficient.utils.logging_utils import logger
 # image_idx, deepstack_features, ...) are intentionally excluded.
 _KV_RETAINED_STEMS = ("past_key.", "past_value.", "compressed_kv.", "k_pe.")
 _RETAINED_STATE_SUFFIX = "_RetainedState"
-_RETAINED_STATE_SUFFIXES = ("_InternalRetainedState", "_RetainedState")
 
 
 def validate_kv_cache_prefix(kv_cache_prefix: Optional[str]) -> Optional[str]:
@@ -60,18 +59,13 @@ def validate_kv_cache_prefix(kv_cache_prefix: Optional[str]) -> Optional[str]:
 
 
 def _infix_kv_prefix(name: str, kv_cache_prefix: str) -> str:
-    """Insert ``_<prefix>`` before the retained-state suffix for LLM KV-cache buffers only.
-
-    Handles both ``_RetainedState`` (standard) and ``_InternalRetainedState`` (subfunction exports)
-    so that ``apply_kv_cache_prefix`` works correctly regardless of which suffix form is in use.
-    """
-    for suffix in _RETAINED_STATE_SUFFIXES:
-        if name.endswith(suffix):
-            stem = name[: -len(suffix)]
-            if not any(stem.startswith(kv_stem) for kv_stem in _KV_RETAINED_STEMS):
-                return name
-            return f"{stem}_{kv_cache_prefix}{suffix}"
-    return name
+    """Insert ``_<prefix>`` before the ``_RetainedState`` suffix for LLM KV-cache buffers only."""
+    if not name.endswith(_RETAINED_STATE_SUFFIX):
+        return name
+    stem = name[: -len(_RETAINED_STATE_SUFFIX)]
+    if not any(stem.startswith(kv_stem) for kv_stem in _KV_RETAINED_STEMS):
+        return name
+    return f"{stem}_{kv_cache_prefix}{_RETAINED_STATE_SUFFIX}"
 
 
 def apply_kv_cache_prefix(output_names, kv_cache_prefix: Optional[str]):

--- a/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_122b_epd_disagg.py
+++ b/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_122b_epd_disagg.py
@@ -1,0 +1,296 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+"""
+End-to-end E-P-D disaggregated inference example for Qwen3.5-122B-A10B.
+
+Three QPCs are compiled separately:
+  - Vision encoder  (skip_lang=True)
+  - Lang prefill    (prefill_only=True, skip_vision=True)
+  - Lang decode     (skip_vision=True)
+
+KV-cache buffers are tagged with KV_CACHE_PREFIX so vLLM can regex-select
+them for device-to-device transfer between prefill and decode workers.
+Both prefill and decode use mxint8_kv_cache for a consistent wire dtype.
+"""
+
+from time import perf_counter
+
+import numpy as np
+import requests
+import torch
+import transformers
+from PIL import Image
+from qwen_vl_utils import process_vision_info
+from transformers import AutoConfig, AutoProcessor
+
+from QEfficient import QEFFAutoModelForImageTextToText
+from QEfficient.generation.cloud_infer import QAICInferenceSession
+
+# ---------------------------------------------------------------------------
+# Global configuration
+# ---------------------------------------------------------------------------
+MODEL_ID = "Qwen/Qwen3.5-122B-A10B"
+KV_CACHE_PREFIX = "vllmKvCache"
+
+BATCH_SIZE = 1
+PREFILL_SEQ_LEN = 32
+CTX_LEN = 1024
+GENERATION_LEN = 256
+
+IMG_HEIGHT = 354
+IMG_WIDTH = 536
+
+NUM_CORES = 16
+NUM_DEVICES_LANG = 4
+NUM_DEVICES_VISION = 1
+MOS = 1
+
+# ---------------------------------------------------------------------------
+# Truncated config for faster testing (reduce num_hidden_layers for full run)
+# ---------------------------------------------------------------------------
+config = AutoConfig.from_pretrained(MODEL_ID)
+config.text_config.num_hidden_layers = 4
+config.torch_dtype = "float16"
+layer_types = list(getattr(config.text_config, "layer_types", []))
+if len(layer_types) < config.text_config.num_hidden_layers:
+    layer_types.extend(["full_attention"] * (config.text_config.num_hidden_layers - len(layer_types)))
+config.text_config.layer_types = layer_types[: config.text_config.num_hidden_layers]
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+kv_infix = f"_{KV_CACHE_PREFIX}" if KV_CACHE_PREFIX else ""
+
+
+def _update_retained_states(target_inputs, source_outputs):
+    for layer_idx, layer_type in enumerate(config.text_config.layer_types):
+        if layer_type == "full_attention":
+            target_inputs[f"past_key.{layer_idx}{kv_infix}"] = source_outputs[
+                f"past_key.{layer_idx}{kv_infix}_RetainedState"
+            ]
+            target_inputs[f"past_value.{layer_idx}{kv_infix}"] = source_outputs[
+                f"past_value.{layer_idx}{kv_infix}_RetainedState"
+            ]
+        else:
+            target_inputs[f"conv_state.{layer_idx}"] = source_outputs[f"conv_state.{layer_idx}_RetainedState"]
+            target_inputs[f"recurrent_state.{layer_idx}"] = source_outputs[f"recurrent_state.{layer_idx}_RetainedState"]
+
+
+# ---------------------------------------------------------------------------
+# Model + processor
+# ---------------------------------------------------------------------------
+qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
+    MODEL_ID, attn_implementation="eager", kv_offload=True, config=config
+)
+tokenizer = transformers.AutoTokenizer.from_pretrained(MODEL_ID)
+processor = AutoProcessor.from_pretrained(MODEL_ID)
+
+# ---------------------------------------------------------------------------
+# Compile: vision encoder
+# ---------------------------------------------------------------------------
+vision_qpc_path = qeff_model.compile(
+    batch_size=BATCH_SIZE,
+    prefill_seq_len=PREFILL_SEQ_LEN,
+    ctx_len=CTX_LEN,
+    height=IMG_HEIGHT,
+    width=IMG_WIDTH,
+    num_cores=NUM_CORES,
+    num_devices=NUM_DEVICES_VISION,
+    mos=MOS,
+    mxfp6_matmul=True,
+    aic_enable_depth_first=True,
+    skip_vision=False,
+    split_model_io=True,
+    skip_lang=True,
+    use_onnx_subfunctions=True,
+    layerwise=False,
+)
+print("vision_qpc_path:", str(vision_qpc_path.get("vision_qpc_path")))
+
+# ---------------------------------------------------------------------------
+# Compile: lang prefill
+# ---------------------------------------------------------------------------
+prefill_qpc_path = qeff_model.compile(
+    batch_size=BATCH_SIZE,
+    prefill_seq_len=PREFILL_SEQ_LEN,
+    ctx_len=CTX_LEN,
+    height=IMG_HEIGHT,
+    width=IMG_WIDTH,
+    num_cores=NUM_CORES,
+    num_devices=NUM_DEVICES_LANG,
+    mos=MOS,
+    mxfp6_matmul=True,
+    mxint8_kv_cache=True,
+    aic_enable_depth_first=True,
+    skip_vision=True,
+    split_model_io=True,
+    use_onnx_subfunctions=True,
+    prefill_only=True,
+    layerwise=True,
+    layerwise_window_size=1,
+    kv_cache_prefix=KV_CACHE_PREFIX,
+)
+print("prefill_qpc_path:", str(prefill_qpc_path.get("lang_prefill_qpc_path")))
+
+# ---------------------------------------------------------------------------
+# Compile: lang decode
+# ---------------------------------------------------------------------------
+decode_qpc_path = qeff_model.compile(
+    batch_size=BATCH_SIZE,
+    prefill_seq_len=1,
+    ctx_len=CTX_LEN,
+    height=IMG_HEIGHT,
+    width=IMG_WIDTH,
+    num_cores=NUM_CORES,
+    num_devices=NUM_DEVICES_LANG,
+    mos=MOS,
+    mxfp6_matmul=True,
+    mxint8_kv_cache=True,
+    aic_enable_depth_first=True,
+    skip_vision=True,
+    split_model_io=True,
+    use_onnx_subfunctions=False,
+    layerwise=True,
+    layerwise_window_size=1,
+    kv_cache_prefix=KV_CACHE_PREFIX,
+)
+print("decode_qpc_path:", str(decode_qpc_path.get("lang_decode_qpc_path")))
+
+# ---------------------------------------------------------------------------
+# Sessions
+# ---------------------------------------------------------------------------
+vision_session = QAICInferenceSession(vision_qpc_path.get("vision_qpc_path"))
+lang_prefill_session = QAICInferenceSession(prefill_qpc_path.get("lang_prefill_qpc_path"))
+lang_decode_session = QAICInferenceSession(decode_qpc_path.get("lang_decode_qpc_path"))
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+image_url = "https://picsum.photos/id/237/536/354"
+image = Image.open(requests.get(image_url, stream=True).raw)
+
+messages = [
+    [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": "Describe all the colors seen in the image."},
+            ],
+        }
+    ]
+] * BATCH_SIZE
+
+texts = [processor.apply_chat_template(msg, tokenize=False, add_generation_prompt=True) for msg in messages]
+image_inputs, video_inputs = process_vision_info(messages)
+inputs = processor(text=texts, images=image_inputs, videos=video_inputs, padding=True, return_tensors="pt")
+inputs = qeff_model.model.prepare_inputs_for_generation(
+    inputs=inputs, prefill_seq_len=PREFILL_SEQ_LEN, batch_size=BATCH_SIZE
+)
+
+pad_token_id = 1
+input_ids_length = inputs["input_ids"].shape[1]
+num_chunks = -(input_ids_length // -PREFILL_SEQ_LEN)
+padded_len = num_chunks * PREFILL_SEQ_LEN
+
+inputs["input_ids"] = torch.nn.functional.pad(
+    inputs["input_ids"], (0, padded_len - input_ids_length), "constant", pad_token_id
+)
+inputs["attention_mask"] = torch.nn.functional.pad(
+    inputs["attention_mask"], (0, padded_len - input_ids_length), "constant", 0
+)
+
+for k, v in inputs.items():
+    inputs[k] = np.array(v)
+
+vision_inputs = {
+    k: v
+    for k, v in inputs.items()
+    if k in {"pixel_values", "image_masks", "image_input_idx", "valid_idx", "aspect_ratio_ids", "aspect_ratio_mask"}
+}
+vision_inputs.update(
+    {k: vision_inputs[k].astype("float16") for k in {"pixel_values", "image_masks"} if k in vision_inputs}
+)
+
+# ---------------------------------------------------------------------------
+# Vision forward
+# ---------------------------------------------------------------------------
+vision_start = perf_counter()
+vision_outputs = vision_session.run(vision_inputs)
+vision_end = perf_counter()
+
+# ---------------------------------------------------------------------------
+# Prefill
+# ---------------------------------------------------------------------------
+lang_inputs = {k: v for k, v in inputs.items() if k not in vision_inputs}
+if "position_ids" in inputs:
+    lang_inputs["position_ids"] = inputs["position_ids"]
+    lang_inputs.pop("attention_mask", None)
+else:
+    lang_inputs["position_ids"] = np.where(lang_inputs.pop("attention_mask"), np.arange(padded_len), -1)
+
+lang_inputs["image_idx"] = np.array([[0]])
+lang_inputs["vision_embeds"] = vision_outputs["vision_embeds"]
+
+lang_prefill_session.set_buffers(vision_outputs)
+
+lang_start = perf_counter()
+chunk_inputs = lang_inputs.copy()
+for i in range(num_chunks):
+    chunk_inputs["input_ids"] = lang_inputs["input_ids"][:, i * PREFILL_SEQ_LEN : (i + 1) * PREFILL_SEQ_LEN]
+    chunk_inputs["position_ids"] = lang_inputs["position_ids"][..., i * PREFILL_SEQ_LEN : (i + 1) * PREFILL_SEQ_LEN]
+    outputs = lang_prefill_session.run(chunk_inputs)
+    _update_retained_states(chunk_inputs, outputs)
+    chunk_inputs["image_idx"] = outputs["image_idx_output"]
+
+prefill_time = perf_counter() - lang_start + vision_end - vision_start
+print(f"Prefill time : {prefill_time:.2f} secs")
+
+# ---------------------------------------------------------------------------
+# Decode
+# ---------------------------------------------------------------------------
+all_outputs = [np.argmax(outputs["logits"])]
+
+decode_inputs = {
+    "input_ids": np.argmax(outputs["logits"]).reshape(1, 1),
+    "position_ids": np.max(lang_inputs["position_ids"], axis=-1, keepdims=True) + 1,
+    "image_idx": outputs["image_idx_output"],
+    "vision_embeds": outputs["vision_embeds_RetainedState"],
+}
+_update_retained_states(decode_inputs, outputs)
+
+st = perf_counter()
+decode_out = lang_decode_session.run(decode_inputs)
+print(f"First decode step: {perf_counter() - st:.3f} secs")
+
+all_outputs.append(np.argmax(decode_out["logits"]))
+pos_id = np.max(decode_inputs["position_ids"], axis=-1, keepdims=True) + 1
+loop_inputs = {
+    "input_ids": np.argmax(decode_out["logits"]).reshape(1, 1),
+    "position_ids": pos_id,
+    "image_idx": decode_out["image_idx_output"],
+    "vision_embeds": decode_out["vision_embeds_RetainedState"],
+}
+_update_retained_states(loop_inputs, decode_out)
+
+st = perf_counter()
+for _ in range(GENERATION_LEN - 2):
+    decode_out = lang_decode_session.run(loop_inputs)
+    all_outputs.append(np.argmax(decode_out["logits"]))
+    pos_id += 1
+    _update_retained_states(loop_inputs, decode_out)
+    loop_inputs.update(
+        {
+            "input_ids": np.argmax(decode_out["logits"]).reshape(1, 1),
+            "position_ids": pos_id,
+        }
+    )
+ft = perf_counter()
+
+print(f"Decode throughput: {(GENERATION_LEN - 2) / (ft - st):.2f} tok/sec")
+print(f"\nOutput:\n{tokenizer.decode(all_outputs)}")

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -2259,3 +2259,181 @@ def test_vlm_export_prefix_lang_only(tmp_path):
     for name in retained:
         if name.startswith(("vision_embeds", "pixel_values", "deepstack_features")):
             assert "_VLLM_" not in name
+
+
+def _capture_layerwise_export_names(qeff_model, *, window, total_layers, export_dir, kv_cache_prefix):
+    """Drive the real ``_export_layerwise`` for one decoder window and capture the
+    ``input_names`` / ``output_names`` handed to ``torch.onnx.export``.
+
+    The spy raises to abort before the heavy ONNX transforms/disk writes — we only
+    care about the buffer names the export was invoked with. Window state is always
+    restored in ``finally`` so the class-level flags never leak into other tests.
+    """
+    from QEfficient.base.modeling_qeff import QEFFBaseModel
+    from QEfficient.transformers.models import _layerwise
+
+    captured = {}
+
+    class _StopExport(Exception):
+        pass
+
+    def _spy(*args, **kwargs):
+        captured["input_names"] = list(kwargs.get("input_names") or [])
+        captured["output_names"] = list(kwargs.get("output_names") or [])
+        raise _StopExport()
+
+    orig_export = torch.onnx.export
+    torch.onnx.export = _spy
+    try:
+        with _layerwise._layerwise_export_env():
+            _layerwise._set_layer_windows(window, window + 1, total_layers)
+            QEFFBaseModel._start = window
+            QEFFBaseModel._end = window + 1
+            QEFFBaseModel._total_layers = total_layers
+            try:
+                qeff_model.export(export_dir=str(export_dir), kv_cache_prefix=kv_cache_prefix)
+            except _StopExport:
+                pass
+    finally:
+        torch.onnx.export = orig_export
+        _layerwise._reset_layer_windows()
+        QEFFBaseModel._start = 0
+        QEFFBaseModel._end = 0
+        QEFFBaseModel._total_layers = None
+    assert "output_names" in captured, "torch.onnx.export was never reached"
+    return captured
+
+
+def _tiny_qwen3_moe_causal():
+    from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
+
+    import QEfficient
+
+    cfg = Qwen3MoeConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        num_experts=4,
+        num_experts_per_tok=2,
+        vocab_size=64,
+        max_position_embeddings=64,
+        decoder_sparse_step=1,
+        norm_topk_prob=True,
+    )
+    cfg.torch_dtype = "float32"
+    torch.manual_seed(0)
+    hf = Qwen3MoeForCausalLM(cfg).eval()
+    return QEfficient.QEFFAutoModelForCausalLM(hf, continuous_batching=False), cfg.num_hidden_layers
+
+
+@pytest.mark.llm_model
+def test_layerwise_export_with_kv_cache_prefix(tmp_path):
+    """Regression for the layerwise + kv_cache_prefix path (previously a silent no-op).
+
+    The non-layerwise paths already prefix KV buffers; ``_export_layerwise`` rebuilds output
+    names from per-window templates, so the prefix has to be threaded into it and applied there.
+    This drives the real ``_export_layerwise`` for every window and asserts:
+      * each retained-state output carries the ``_<prefix>_RetainedState`` infix (Bug 2), and
+      * the matching KV *input* buffer is renamed to ``past_*.{i}_<prefix>`` so the compiler can
+        pair input↔retained-output (Bug 3).
+    """
+    qeff_model, total_layers = _tiny_qwen3_moe_causal()
+
+    for window in range(total_layers):
+        captured = _capture_layerwise_export_names(
+            qeff_model,
+            window=window,
+            total_layers=total_layers,
+            export_dir=tmp_path / f"prefixed_w{window}",
+            kv_cache_prefix="vllmKvCache",
+        )
+        kv_outputs = [n for n in captured["output_names"] if n.startswith(("past_key.", "past_value."))]
+        assert kv_outputs, f"window {window}: expected KV retained outputs"
+        # Bug 2: every per-window KV retained output carries the infix.
+        for name in kv_outputs:
+            assert name == f"past_key.{window}_vllmKvCache_RetainedState" or (
+                name == f"past_value.{window}_vllmKvCache_RetainedState"
+            ), f"window {window}: output not prefixed: {name}"
+        # Bug 3: the paired input buffer is the output minus _RetainedState and carries the infix.
+        kv_inputs = [n for n in captured["input_names"] if n.startswith(("past_key.", "past_value."))]
+        assert kv_inputs, f"window {window}: expected KV input buffers"
+        for out_name in kv_outputs:
+            paired_input = out_name[: -len("_RetainedState")]
+            assert paired_input in kv_inputs, f"window {window}: missing aligned input for {out_name}"
+            assert paired_input.endswith("_vllmKvCache")
+
+
+@pytest.mark.llm_model
+def test_layerwise_export_with_kv_cache_prefix_subfunctions(tmp_path):
+    """Prefix must survive the subfunction export path end-to-end (the config the EPD example ships).
+
+    With ``use_onnx_subfunctions=True`` the decoder emits ``_InternalRetainedState`` function outputs
+    that ``RenameFunctionOutputsTransform`` rewrites to plain ``past_key.{i}_RetainedState``; the
+    positional rename loop in ``_export_layerwise`` then overwrites them with the (prefixed) names we
+    passed. This asserts the *final transformed* per-window shard on disk carries the infix on both the
+    retained-state outputs and the paired input buffers — i.e. the prefix is not lost by the transforms.
+    """
+    from QEfficient.base.modeling_qeff import QEFFBaseModel
+    from QEfficient.transformers.models import _layerwise
+
+    qeff_model, total_layers = _tiny_qwen3_moe_causal()
+    export_dir = tmp_path / "subfn_prefixed"
+    try:
+        with _layerwise._layerwise_export_env():
+            _layerwise._set_layer_windows(0, 1, total_layers)
+            QEFFBaseModel._start = 0
+            QEFFBaseModel._end = 1
+            QEFFBaseModel._total_layers = total_layers
+            qeff_model.export(
+                export_dir=str(export_dir),
+                kv_cache_prefix="vllmKvCache",
+                use_onnx_subfunctions=True,
+            )
+    finally:
+        _layerwise._reset_layer_windows()
+        QEFFBaseModel._start = 0
+        QEFFBaseModel._end = 0
+        QEFFBaseModel._total_layers = None
+
+    # export_dir gets a hash suffix appended by export_wrapper; find the per-window shard under it.
+    shards = list(tmp_path.glob("subfn_prefixed*/onnx_layerwise_tmp/layer_0_1/*_layer_tmp_0_1.onnx"))
+    assert shards, "subfunction per-window shard was not produced"
+    graph = onnx.load(str(shards[0]), load_external_data=False).graph
+    kv_outputs = [o.name for o in graph.output if o.name.startswith(("past_key.", "past_value."))]
+    kv_inputs = [i.name for i in graph.input if i.name.startswith(("past_key.", "past_value."))]
+    assert kv_outputs, "no KV retained outputs in subfunction shard"
+    # Final names use _RetainedState (post-rename) and carry the infix — never raw _InternalRetainedState.
+    for name in kv_outputs:
+        assert name.endswith("_vllmKvCache_RetainedState"), f"prefix lost in subfunction output: {name}"
+        assert "_InternalRetainedState" not in name
+    for out_name in kv_outputs:
+        assert out_name[: -len("_RetainedState")] in kv_inputs, f"missing aligned input for {out_name}"
+
+
+@pytest.mark.llm_model
+def test_layerwise_export_default_names_unchanged(tmp_path):
+    """Backward-compat: without the flag, layerwise per-window names must stay byte-for-byte plain.
+
+    Guards against the prefix plumbing accidentally altering the default (no-prefix) path — the
+    output names and the paired input buffers must remain exactly what they were before the feature.
+    """
+    qeff_model, total_layers = _tiny_qwen3_moe_causal()
+
+    for window in range(total_layers):
+        captured = _capture_layerwise_export_names(
+            qeff_model,
+            window=window,
+            total_layers=total_layers,
+            export_dir=tmp_path / f"default_w{window}",
+            kv_cache_prefix=None,
+        )
+        assert f"past_key.{window}_RetainedState" in captured["output_names"]
+        assert f"past_value.{window}_RetainedState" in captured["output_names"]
+        # Inputs use the plain names; no infix anywhere.
+        assert f"past_key.{window}" in captured["input_names"]
+        assert all("_vllmKvCache" not in n and "_VLLM" not in n for n in captured["output_names"])
+        assert all("_vllmKvCache" not in n and "_VLLM" not in n for n in captured["input_names"])


### PR DESCRIPTION
## Background

PR #1046 introduced the optional `kv_cache_prefix` parameter for
`QEFFAutoModelForCausalLM`, single-QPC VLMs, and dual-QPC VLMs. When set,
it injects an infix token into LLM KV-cache retained-state buffer names:

```
past_key.N_RetainedState  →  past_key.N_<prefix>_RetainedState
```

This gives vLLM a stable regex handle to select only LLM KV buffers for
disaggregated device-to-device transfer, leaving vision buffers
(`vision_embeds_RetainedState`, etc.) untouched.

The feature worked for non-layerwise paths. This work extends it to the
**layerwise E-P-D path** used by large models (e.g. Qwen3.5-122B-A10B).

---

## Bugs Fixed

### Bug 1 — `kv_cache_prefix` dropped in layerwise `compile()` and `export()`
**File:** `QEfficient/transformers/models/modeling_auto.py`

`_QEffAutoModelForImageTextToTextDualQPC.compile()` and `.export()` both
accept `kv_cache_prefix` as a named parameter, but neither forwarded it
when taking the `layerwise=True` early-return branch:

- `compile()` → `_run_layerwise_compile(...)` — missing
- `compile()` → `vision_wrapper.compile(...)` (vision-only branch) — missing
- `export()` → `_run_layerwise_export(...)` — missing (explicit named param,
  not captured by `**kwargs`)

**Fix:** Added `kv_cache_prefix=kv_cache_prefix` to all three call sites.

---

### Bug 2 — `_export_layerwise` rebuilt output names from scratch
**File:** `QEfficient/base/modeling_qeff.py`

`_export_layerwise` constructed its own `output_name` list using hardcoded
templates:

```python
output_name.append(f"past_key.{layer_idx}_RetainedState")
output_name.append(f"past_value.{layer_idx}_RetainedState")
```

It never consulted the `output_names` parameter passed in by the caller,
which already carried the prefixed names from `apply_kv_cache_prefix`.
The per-window ONNXes were therefore exported with plain names, and the
stitched merged ONNX had no prefix — making `kv_cache_prefix` silently a
no-op for all layerwise exports.

**Fix:** Built a `_caller_retained_map` from the incoming `output_names`:
for each KV retained-state name it finds the plain stem (e.g.
`past_key.3_vllmKvCache_RetainedState` → plain stem `past_key.3`),
then registers the prefixed+suffix-corrected form under both
`_RetainedState` and `_InternalRetainedState` keys. When appending each
KV buffer to `output_name`, the map is consulted first; the plain default
is used as fallback (preserving existing behaviour when no prefix is set).

---

### Bug 3 — KV input names not aligned in `_export_layerwise`
**File:** `QEfficient/base/modeling_qeff.py`

The regular `_export` path calls `align_kv_input_names_to_retained_outputs`
to rename KV input buffers to match the prefixed outputs:

```
past_key.3  →  past_key.3_vllmKvCache
```

The AIC compiler pairs an output `X_RetainedState` to the input named `X`;
without this rename the compiler cannot establish KV retention for prefixed
buffers. `_export_layerwise` skipped this alignment entirely.

**Fix:** Added the same `align_kv_input_names_to_retained_outputs` call
(with dynamic-axes propagation) immediately before `torch.onnx.export` in
`_export_layerwise`.

---

## Files Changed

| File | Change |
|------|--------|
| `QEfficient/transformers/models/modeling_auto.py` | Forward `kv_cache_prefix` in all layerwise `compile()` and `export()` branches |
| `QEfficient/base/modeling_qeff.py` | Respect caller's prefixed `output_names` and align input names in `_export_layerwise` |
| `examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_122b_epd_disagg.py` | New end-to-end E-P-D disaggregated inference example for Qwen3.5-122B-A10B |

---

## Example Script Notes (`qwen3_5_122b_epd_disagg.py`)

- Three separate compile calls: vision encoder, lang prefill, lang decode
- `kv_infix` computed once from `KV_CACHE_PREFIX`; `_update_retained_states`
  uses it to feed the correct buffer names back as inputs for the next step

---

## Runtime Behaviour

- **No prefix set:** all paths are no-ops; buffer names unchanged
- **Prefix set, non-layerwise:** unchanged from PR #1046
- **Prefix set, layerwise:** per-window ONNXes are now exported with prefixed output names and aligned input names; the stitched merged ONNX carries them through to the compiled QPC
