### PR TITLE
Added MDP generation to QEff Compile

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -32,6 +32,7 @@ from QEfficient.compile.mdp_generator import (
     MdpStrategy,
     generate_disagg_mdp_intersection_config,
     generate_disagg_mdp_partition_config,
+    generate_mdp_partition_config,
 )
 from QEfficient.compile.qnn_compiler import compile as qnn_compile
 from QEfficient.generation.cloud_infer import QAICInferenceSession
@@ -46,7 +47,6 @@ from QEfficient.utils import (
     create_json,
     create_model_params,
     dump_qconfig,
-    generate_mdp_partition_config,
     get_attr_or_key,
     hash_dict_params,
     load_json,
@@ -779,6 +779,64 @@ class QEFFBaseModel(ABC):
         self.onnx_path = layer_onnx_path_tmp
         return layer_onnx_path_tmp
 
+    def _generate_disagg_mdp_config(
+        self,
+        onnx_path: Path,
+        compile_dir: Path,
+        mdp_ts_num_devices: int,
+        mdp_num_partitions: int,
+        mdp_strategy: "MdpStrategy",
+        mdp_compiler_dump_path: Optional[str],
+        num_cores: int,
+    ):
+        """Generate the disaggregated (pipeline-parallel) MDP partition config JSON.
+
+        Resolves num_layers from self.num_layers or the language_model config, dispatches
+        to the appropriate generator based on mdp_strategy, persists the result to
+        compile_dir, and returns (json_path, json_object) for use by _compile.
+        """
+        num_layers = getattr(self, "num_layers", None)
+        if getattr(self, "model", None) and getattr(self.model, "language_model", None) and not num_layers:
+            num_layers = getattr(self.model.language_model.config, "num_hidden_layers", None)
+        if num_layers is None:
+            raise AttributeError(
+                "Model or Language Model does not expose 'num_layers' or 'num_hidden_layers' respectively. Cannot generate disagg MDP partition config."
+            )
+
+        logger.info(
+            f"Generating disagg MDP (strategy={mdp_strategy.value!r}): "
+            f"num_devices={mdp_ts_num_devices}, num_partitions={mdp_num_partitions}, "
+            f"num_layers={num_layers}, num_cores={num_cores}"
+        )
+
+        if mdp_strategy is MdpStrategy.ONNX:
+            mdp_ts_json = generate_disagg_mdp_partition_config(
+                onnx_path=str(onnx_path),
+                num_devices=mdp_ts_num_devices,
+                num_partitions=mdp_num_partitions,
+                num_layers=num_layers,
+                num_cores=num_cores,
+            )
+        else:  # MdpStrategy.INTERSECTION
+            if not mdp_compiler_dump_path:
+                raise ValueError(
+                    "mdp_strategy='intersection' requires mdp_compiler_dump_path to be set. "
+                    "Run qaic-compile with -mdp-dump-partition-config=<path> first, "
+                    "then pass that path as mdp_compiler_dump_path."
+                )
+            mdp_ts_json = generate_disagg_mdp_intersection_config(
+                onnx_path=str(onnx_path),
+                compiler_dump_path=mdp_compiler_dump_path,
+                num_devices=mdp_ts_num_devices,
+                num_partitions=mdp_num_partitions,
+                num_layers=num_layers,
+                num_cores=num_cores,
+            )
+
+        mdp_ts_json_path = compile_dir / f"mdp_disagg_{mdp_ts_num_devices}d_{mdp_num_partitions}p.json"
+        create_json(str(mdp_ts_json_path), mdp_ts_json)
+        return mdp_ts_json_path, mdp_ts_json
+
     def transform(
         self,
         ctx_len: Optional[int] = None,
@@ -956,49 +1014,17 @@ class QEFFBaseModel(ABC):
             command.append(f"-mdp-load-partition-config={mdp_ts_json_path}")
             mdp_ts_json = load_json(str(mdp_ts_json_path))
         elif mdp_num_partitions > 1:
-            # Disaggregated (pipeline-parallel) MDP.
-
-            num_layers = getattr(self, "num_layers", None)
-            if getattr(self, "model", None) and getattr(self.model, "language_model", None) and not num_layers:
-                num_layers = getattr(self.model.language_model.config, "num_hidden_layers", None)
-            if num_layers is None:
-                raise AttributeError(
-                    "Model or Language Model does not expose 'num_layers' or 'num_hidden_layers' respectively. Cannot generate disagg MDP partition config."
-                )
+            # Disaggregated (pipeline-parallel) MDP — delegate to focused helper.
             num_cores = compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES)
-
-            logger.info(
-                f"Generating disagg MDP (strategy={mdp_strategy.value!r}): "
-                f"num_devices={mdp_ts_num_devices}, num_partitions={mdp_num_partitions}, "
-                f"num_layers={num_layers}, num_cores={num_cores}"
+            mdp_ts_json_path, mdp_ts_json = self._generate_disagg_mdp_config(
+                onnx_path=onnx_path,
+                compile_dir=compile_dir,
+                mdp_ts_num_devices=mdp_ts_num_devices,
+                mdp_num_partitions=mdp_num_partitions,
+                mdp_strategy=mdp_strategy,
+                mdp_compiler_dump_path=mdp_compiler_dump_path,
+                num_cores=num_cores,
             )
-
-            if mdp_strategy is MdpStrategy.ONNX:
-                mdp_ts_json = generate_disagg_mdp_partition_config(
-                    onnx_path=str(onnx_path),
-                    num_devices=mdp_ts_num_devices,
-                    num_partitions=mdp_num_partitions,
-                    num_layers=num_layers,
-                    num_cores=num_cores,
-                )
-            else:  # MdpStrategy.INTERSECTION
-                if not mdp_compiler_dump_path:
-                    raise ValueError(
-                        "mdp_strategy='intersection' requires mdp_compiler_dump_path to be set. "
-                        "Run qaic-compile with -mdp-dump-partition-config=<path> first, "
-                        "then pass that path as mdp_compiler_dump_path."
-                    )
-                mdp_ts_json = generate_disagg_mdp_intersection_config(
-                    onnx_path=str(onnx_path),
-                    compiler_dump_path=mdp_compiler_dump_path,
-                    num_devices=mdp_ts_num_devices,
-                    num_partitions=mdp_num_partitions,
-                    num_layers=num_layers,
-                    num_cores=num_cores,
-                )
-
-            mdp_ts_json_path = compile_dir / f"mdp_disagg_{mdp_ts_num_devices}d_{mdp_num_partitions}p.json"
-            create_json(str(mdp_ts_json_path), mdp_ts_json)
             command.append(f"-mdp-load-partition-config={mdp_ts_json_path}")
         elif mdp_ts_num_devices > 1 and not compiler_options.get("mdp_dump_partition_config", None):
             # Template (tensor-slice) MDP: single partition, empty nodeList; compiler fills it.

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -936,6 +936,11 @@ class QEFFBaseModel(ABC):
 
         layerwise_cache_probe = compiler_options.pop("_layerwise_cache_probe", False)
         moe_prefill_packed_chunk_size = compiler_options.pop("moe_prefill_packed_chunk_size", None)
+
+        mdp_ts_json_path = compiler_options.pop("mdp_load_partition_config", None)
+        mdp_strategy = MdpStrategy(compiler_options.pop("mdp_strategy", MdpStrategy.ONNX))
+        mdp_compiler_dump_path = compiler_options.pop("mdp_compiler_dump_path", None)
+
         if onnx_path is None:
             # If weights were offloaded after export, compiling must use the existing
             # ONNX because re-exporting is no longer possible. Otherwise export for
@@ -1005,9 +1010,6 @@ class QEFFBaseModel(ABC):
         #      Strategy INTERSECTION: intersect with compiler dump; compact (~1-2 MB),
         #        requires a prior -mdp-dump-partition-config run.
         #   3. Template (tensor-slice) MDP — single partition, nodeList absent.
-        mdp_ts_json_path = compiler_options.pop("mdp_load_partition_config", None)
-        mdp_strategy = MdpStrategy(compiler_options.pop("mdp_strategy", MdpStrategy.ONNX))
-        mdp_compiler_dump_path = compiler_options.pop("mdp_compiler_dump_path", None)
         mdp_ts_json = None
 
         if mdp_ts_json_path:

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -28,6 +28,11 @@ from QEfficient.base.onnx_transforms import (
 )
 from QEfficient.base.pytorch_transforms import PytorchTransform
 from QEfficient.blocking.blocking_configurator import build_transformer_blocking_config_for_transform
+from QEfficient.compile.mdp_generator import (
+    MdpStrategy,
+    generate_disagg_mdp_intersection_config,
+    generate_disagg_mdp_partition_config,
+)
 from QEfficient.compile.qnn_compiler import compile as qnn_compile
 from QEfficient.generation.cloud_infer import QAICInferenceSession
 from QEfficient.transformers.models.pytorch_transforms import (
@@ -828,6 +833,7 @@ class QEFFBaseModel(ABC):
         specializations: Optional[List[Dict[str, int]]] = None,
         custom_io: Optional[Dict[str, str]] = None,
         mdp_ts_num_devices: int = 1,
+        mdp_num_partitions: Optional[int] = 1,
         num_speculative_tokens: Optional[Union[int, List[int]]] = None,
         enable_qnn: Optional[bool] = False,
         qnn_config: Optional[str] = None,
@@ -851,6 +857,11 @@ class QEFFBaseModel(ABC):
             :specializations (list): List of specializations to compile for
             :custom_io (dict): Custom IO to specify the input and outputs in different formats than default
             :mdp_ts_num_devices (int): Number of devices to partition to use Multi-Device Partitioning with tensor-slicing.
+            :mdp_num_partitions (int): Number of pipeline-parallel partitions for disaggregated prefill serving.
+                When > 1, the ONNX graph is read directly to generate a fully-populated MDP partition
+                config (nodeList per partition) without requiring a compiler round-trip.
+                Ignored when ``mdp_load_partition_config`` is already provided in compiler_options.
+                Defaults to 1 (template / tensor-slice MDP, existing behaviour).
             :num_speculative_tokens (int | List[int], optional): Number of speculative tokens for TLM decode. A plain int K compiles one decode specialization (seq_len=K+1). A list [K0, K1, ...] compiles one specialization per value, enabling per-step dispatch to the cheapest kernel.
             :enable_qnn (bool): Enables QNN Compilation. ``Defaults to False.``
             :qnn_config (str): Path of QNN Config parameters file. Any extra parameters for QNN compilation can be passed via this file. ``Defaults to None.``
@@ -929,22 +940,76 @@ class QEFFBaseModel(ABC):
             + [f"-m={onnx_path}"]
         )
 
-        # MDP partition config: prioritize dump over load
-        mdp_dump_json_path = compiler_options.pop("mdp_dump_partition_config", None)
+        # MDP partition config selection (three priorities, highest first):
+        #   1. User explicitly provides a pre-built MDP JSON to load.
+        #   2. Disaggregated (pipeline-parallel) MDP — generate from ONNX topsort.
+        #   3. Template (tensor-slice) MDP — single partition, nodeList absent.
         mdp_ts_json_path = compiler_options.pop("mdp_load_partition_config", None)
+        mdp_strategy = MdpStrategy(compiler_options.pop("mdp_strategy", MdpStrategy.ONNX))
+        mdp_compiler_dump_path = compiler_options.pop("mdp_compiler_dump_path", None)
         mdp_ts_json = None
 
-        if mdp_dump_json_path:
-            if mdp_ts_json_path:
-                logger.warning(
-                    "Loading and Dumping partition is not supported at the same time. Prioritizing dump config over load config!"
-                )
-            command.append(f"-mdp-dump-partition-config={mdp_dump_json_path}")
-        elif mdp_ts_json_path:
+        if mdp_ts_json_path:
             command.append(f"-mdp-load-partition-config={mdp_ts_json_path}")
             mdp_ts_json = load_json(str(mdp_ts_json_path))
-        elif mdp_ts_num_devices > 1:
-            # Generate mdp config only if neither dump nor load is provided and num_devices > 1
+        elif mdp_num_partitions > 1:
+            # Disaggregated (pipeline-parallel) MDP.
+            # Two strategies are available via mdp_strategy (see MdpStrategy enum):
+            #
+            #   MdpStrategy.ONNX ("onnx", default)
+            #       Enumerates every node from the ONNX graph.
+            #       Most accurate; requires loading external ONNX data; ~19 MB JSON.
+            #   MdpStrategy.INTERSECTION ("intersection")
+            #       Generates the full ONNX MDP (superset) then filters to only the
+            #       exact Glow IR node names present in the compiler dump.
+            #       Compact (~1-2 MB); requires a prior compile run with
+            #       -mdp-dump-partition-config to produce mdp_compiler_dump_path.
+
+            num_layers = getattr(self, "num_layers", None)
+            if getattr(self, "model", None) and getattr(self.model, "language_model", None) and not num_layers:
+                num_layers = getattr(self.model.language_model.config, "num_hidden_layers", None)
+            if num_layers is None:
+                raise AttributeError(
+                    "Model or Language Model does not expose 'num_layers' or 'num_hidden_layers' respectively. Cannot generate disagg MDP partition config."
+                )
+            num_cores = compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES)
+
+            logger.info(
+                f"Generating disagg MDP (strategy={mdp_strategy.value!r}): "
+                f"num_devices={mdp_ts_num_devices}, num_partitions={mdp_num_partitions}, "
+                f"num_layers={num_layers}, num_cores={num_cores}"
+            )
+
+            if mdp_strategy is MdpStrategy.ONNX:
+                mdp_ts_json = generate_disagg_mdp_partition_config(
+                    onnx_path=str(onnx_path),
+                    num_devices=mdp_ts_num_devices,
+                    num_partitions=mdp_num_partitions,
+                    num_layers=num_layers,
+                    num_cores=num_cores,
+                )
+            else:  # MdpStrategy.INTERSECTION
+                if not mdp_compiler_dump_path:
+                    raise ValueError(
+                        "mdp_strategy='intersection' requires mdp_compiler_dump_path to be set. "
+                        "Run qaic-compile with -mdp-dump-partition-config=<path> first, "
+                        "then pass that path as mdp_compiler_dump_path."
+                    )
+                mdp_ts_json = generate_disagg_mdp_intersection_config(
+                    onnx_path=str(onnx_path),
+                    compiler_dump_path=mdp_compiler_dump_path,
+                    num_devices=mdp_ts_num_devices,
+                    num_partitions=mdp_num_partitions,
+                    num_layers=num_layers,
+                    num_cores=num_cores,
+                )
+
+            mdp_ts_json_path = compile_dir / f"mdp_disagg_{mdp_ts_num_devices}d_{mdp_num_partitions}p.json"
+            create_json(str(mdp_ts_json_path), mdp_ts_json)
+            command.append(f"-mdp-load-partition-config={mdp_ts_json_path}")
+        elif mdp_ts_num_devices > 1 and not compiler_options.get("mdp_dump_partition_config", None):
+            # Template (tensor-slice) MDP: single partition, empty nodeList.
+            # Used when PP is disabled (stages=1). Compiler fills the nodeList.
             mdp_ts_json = generate_mdp_partition_config(
                 mdp_ts_num_devices, compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES)
             )
@@ -994,6 +1059,8 @@ class QEFFBaseModel(ABC):
             "specializations": specializations,
             "custom_io": custom_io,
             "mdp_ts_num_devices": mdp_ts_num_devices,
+            "mdp_num_partitions": mdp_num_partitions,
+            "mdp_strategy": mdp_strategy.value,
             "mdp_ts_json": mdp_ts_json,
             "num_speculative_tokens": num_speculative_tokens,
             "prefill_only": prefill_only,

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -30,8 +30,7 @@ from QEfficient.base.pytorch_transforms import PytorchTransform
 from QEfficient.blocking.blocking_configurator import build_transformer_blocking_config_for_transform
 from QEfficient.compile.mdp_generator import (
     MdpStrategy,
-    generate_disagg_mdp_intersection_config,
-    generate_disagg_mdp_partition_config,
+    generate_disagg_mdp_config,
     generate_mdp_partition_config,
 )
 from QEfficient.compile.qnn_compiler import compile as qnn_compile
@@ -779,64 +778,6 @@ class QEFFBaseModel(ABC):
         self.onnx_path = layer_onnx_path_tmp
         return layer_onnx_path_tmp
 
-    def _generate_disagg_mdp_config(
-        self,
-        onnx_path: Path,
-        compile_dir: Path,
-        mdp_ts_num_devices: int,
-        mdp_num_partitions: int,
-        mdp_strategy: "MdpStrategy",
-        mdp_compiler_dump_path: Optional[str],
-        num_cores: int,
-    ):
-        """Generate the disaggregated (pipeline-parallel) MDP partition config JSON.
-
-        Resolves num_layers from self.num_layers or the language_model config, dispatches
-        to the appropriate generator based on mdp_strategy, persists the result to
-        compile_dir, and returns (json_path, json_object) for use by _compile.
-        """
-        num_layers = getattr(self, "num_layers", None)
-        if getattr(self, "model", None) and getattr(self.model, "language_model", None) and not num_layers:
-            num_layers = getattr(self.model.language_model.config, "num_hidden_layers", None)
-        if num_layers is None:
-            raise AttributeError(
-                "Model or Language Model does not expose 'num_layers' or 'num_hidden_layers' respectively. Cannot generate disagg MDP partition config."
-            )
-
-        logger.info(
-            f"Generating disagg MDP (strategy={mdp_strategy.value!r}): "
-            f"num_devices={mdp_ts_num_devices}, num_partitions={mdp_num_partitions}, "
-            f"num_layers={num_layers}, num_cores={num_cores}"
-        )
-
-        if mdp_strategy is MdpStrategy.ONNX:
-            mdp_ts_json = generate_disagg_mdp_partition_config(
-                onnx_path=str(onnx_path),
-                num_devices=mdp_ts_num_devices,
-                num_partitions=mdp_num_partitions,
-                num_layers=num_layers,
-                num_cores=num_cores,
-            )
-        else:  # MdpStrategy.INTERSECTION
-            if not mdp_compiler_dump_path:
-                raise ValueError(
-                    "mdp_strategy='intersection' requires mdp_compiler_dump_path to be set. "
-                    "Run qaic-compile with -mdp-dump-partition-config=<path> first, "
-                    "then pass that path as mdp_compiler_dump_path."
-                )
-            mdp_ts_json = generate_disagg_mdp_intersection_config(
-                onnx_path=str(onnx_path),
-                compiler_dump_path=mdp_compiler_dump_path,
-                num_devices=mdp_ts_num_devices,
-                num_partitions=mdp_num_partitions,
-                num_layers=num_layers,
-                num_cores=num_cores,
-            )
-
-        mdp_ts_json_path = compile_dir / f"mdp_disagg_{mdp_ts_num_devices}d_{mdp_num_partitions}p.json"
-        create_json(str(mdp_ts_json_path), mdp_ts_json)
-        return mdp_ts_json_path, mdp_ts_json
-
     def transform(
         self,
         ctx_len: Optional[int] = None,
@@ -1018,7 +959,14 @@ class QEFFBaseModel(ABC):
         elif mdp_num_partitions > 1:
             # Disaggregated (pipeline-parallel) MDP — delegate to focused helper.
             num_cores = compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES)
-            mdp_ts_json_path, mdp_ts_json = self._generate_disagg_mdp_config(
+            num_layers = getattr(self, "num_layers", None)
+            if getattr(self, "model", None) and getattr(self.model, "language_model", None) and not num_layers:
+                num_layers = getattr(self.model.language_model.config, "num_hidden_layers", None)
+            if num_layers is None:
+                raise AttributeError(
+                    "Model or Language Model does not expose 'num_layers' or 'num_hidden_layers' respectively. Cannot generate disagg MDP partition config."
+                )
+            mdp_ts_json_path, mdp_ts_json = generate_disagg_mdp_config(
                 onnx_path=onnx_path,
                 compile_dir=compile_dir,
                 mdp_ts_num_devices=mdp_ts_num_devices,
@@ -1026,6 +974,7 @@ class QEFFBaseModel(ABC):
                 mdp_strategy=mdp_strategy,
                 mdp_compiler_dump_path=mdp_compiler_dump_path,
                 num_cores=num_cores,
+                num_layers=num_layers,
             )
             command.append(f"-mdp-load-partition-config={mdp_ts_json_path}")
         elif mdp_ts_num_devices > 1 and not compiler_options.get("mdp_dump_partition_config", None):

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -940,9 +940,12 @@ class QEFFBaseModel(ABC):
             + [f"-m={onnx_path}"]
         )
 
-        # MDP partition config selection (three priorities, highest first):
-        #   1. User explicitly provides a pre-built MDP JSON to load.
-        #   2. Disaggregated (pipeline-parallel) MDP — generate from ONNX topsort.
+        # MDP partition config selection (highest priority first):
+        #   1. User-provided pre-built MDP JSON (mdp_load_partition_config).
+        #   2. Disaggregated (pipeline-parallel) MDP — generated from ONNX topsort.
+        #      Strategy ONNX (default): full superset from ONNX graph (~19 MB).
+        #      Strategy INTERSECTION: intersect with compiler dump; compact (~1-2 MB),
+        #        requires a prior -mdp-dump-partition-config run.
         #   3. Template (tensor-slice) MDP — single partition, nodeList absent.
         mdp_ts_json_path = compiler_options.pop("mdp_load_partition_config", None)
         mdp_strategy = MdpStrategy(compiler_options.pop("mdp_strategy", MdpStrategy.ONNX))
@@ -954,16 +957,6 @@ class QEFFBaseModel(ABC):
             mdp_ts_json = load_json(str(mdp_ts_json_path))
         elif mdp_num_partitions > 1:
             # Disaggregated (pipeline-parallel) MDP.
-            # Two strategies are available via mdp_strategy (see MdpStrategy enum):
-            #
-            #   MdpStrategy.ONNX ("onnx", default)
-            #       Enumerates every node from the ONNX graph.
-            #       Most accurate; requires loading external ONNX data; ~19 MB JSON.
-            #   MdpStrategy.INTERSECTION ("intersection")
-            #       Generates the full ONNX MDP (superset) then filters to only the
-            #       exact Glow IR node names present in the compiler dump.
-            #       Compact (~1-2 MB); requires a prior compile run with
-            #       -mdp-dump-partition-config to produce mdp_compiler_dump_path.
 
             num_layers = getattr(self, "num_layers", None)
             if getattr(self, "model", None) and getattr(self.model, "language_model", None) and not num_layers:
@@ -1008,8 +1001,7 @@ class QEFFBaseModel(ABC):
             create_json(str(mdp_ts_json_path), mdp_ts_json)
             command.append(f"-mdp-load-partition-config={mdp_ts_json_path}")
         elif mdp_ts_num_devices > 1 and not compiler_options.get("mdp_dump_partition_config", None):
-            # Template (tensor-slice) MDP: single partition, empty nodeList.
-            # Used when PP is disabled (stages=1). Compiler fills the nodeList.
+            # Template (tensor-slice) MDP: single partition, empty nodeList; compiler fills it.
             mdp_ts_json = generate_mdp_partition_config(
                 mdp_ts_num_devices, compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES)
             )

--- a/QEfficient/compile/mdp_generator.py
+++ b/QEfficient/compile/mdp_generator.py
@@ -1,0 +1,412 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+"""MDP generator for disaggregated prefill serving (PP-enabled, TS-enabled, stages>1)."""
+
+import logging
+from enum import Enum
+from typing import Any, Dict, List, Optional, Set
+
+import onnx
+
+logger = logging.getLogger(__name__)
+
+
+class MdpStrategy(str, Enum):
+    """MDP partition-config generation strategy for disaggregated prefill.
+
+    ONNX        : Enumerate every node from the exported ONNX graph and assign
+                  to partitions by transformer layer index.  No prior compile
+                  run needed; produces a ~19 MB JSON that is a superset of the
+                  real Glow IR.  Default.
+
+    INTERSECTION: Requires a prior ``qaic-compile -mdp-dump-partition-config``
+                  run.  Generates the full ONNX-based MDP (superset), then
+                  filters each partition's nodeList to only the exact Glow IR
+                  node names present in the compiler dump.  Result is compact
+                  (~1-2 MB) and contains only exact-match names for the
+                  compiler's ``doManualPartitioning()``.
+    """
+
+    ONNX = "onnx"
+    INTERSECTION = "intersection"
+
+
+def _get_compiler_folded_nodes(graph) -> Set[str]:
+    """Return node names the compiler will fold away during ONNX import.
+
+    Mirrors computeIsConstantFoldable() in ONNXModelLoader.cpp: a node is
+    foldable if every one of its inputs is a compile-time constant (initializer,
+    Constant op output, or output of another foldable node). Folded nodes are
+    absent from the compiler IR, so including them in nodeList is harmless but
+    excluding them produces a cleaner MDP closer to the compiler dump.
+
+    Op types that the compiler never folds (ProtobufLoader.cpp:68):
+        Loop, Const, Identity, If, DequantizeLinear
+    """
+    # const_values: output tensor names whose value is known at compile time.
+    # Seeded with all initializer names (model weights / constants).
+    const_values: Set[str] = {init.name for init in graph.initializer}
+
+    # Constant op outputs are trivially compile-time constants; collect them
+    # upfront so the fixed-point loop below only needs one pass for everything else.
+    for node in graph.node:
+        if node.op_type == "Constant":
+            const_values.update(out for out in node.output if out)
+
+    # Never-folded op types (compiler explicitly skips these - ProtobufLoader.cpp:68).
+    _NEVER_FOLD = frozenset({"Loop", "Const", "Identity", "If", "DequantizeLinear"})
+
+    # Keep marking nodes foldable until no new ones are found.
+    foldable_nodes: Set[str] = set()
+    while True:
+        changed = False
+        for node in graph.node:
+            if not node.name or node.name in foldable_nodes:
+                continue
+            if node.op_type in _NEVER_FOLD or not node.input:
+                continue
+            if all(inp in const_values for inp in node.input if inp):
+                foldable_nodes.add(node.name)
+                const_values.update(out for out in node.output if out)
+                changed = True
+        if not changed:
+            break
+
+    return foldable_nodes
+
+
+def _get_layer_num(node_name: str) -> Optional[int]:
+    """Return transformer layer index from node name, or None.
+
+    Supports:
+      - layers.N  (Llama/Mistral/Qwen/Gemma/Granite)
+      - h.N       (GPT-2)
+      - layer_N// prefix  (subfunctions/merged ONNX where each subgraph is
+                           prefixed with the layer index it belongs to, e.g.
+                           "layer_3//model/embed_tokens/Gather")
+    """
+    for part in node_name.split("/"):
+        if part.startswith("layers."):
+            suffix = part[len("layers.") :]
+            if suffix.isdigit():
+                return int(suffix)
+        elif part.startswith("h."):
+            suffix = part[len("h.") :]
+            if suffix.isdigit():
+                return int(suffix)
+        elif part.startswith("layer_"):
+            suffix = part[len("layer_") :]
+            if suffix.isdigit():
+                return int(suffix)
+    return None
+
+
+def _get_inlined_node_map(model) -> tuple:
+    """Classify ONNX local functions and build inlined sub-node names.
+
+    The compiler inlines a local function body into the parent graph during
+    ONNX import if it has < 100 nodes AND is not a known custom op
+    (ONNXModelLoaderSubFuns.cpp). Inlined call-sites do not appear in the
+    compiler IR; their sub-nodes are named <call_site>/<func_node>.
+    Known custom ops (registered via DEFINEKNOWNCUSTOMOP) keep their
+    call-site name in the IR and must be included in nodeList as-is.
+
+    Returns:
+        inlined_node_map:   dict mapping call-site name -> list of inlined
+                            sub-node names (<call_site>/<func_node>).
+        non_inlined_funcs:  set of function names that are NOT inlined
+                            (known custom ops or >= 100 nodes); their
+                            call-site names are valid nodeList entries.
+    """
+    # Op types registered via DEFINEKNOWNCUSTOMOP in ONNXModelLoaderCustomOp.cpp.
+    # The compiler loads these as a single named node (not expanded/inlined).
+    _KNOWN_CUSTOM_OPS = frozenset(
+        {
+            "CustomRMSNorm",
+            "CastToUInt4",
+        }
+    )
+
+    local_functions = {f.name: f for f in model.functions}
+    logger.info(f"Found {len(local_functions)} local function types: {set(local_functions.keys())}")
+
+    inlined_funcs: Set[str] = set()
+    non_inlined_funcs: Set[str] = set()
+    for func_name, func in local_functions.items():
+        if func_name in _KNOWN_CUSTOM_OPS or len(func.node) >= 100:
+            non_inlined_funcs.add(func_name)
+            logger.info(f"  {func_name}: not inlined")
+        else:
+            inlined_funcs.add(func_name)
+            logger.info(f"  {func_name}: {len(func.node)} nodes, will inline")
+
+    inlined_node_map: Dict[str, List[str]] = {}
+    for node in model.graph.node:
+        if node.op_type in inlined_funcs:
+            func = local_functions[node.op_type]
+            inlined_node_map[node.name] = [f"{node.name}/{fn.name}" for fn in func.node if fn.name]
+
+    logger.info(f"Inlined sub-nodes mapped for {len(inlined_node_map)} call-sites")
+    return inlined_node_map, non_inlined_funcs
+
+
+def generate_disagg_mdp_partition_config(
+    onnx_path: str,
+    num_devices: int,
+    num_partitions: int,
+    num_layers: int,
+    num_cores: int = 16,
+) -> Dict[str, Any]:
+    """Generate a pipeline-partitioned MDP config from an exported ONNX graph.
+
+    Assigns nodes to partitions by transformer layer index. Non-layer nodes
+    (embeddings, lm_head) follow the nearest layer in topological order.
+    nodeList is a superset of the compiler dump; the compiler silently ignores
+    optimized-away names. Inlined local function call-sites (CtxScatterCB,
+    CtxGatherCB) are excluded; their /nNN sub-nodes are assigned automatically.
+    Known custom ops (CustomRMSNorm) are included by call-site name.
+
+    For PP+TS: num_devices // num_partitions devices per partition; the
+    compiler applies tensor-slicing within each stage.
+
+    Args:
+        onnx_path:      Path to the exported ONNX file.
+        num_devices:    Total devices (num_partitions * ts_per_stage).
+        num_partitions: Number of pipeline stages.
+        num_layers:     Number of transformer layers.
+        num_cores:      NSP cores per device (default 16).
+
+    Returns:
+        dict with keys 'connections' and 'partitions'.
+    """
+
+    if num_partitions <= 0:
+        raise ValueError(f"Invalid number of partitions: {num_partitions}")
+
+    if num_partitions > num_devices:
+        raise ValueError(
+            f"Num of partitions should be <= number of devices. Found {num_partitions} partitions and {num_devices} devices"
+        )
+
+    layers_per_partition = num_layers // num_partitions
+    model = onnx.load(onnx_path, load_external_data=False)
+
+    # Verify topological order (ONNX spec §3.3). Fails loudly on malformed exports.
+    # Graph inputs and initializers are excluded — they are not produced by any node.
+    graph_input_names: Set[str] = {inp.name for inp in model.graph.input}
+    initializer_names: Set[str] = {init.name for init in model.graph.initializer}
+    external_names: Set[str] = graph_input_names | initializer_names
+
+    output_to_node: Dict[str, str] = {}
+    for node in model.graph.node:
+        for out in node.output:
+            if out:  # "" marks optional unused outputs
+                output_to_node[out] = node.name
+
+    seen_outputs: Set[str] = set()
+    for node in model.graph.node:
+        for inp in node.input:
+            if not inp:
+                continue
+            if inp in external_names:
+                continue
+            if inp in output_to_node and inp not in seen_outputs:
+                raise ValueError(
+                    f"ONNX graph has a cycle or violates topological order: "
+                    f"node '{node.name}' consumes '{inp}' produced by "
+                    f"'{output_to_node[inp]}', but that producer has not appeared yet."
+                )
+        for out in node.output:
+            if out:
+                seen_outputs.add(out)
+
+    logger.info("Computing constant-foldable nodes...")
+    folded_nodes = _get_compiler_folded_nodes(model.graph)
+    logger.info(f"Found {len(folded_nodes)} compiler-folded nodes (excluded from nodeList)")
+
+    _, non_inlined_functions = _get_inlined_node_map(model)
+    inlined_functions = {f.name for f in model.functions} - non_inlined_functions
+    local_functions = {f.name: f for f in model.functions}
+
+    # Single pass: assign main graph nodes to partitions by layer index.
+    # Inlined function call-sites are expanded inline (sub-nodes inserted at their
+    # topological position) so the nodeList ordering matches the ONNX topsort.
+    # The compiler's SplitPlanMerge reads nodeList as an ordered sequence; appending
+    # inlined sub-nodes out-of-order (in a second pass) causes unresolvable tensor
+    # splits in the split-plan merge loop.
+    partitions: List[List[str]] = [[] for _ in range(num_partitions)]
+    current_layer_partition = 0
+    seen_first_layer = False
+    max_layer_seen = -1
+
+    for node in model.graph.node:
+        if not node.name:
+            continue
+        if node.name in folded_nodes:
+            continue
+
+        layer_num = _get_layer_num(node.name)
+        if layer_num is not None:
+            max_layer_seen = max(max_layer_seen, layer_num)
+            seen_first_layer = True
+            partition_idx = min(layer_num // layers_per_partition, num_partitions - 1)
+            current_layer_partition = partition_idx
+        else:
+            partition_idx = 0 if not seen_first_layer else current_layer_partition
+
+        if node.op_type in inlined_functions:
+            # Expand the call-site inline: emit sub-nodes at this topological position.
+            func = local_functions[node.op_type]
+            sub_nodes = [f"{node.name}/{fn.name}" for fn in func.node if fn.name]
+            partitions[partition_idx].extend(sub_nodes)
+        else:
+            partitions[partition_idx].append(node.name)
+
+    for i, partition in enumerate(partitions):
+        logger.info(f"Partition {i}: {len(partition)} nodes")
+    logger.info(f"Total nodes in MDP: {sum(len(p) for p in partitions)}")
+
+    # PP-only: 1 device/partition; PP+TS: num_devices//num_partitions devices/partition.
+    device_ids = list(range(num_devices))
+    devices_per_partition = num_devices // num_partitions
+    partition_objs = []
+    for i, node_list in enumerate(partitions):
+        assigned_devices = device_ids[i * devices_per_partition : (i + 1) * devices_per_partition]
+        partition_objs.append(
+            {
+                "name": f"Partition{i}",
+                "nodeList": node_list,
+                "devices": [{"deviceId": dev_id, "numCores": num_cores} for dev_id in assigned_devices],
+            }
+        )
+
+    return {
+        "connections": [{"devices": device_ids, "type": "p2p"}],
+        "partitions": partition_objs,
+    }
+
+
+def generate_disagg_mdp_intersection_config(
+    onnx_path: str,
+    compiler_dump_path: str,
+    num_devices: int,
+    num_partitions: int,
+    num_layers: int,
+    num_cores: int = 16,
+) -> Dict[str, Any]:
+    """Generate an MDP config by intersecting the QEff MDP with the compiler dump.
+
+    The QEff MDP (derived from the ONNX graph) is always a superset of the
+    compiler dump: every node the compiler actually processes appears in the
+    QEff MDP, but the QEff MDP also contains nodes the compiler optimises away
+    (constant-folded, etc.).  The intersection keeps only nodes that survive
+    into the compiler IR, while preserving the **QEff MDP node order and
+    partition assignment** as the authoritative source of truth.
+
+    Algorithm
+    ---------
+    1. Generate the full QEff MDP via ``generate_disagg_mdp_partition_config``
+       (ONNX topsort, layer-heuristic partition assignment).  This is the
+       superset and determines both node order and partition boundaries.
+    2. Read the compiler dump JSON and collect the set of real Glow IR node
+       names the compiler will actually process.
+    3. For each partition in the QEff MDP, retain only nodes whose names appear
+       in the compiler dump set, in the original QEff order.
+
+    Why this is better than re-assigning compiler-dump nodes by heuristic:
+    - Node order follows the ONNX topsort (compiler's SplitPlanMerge requires
+      this); the compiler dump order is the compiler's internal IR order which
+      may differ after constant-folding and other transforms.
+    - Partition boundaries are the same as the onnx strategy — no divergence.
+    - Every retained node is an exact-match hit in ``doManualPartitioning()``.
+    - Output JSON is compact (~1-2 MB) because constant-folded nodes are pruned.
+
+    Parameters
+    ----------
+    onnx_path          : path to the exported ONNX file (same as used for
+                         ``generate_disagg_mdp_partition_config``).
+    compiler_dump_path : path to the JSON produced by
+                         ``qaic-compile -mdp-dump-partition-config=<path>``.
+    num_devices        : total devices (e.g. 2 for PP-only, 4 for 2x2 PP+TS).
+    num_partitions     : pipeline stages (e.g. 2).
+    num_layers         : transformer layers (e.g. 40, 94).
+    num_cores          : NSP cores per device (default 16).
+
+    Returns
+    -------
+    dict  with 'connections' and 'partitions' keys (same schema as all other
+          generate_disagg_mdp_* functions).
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
+    dump_path = _Path(compiler_dump_path)
+    if not dump_path.exists():
+        raise FileNotFoundError(
+            f"Compiler dump not found: {dump_path}. Run qaic-compile with -mdp-dump-partition-config=<path> first."
+        )
+
+    logger.info(f"Generating QEff MDP (superset) from ONNX: {onnx_path}")
+    qeff_mdp = generate_disagg_mdp_partition_config(
+        onnx_path=onnx_path,
+        num_devices=num_devices,
+        num_partitions=num_partitions,
+        num_layers=num_layers,
+        num_cores=num_cores,
+    )
+
+    logger.info(f"Loading compiler dump for intersection: {dump_path}")
+    with open(dump_path) as fh:
+        dump = _json.load(fh)
+
+    compiler_nodes: Set[str] = set()
+    for part in dump.get("partitions", []):
+        for name in part.get("nodeList", []):
+            if name:
+                compiler_nodes.add(name)
+
+    logger.info(f"Compiler dump: {len(compiler_nodes)} unique node names")
+
+    qeff_total = sum(len(p["nodeList"]) for p in qeff_mdp["partitions"])
+    logger.info(f"QEff MDP (superset): {qeff_total} nodes across {num_partitions} partitions")
+
+    partition_objs = []
+    total_kept = 0
+    total_dropped = 0
+    for part in qeff_mdp["partitions"]:
+        kept = [name for name in part["nodeList"] if name in compiler_nodes]
+        dropped = len(part["nodeList"]) - len(kept)
+        total_kept += len(kept)
+        total_dropped += dropped
+        logger.info(
+            f"  {part['name']}: {len(part['nodeList'])} QEff nodes "
+            f"-> {len(kept)} kept, {dropped} dropped (compiler-optimised away)"
+        )
+        partition_objs.append(
+            {
+                "name": part["name"],
+                "nodeList": kept,
+                "devices": part["devices"],
+            }
+        )
+
+    logger.info(
+        f"Intersection: {total_kept} nodes kept, {total_dropped} dropped "
+        f"({total_dropped * 100 // max(qeff_total, 1)}% pruned by compiler)"
+    )
+
+    in_dump_not_qeff = compiler_nodes - {name for part in qeff_mdp["partitions"] for name in part["nodeList"]}
+    if in_dump_not_qeff:
+        logger.warning(
+            f"{len(in_dump_not_qeff)} compiler-dump nodes not found in QEff MDP "
+            f"(compiler may have renamed them). Examples: {list(in_dump_not_qeff)[:5]}"
+        )
+
+    return {
+        "connections": qeff_mdp["connections"],
+        "partitions": partition_objs,
+    }

--- a/QEfficient/compile/mdp_generator.py
+++ b/QEfficient/compile/mdp_generator.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # -----------------------------------------------------------------------------
-"""MDP generator for disaggregated prefill serving (PP-enabled, TS-enabled, stages>1)."""
+"""MDP generator: template tensor-slice configs and disaggregated prefill configs (PP-enabled, TS-enabled, stages>1)."""
 
 import bisect
 import logging
@@ -14,6 +14,8 @@ from typing import Any, Dict, List, Optional, Set
 import onnx
 
 logger = logging.getLogger(__name__)
+
+_MAX_INLINABLE_NODES = 100
 
 
 class MdpStrategy(str, Enum):
@@ -145,15 +147,17 @@ def _get_inlined_node_map(model) -> tuple:
     """Classify ONNX local functions and build inlined sub-node names.
 
     The compiler inlines a local function body into the parent graph during
-    ONNX import if it has < 100 nodes AND is not a known custom op
-    (ONNXModelLoaderSubFuns.cpp).  Inlined call-sites do not appear in the
-    compiler IR; their sub-nodes are named ``<call_site>/<func_node>``.
-    Known custom ops (registered via DEFINEKNOWNCUSTOMOP) keep their
-    call-site name in the IR and must be included in nodeList as-is.
+    ONNX import if it has fewer than _MAX_INLINABLE_NODES nodes AND is not a
+    known custom op (ONNXModelLoaderSubFuns.cpp).  Inlined call-sites do not
+    appear in the compiler IR; their sub-nodes are named
+    ``<call_site>/<func_node>``.  Known custom ops (registered via
+    DEFINEKNOWNCUSTOMOP) keep their call-site name in the IR and must be
+    included in nodeList as-is.
 
     Returns:
         inlined_node_map:  call-site name -> list of inlined sub-node names.
-        non_inlined_funcs: function names NOT inlined (custom ops or >=100 nodes).
+        non_inlined_funcs: function names NOT inlined (custom ops or
+            >= _MAX_INLINABLE_NODES nodes).
     """
     # Op types registered via DEFINEKNOWNCUSTOMOP in ONNXModelLoaderCustomOp.cpp.
     _KNOWN_CUSTOM_OPS = frozenset(
@@ -169,7 +173,7 @@ def _get_inlined_node_map(model) -> tuple:
     inlined_funcs: Set[str] = set()
     non_inlined_funcs: Set[str] = set()
     for func_name, func in local_functions.items():
-        if func_name in _KNOWN_CUSTOM_OPS or len(func.node) >= 100:
+        if func_name in _KNOWN_CUSTOM_OPS or len(func.node) >= _MAX_INLINABLE_NODES:
             non_inlined_funcs.add(func_name)
             logger.info(f"  {func_name}: not inlined")
         else:
@@ -184,6 +188,34 @@ def _get_inlined_node_map(model) -> tuple:
 
     logger.info(f"Inlined sub-nodes mapped for {len(inlined_node_map)} call-sites")
     return inlined_node_map, non_inlined_funcs
+
+
+def generate_mdp_partition_config(num_devices: int, num_cores: int) -> Dict[str, Any]:
+    """Generate a template tensor-slice MDP partition config (single partition, all devices).
+
+    All ``num_devices`` devices are placed in a single ``Partition0`` so the
+    compiler distributes tensor-slice work evenly across them.  The
+    ``connections`` block lists every device ID as a p2p group.
+
+    Args:
+        num_devices (int): Total number of devices.
+        num_cores (int): NSP cores per device.
+
+    Returns:
+        dict: MDP config with ``connections`` and ``partitions`` keys.
+              ``connections`` contains one entry with all device IDs and type
+              ``"p2p"``.  ``partitions`` contains a single ``Partition0`` entry
+              with a ``devices`` list of ``{"deviceId": …, "numCores": …}`` dicts.
+    """
+    return {
+        "connections": [{"devices": list(range(num_devices)), "type": "p2p"}],
+        "partitions": [
+            {
+                "name": "Partition0",
+                "devices": [{"deviceId": d, "numCores": num_cores} for d in range(num_devices)],
+            }
+        ],
+    }
 
 
 def generate_disagg_mdp_partition_config(
@@ -271,7 +303,6 @@ def generate_disagg_mdp_partition_config(
     partitions: List[List[str]] = [[] for _ in range(num_partitions)]
     current_layer_partition = 0
     seen_first_layer = False
-    max_layer_seen = -1
 
     for node in model.graph.node:
         if not node.name:
@@ -281,7 +312,6 @@ def generate_disagg_mdp_partition_config(
 
         layer_num = _get_layer_num(node.name)
         if layer_num is not None:
-            max_layer_seen = max(max_layer_seen, layer_num)
             seen_first_layer = True
             partition_idx = bisect.bisect_right(partition_bounds, layer_num)
             current_layer_partition = partition_idx
@@ -302,6 +332,11 @@ def generate_disagg_mdp_partition_config(
 
     # PP-only: 1 device/partition; PP+TS: num_devices//num_partitions per partition.
     device_ids = list(range(num_devices))
+    if num_devices % num_partitions != 0:
+        logger.warning(
+            f"num_devices ({num_devices}) is not evenly divisible by num_partitions ({num_partitions}). "
+            "Floor-division allocation is used, so extra devices will not be assigned to any partition."
+        )
     devices_per_partition = num_devices // num_partitions
     partition_objs = []
     for i, node_list in enumerate(partitions):

--- a/QEfficient/compile/mdp_generator.py
+++ b/QEfficient/compile/mdp_generator.py
@@ -9,9 +9,12 @@
 import bisect
 import logging
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import onnx
+
+from QEfficient.utils import create_json
 
 logger = logging.getLogger(__name__)
 
@@ -475,3 +478,72 @@ def generate_disagg_mdp_intersection_config(
         "connections": qeff_mdp["connections"],
         "partitions": partition_objs,
     }
+
+
+def generate_disagg_mdp_config(
+    onnx_path: Path,
+    compile_dir: Path,
+    mdp_ts_num_devices: int,
+    mdp_num_partitions: int,
+    mdp_strategy: MdpStrategy,
+    mdp_compiler_dump_path: Optional[str],
+    num_cores: int,
+    num_layers: int,
+) -> Tuple[Path, Dict[str, Any]]:
+    """Dispatch to the appropriate disaggregated MDP generator and persist the result.
+
+    Selects between the ONNX-based and intersection-based strategies, writes the
+    partition config JSON to *compile_dir*, and returns ``(json_path, json_object)``
+    for use by the compile flow.
+
+    Args:
+        onnx_path: Path to the exported ONNX model file.
+        compile_dir: Directory where the JSON config will be written.
+        mdp_ts_num_devices: Total number of devices across all partitions.
+        mdp_num_partitions: Number of pipeline-parallel partitions (stages).
+        mdp_strategy: :class:`MdpStrategy` enum value selecting ONNX or INTERSECTION.
+        mdp_compiler_dump_path: Path to a prior ``qaic-compile -mdp-dump-partition-config``
+            dump; required when *mdp_strategy* is ``INTERSECTION``.
+        num_cores: NSP cores per device.
+        num_layers: Number of transformer layers in the model.
+
+    Returns:
+        Tuple of ``(json_path, json_object)`` where *json_path* is the :class:`~pathlib.Path`
+        of the written file and *json_object* is the in-memory partition config dict.
+
+    Raises:
+        ValueError: When *mdp_strategy* is INTERSECTION but *mdp_compiler_dump_path* is not set.
+    """
+    logger.info(
+        f"Generating disagg MDP (strategy={mdp_strategy.value!r}): "
+        f"num_devices={mdp_ts_num_devices}, num_partitions={mdp_num_partitions}, "
+        f"num_layers={num_layers}, num_cores={num_cores}"
+    )
+
+    if mdp_strategy is MdpStrategy.ONNX:
+        mdp_ts_json = generate_disagg_mdp_partition_config(
+            onnx_path=str(onnx_path),
+            num_devices=mdp_ts_num_devices,
+            num_partitions=mdp_num_partitions,
+            num_layers=num_layers,
+            num_cores=num_cores,
+        )
+    else:
+        if not mdp_compiler_dump_path:
+            raise ValueError(
+                "mdp_strategy='intersection' requires mdp_compiler_dump_path to be set. "
+                "Run qaic-compile with -mdp-dump-partition-config=<path> first, "
+                "then pass that path as mdp_compiler_dump_path."
+            )
+        mdp_ts_json = generate_disagg_mdp_intersection_config(
+            onnx_path=str(onnx_path),
+            compiler_dump_path=mdp_compiler_dump_path,
+            num_devices=mdp_ts_num_devices,
+            num_partitions=mdp_num_partitions,
+            num_layers=num_layers,
+            num_cores=num_cores,
+        )
+
+    mdp_ts_json_path = compile_dir / f"mdp_disagg_{mdp_ts_num_devices}d_{mdp_num_partitions}p.json"
+    create_json(str(mdp_ts_json_path), mdp_ts_json)
+    return mdp_ts_json_path, mdp_ts_json

--- a/QEfficient/compile/mdp_generator.py
+++ b/QEfficient/compile/mdp_generator.py
@@ -19,17 +19,10 @@ logger = logging.getLogger(__name__)
 class MdpStrategy(str, Enum):
     """MDP partition-config generation strategy for disaggregated prefill.
 
-    ONNX        : Enumerate every node from the exported ONNX graph and assign
-                  to partitions by transformer layer index.  No prior compile
-                  run needed; produces a ~19 MB JSON that is a superset of the
-                  real Glow IR.  Default.
-
-    INTERSECTION: Requires a prior ``qaic-compile -mdp-dump-partition-config``
-                  run.  Generates the full ONNX-based MDP (superset), then
-                  filters each partition's nodeList to only the exact Glow IR
-                  node names present in the compiler dump.  Result is compact
-                  (~1-2 MB) and contains only exact-match names for the
-                  compiler's ``doManualPartitioning()``.
+    ONNX        : Enumerate every node from the ONNX graph; assigns to partitions
+                  by layer index.  No prior compile run needed (~19 MB JSON superset).
+    INTERSECTION: Requires a prior ``qaic-compile -mdp-dump-partition-config`` run.
+                  Filters the ONNX MDP to only exact Glow IR names; compact (~1-2 MB).
     """
 
     ONNX = "onnx"
@@ -40,20 +33,17 @@ def _get_compiler_folded_nodes(graph) -> Set[str]:
     """Return node names the compiler will fold away during ONNX import.
 
     Mirrors computeIsConstantFoldable() in ONNXModelLoader.cpp: a node is
-    foldable if every one of its inputs is a compile-time constant (initializer,
-    Constant op output, or output of another foldable node). Folded nodes are
-    absent from the compiler IR, so including them in nodeList is harmless but
-    excluding them produces a cleaner MDP closer to the compiler dump.
+    foldable if every input is a compile-time constant (initializer, Constant
+    op output, or output of another foldable node).  Folded nodes are absent
+    from the compiler IR; excluding them produces a cleaner MDP.
 
     Op types that the compiler never folds (ProtobufLoader.cpp:68):
         Loop, Const, Identity, If, DequantizeLinear
     """
-    # const_values: output tensor names whose value is known at compile time.
-    # Seeded with all initializer names (model weights / constants).
+    # Seed with initializer names (weights/constants known at compile time).
     const_values: Set[str] = {init.name for init in graph.initializer}
 
-    # Constant op outputs are trivially compile-time constants; collect them
-    # upfront so the fixed-point loop below only needs one pass for everything else.
+    # Constant op outputs are trivially compile-time constants.
     for node in graph.node:
         if node.op_type == "Constant":
             const_values.update(out for out in node.output if out)
@@ -109,32 +99,14 @@ def _get_layer_num(node_name: str) -> Optional[int]:
 def _layer_partition_bounds(num_layers: int, num_partitions: int) -> List[int]:
     """Compute exclusive-upper-bound layer bounds for balanced pipeline partitioning.
 
-    Distributes remainder layers so that the last partition (which carries postprocessing
-    such as lm_head and final norm) always receives only the base allocation.  Remainder
-    layers are spread to the middle partitions first (indices 1 .. num_partitions-2),
-    filling left-to-right starting from the centre of the middle zone.  The first
-    partition (which carries embedding preprocessing) absorbs any overflow only when
-    the remainder exceeds the number of available middle stages.
+    Remainder layers are spread to middle partitions first (indices 1..n-2),
+    filling outward from the centre.  The first partition absorbs overflow only
+    when remainder exceeds the number of middle stages.  The last partition
+    (postprocessing — lm_head, final norm) always receives only the base count.
 
-    Worst case (remainder == num_partitions - 1): every stage except the last receives
-    one extra layer.
-
-    Special cases:
-      num_partitions == 1  — single stage; returns an empty list.
-      num_partitions == 2  — no middle zone; any remainder goes to the first stage.
-
-    Returns:
-        A list of length (num_partitions - 1).  bounds[i] is the exclusive upper
-        bound of partition i.  Use ``bisect.bisect_right(bounds, layer_num)`` to
-        map a layer index to its partition index.
-
-    Examples (layer counts [partition-0, partition-1, ...]):
-        12 layers / 4 stages  ->  [3, 3, 3, 3]   (no remainder)
-        9  layers / 4 stages  ->  [2, 3, 2, 2]   (r=1  -> centre-middle gets +1)
-        10 layers / 4 stages  ->  [2, 3, 3, 2]   (r=2  -> both middle get +1)
-        11 layers / 4 stages  ->  [3, 3, 3, 2]   (r=3 = n-1 -> first+middle get +1)
-        8  layers / 3 stages  ->  [3, 3, 2]       (r=2 = n-1 -> first+middle get +1)
-        5  layers / 2 stages  ->  [3, 2]           (r=1 -> first gets +1)
+    Returns a list of length (num_partitions - 1); use
+    ``bisect.bisect_right(bounds, layer_num)`` to map a layer to its partition.
+    Returns an empty list when num_partitions == 1.
     """
     base = num_layers // num_partitions
     remainder = num_layers % num_partitions
@@ -174,20 +146,16 @@ def _get_inlined_node_map(model) -> tuple:
 
     The compiler inlines a local function body into the parent graph during
     ONNX import if it has < 100 nodes AND is not a known custom op
-    (ONNXModelLoaderSubFuns.cpp). Inlined call-sites do not appear in the
-    compiler IR; their sub-nodes are named <call_site>/<func_node>.
+    (ONNXModelLoaderSubFuns.cpp).  Inlined call-sites do not appear in the
+    compiler IR; their sub-nodes are named ``<call_site>/<func_node>``.
     Known custom ops (registered via DEFINEKNOWNCUSTOMOP) keep their
     call-site name in the IR and must be included in nodeList as-is.
 
     Returns:
-        inlined_node_map:   dict mapping call-site name -> list of inlined
-                            sub-node names (<call_site>/<func_node>).
-        non_inlined_funcs:  set of function names that are NOT inlined
-                            (known custom ops or >= 100 nodes); their
-                            call-site names are valid nodeList entries.
+        inlined_node_map:  call-site name -> list of inlined sub-node names.
+        non_inlined_funcs: function names NOT inlined (custom ops or >=100 nodes).
     """
     # Op types registered via DEFINEKNOWNCUSTOMOP in ONNXModelLoaderCustomOp.cpp.
-    # The compiler loads these as a single named node (not expanded/inlined).
     _KNOWN_CUSTOM_OPS = frozenset(
         {
             "CustomRMSNorm",
@@ -227,19 +195,16 @@ def generate_disagg_mdp_partition_config(
 ) -> Dict[str, Any]:
     """Generate a pipeline-partitioned MDP config from an exported ONNX graph.
 
-    Assigns nodes to partitions by transformer layer index using a balanced
-    remainder distribution: the last partition (postprocessing — lm_head, final
-    norm) always receives only the base layer count; any remainder layers are
-    spread to the middle partitions first, then to the first partition (embedding
-    preprocessing) only when the remainder exceeds the number of middle stages.
-    Non-layer nodes (embeddings, lm_head) follow the nearest layer in topological
-    order.  nodeList is a superset of the compiler dump; the compiler silently
-    ignores optimized-away names.  Inlined local function call-sites
-    (CtxScatterCB, CtxGatherCB) are excluded; their /nNN sub-nodes are assigned
-    automatically.  Known custom ops (CustomRMSNorm) are included by call-site name.
+    Assigns ONNX nodes to partitions by transformer layer index using a balanced
+    remainder distribution (last partition always gets the base count; remainder
+    spreads to middle stages first, then to the first stage).  Non-layer nodes
+    (embeddings, lm_head) follow the nearest layer in topological order.  nodeList
+    is a superset of the compiler dump; the compiler silently ignores names it has
+    optimised away.  Inlined local function call-sites are excluded; their
+    ``/nNN`` sub-nodes are assigned in topological position.  Known custom ops
+    (e.g. CustomRMSNorm) are included by call-site name.
 
-    For PP+TS: num_devices // num_partitions devices per partition; the
-    compiler applies tensor-slicing within each stage.
+    For PP+TS: ``num_devices // num_partitions`` devices per partition.
 
     Args:
         onnx_path:      Path to the exported ONNX file.
@@ -300,12 +265,9 @@ def generate_disagg_mdp_partition_config(
     inlined_functions = {f.name for f in model.functions} - non_inlined_functions
     local_functions = {f.name: f for f in model.functions}
 
-    # Single pass: assign main graph nodes to partitions by layer index.
-    # Inlined function call-sites are expanded inline (sub-nodes inserted at their
-    # topological position) so the nodeList ordering matches the ONNX topsort.
-    # The compiler's SplitPlanMerge reads nodeList as an ordered sequence; appending
-    # inlined sub-nodes out-of-order (in a second pass) causes unresolvable tensor
-    # splits in the split-plan merge loop.
+    # Single pass: assign main-graph nodes by layer index.  Inlined call-sites
+    # are expanded in topological position so nodeList order matches the ONNX
+    # topsort — required by the compiler's SplitPlanMerge.
     partitions: List[List[str]] = [[] for _ in range(num_partitions)]
     current_layer_partition = 0
     seen_first_layer = False
@@ -338,7 +300,7 @@ def generate_disagg_mdp_partition_config(
         logger.info(f"Partition {i}: {len(partition)} nodes")
     logger.info(f"Total nodes in MDP: {sum(len(p) for p in partitions)}")
 
-    # PP-only: 1 device/partition; PP+TS: num_devices//num_partitions devices/partition.
+    # PP-only: 1 device/partition; PP+TS: num_devices//num_partitions per partition.
     device_ids = list(range(num_devices))
     devices_per_partition = num_devices // num_partitions
     partition_objs = []

--- a/QEfficient/compile/mdp_generator.py
+++ b/QEfficient/compile/mdp_generator.py
@@ -6,6 +6,7 @@
 # -----------------------------------------------------------------------------
 """MDP generator for disaggregated prefill serving (PP-enabled, TS-enabled, stages>1)."""
 
+import bisect
 import logging
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set
@@ -105,6 +106,69 @@ def _get_layer_num(node_name: str) -> Optional[int]:
     return None
 
 
+def _layer_partition_bounds(num_layers: int, num_partitions: int) -> List[int]:
+    """Compute exclusive-upper-bound layer bounds for balanced pipeline partitioning.
+
+    Distributes remainder layers so that the last partition (which carries postprocessing
+    such as lm_head and final norm) always receives only the base allocation.  Remainder
+    layers are spread to the middle partitions first (indices 1 .. num_partitions-2),
+    filling left-to-right starting from the centre of the middle zone.  The first
+    partition (which carries embedding preprocessing) absorbs any overflow only when
+    the remainder exceeds the number of available middle stages.
+
+    Worst case (remainder == num_partitions - 1): every stage except the last receives
+    one extra layer.
+
+    Special cases:
+      num_partitions == 1  — single stage; returns an empty list.
+      num_partitions == 2  — no middle zone; any remainder goes to the first stage.
+
+    Returns:
+        A list of length (num_partitions - 1).  bounds[i] is the exclusive upper
+        bound of partition i.  Use ``bisect.bisect_right(bounds, layer_num)`` to
+        map a layer index to its partition index.
+
+    Examples (layer counts [partition-0, partition-1, ...]):
+        12 layers / 4 stages  ->  [3, 3, 3, 3]   (no remainder)
+        9  layers / 4 stages  ->  [2, 3, 2, 2]   (r=1  -> centre-middle gets +1)
+        10 layers / 4 stages  ->  [2, 3, 3, 2]   (r=2  -> both middle get +1)
+        11 layers / 4 stages  ->  [3, 3, 3, 2]   (r=3 = n-1 -> first+middle get +1)
+        8  layers / 3 stages  ->  [3, 3, 2]       (r=2 = n-1 -> first+middle get +1)
+        5  layers / 2 stages  ->  [3, 2]           (r=1 -> first gets +1)
+    """
+    base = num_layers // num_partitions
+    remainder = num_layers % num_partitions
+    sizes: List[int] = [base] * num_partitions
+
+    if remainder > 0 and num_partitions >= 2:
+        if num_partitions == 2:
+            sizes[0] += remainder
+        else:
+            num_middle = num_partitions - 2
+            middle_fill = min(remainder, num_middle)
+            first_fill = remainder - middle_fill
+            mid_center = (1 + num_partitions - 2) // 2
+            left, right, filled = mid_center, mid_center + 1, 0
+            while filled < middle_fill:
+                if left >= 1:
+                    sizes[left] += 1
+                    left -= 1
+                    filled += 1
+                if filled < middle_fill and right <= num_partitions - 2:
+                    sizes[right] += 1
+                    right += 1
+                    filled += 1
+            if first_fill > 0:
+                sizes[0] += 1
+
+    cumsum = 0
+    bounds: List[int] = []
+    for sz in sizes[:-1]:
+        cumsum += sz
+        bounds.append(cumsum)
+    return bounds
+
+
 def _get_inlined_node_map(model) -> tuple:
     """Classify ONNX local functions and build inlined sub-node names.
 
@@ -163,12 +227,16 @@ def generate_disagg_mdp_partition_config(
 ) -> Dict[str, Any]:
     """Generate a pipeline-partitioned MDP config from an exported ONNX graph.
 
-    Assigns nodes to partitions by transformer layer index. Non-layer nodes
-    (embeddings, lm_head) follow the nearest layer in topological order.
-    nodeList is a superset of the compiler dump; the compiler silently ignores
-    optimized-away names. Inlined local function call-sites (CtxScatterCB,
-    CtxGatherCB) are excluded; their /nNN sub-nodes are assigned automatically.
-    Known custom ops (CustomRMSNorm) are included by call-site name.
+    Assigns nodes to partitions by transformer layer index using a balanced
+    remainder distribution: the last partition (postprocessing — lm_head, final
+    norm) always receives only the base layer count; any remainder layers are
+    spread to the middle partitions first, then to the first partition (embedding
+    preprocessing) only when the remainder exceeds the number of middle stages.
+    Non-layer nodes (embeddings, lm_head) follow the nearest layer in topological
+    order.  nodeList is a superset of the compiler dump; the compiler silently
+    ignores optimized-away names.  Inlined local function call-sites
+    (CtxScatterCB, CtxGatherCB) are excluded; their /nNN sub-nodes are assigned
+    automatically.  Known custom ops (CustomRMSNorm) are included by call-site name.
 
     For PP+TS: num_devices // num_partitions devices per partition; the
     compiler applies tensor-slicing within each stage.
@@ -192,7 +260,7 @@ def generate_disagg_mdp_partition_config(
             f"Num of partitions should be <= number of devices. Found {num_partitions} partitions and {num_devices} devices"
         )
 
-    layers_per_partition = num_layers // num_partitions
+    partition_bounds = _layer_partition_bounds(num_layers, num_partitions)
     model = onnx.load(onnx_path, load_external_data=False)
 
     # Verify topological order (ONNX spec §3.3). Fails loudly on malformed exports.
@@ -253,7 +321,7 @@ def generate_disagg_mdp_partition_config(
         if layer_num is not None:
             max_layer_seen = max(max_layer_seen, layer_num)
             seen_first_layer = True
-            partition_idx = min(layer_num // layers_per_partition, num_partitions - 1)
+            partition_idx = bisect.bisect_right(partition_bounds, layer_num)
             current_layer_partition = partition_idx
         else:
             partition_idx = 0 if not seen_first_layer else current_layer_partition

--- a/QEfficient/utils/__init__.py
+++ b/QEfficient/utils/__init__.py
@@ -18,7 +18,6 @@ from QEfficient.utils._utils import (  # noqa: F401
     create_model_params,
     custom_format_warning,
     dump_qconfig,
-    generate_mdp_partition_config,
     get_attr_or_key,
     get_num_layers_from_config,
     get_num_layers_vlm,

--- a/QEfficient/utils/_utils.py
+++ b/QEfficient/utils/_utils.py
@@ -752,32 +752,6 @@ def create_json(file_path: str, json_data: object):
         print(f"Failed to create JSON File {file_path}: {e}")
 
 
-def generate_mdp_partition_config(num_devices: int, num_cores: int) -> str:
-    """
-    Generates an MDP partition configuration JSON file using the create_json utility.
-
-    Args:
-        num_devices (int): Number of devices.
-        num_cores (int): Number of cores per device.
-        output_dir (str): Directory where the JSON file will be saved.
-
-    Returns:
-        str: Path to the generated JSON file.
-    """
-
-    mdp_config = {
-        "connections": [{"devices": list(range(num_devices)), "type": "p2p"}],
-        "partitions": [
-            {
-                "name": "Partition0",
-                "devices": [{"deviceId": d, "numCores": num_cores} for d in range(num_devices)],
-            }
-        ],
-    }
-
-    return mdp_config
-
-
 def model_swap(func):
     def wrapper(*args, **kwargs):
         if "model" in kwargs and kwargs["model"] is not None:

--- a/examples/README.md
+++ b/examples/README.md
@@ -98,6 +98,7 @@ Distributed inference across multiple devices.
 |---------|-------------|--------|
 | Basic Disaggregated Serving | Multi-device serving | [disagg_serving/gpt_oss_disagg_mode.py](disagg_serving/gpt_oss_disagg_mode.py) |
 | Chunking Disaggregated Serving | Multi-device serving | [disagg_serving/gpt_oss_disagg_mode_with_chunking.py](disagg_serving/gpt_oss_disagg_mode_with_chunking.py) |
+| Qwen3-VL MDP Compile | MDP compile-only validation for Qwen3-VL | [disagg_serving/qwen3_vl_mdp_compile.py](disagg_serving/qwen3_vl_mdp_compile.py) |
 
 ## Installation
 

--- a/examples/disagg_serving/README.md
+++ b/examples/disagg_serving/README.md
@@ -14,6 +14,39 @@
  - Optimized SWA i.e. reading only valid KV as per diagonal attention mask is enabled for this version by default
  - This model can be used for prefix_caching by passing `kv_cache_batch_size=<int>` in compile API
 
+## Multi-Device Pipeline (MDP) for prefill-only model
+MDP allows the prefill model to be partitioned across multiple devices in a pipeline-parallel fashion.
+Pass the options below to `qeff_model.compile()` together with `prefill_only=True`.
+
+| Option | Type | Description |
+|---|---|---|
+| `mdp_num_partitions` | `int` | Number of pipeline-parallel partitions. Values > 1 cause the compiler to generate a partition config. `mdp_ts_num_devices` must be evenly divisible by `mdp_num_partitions`; if it is not, floor-division is used to assign devices per partition and the remainder devices are unused/unassigned. |
+| `mdp_strategy` | `str` | Partitioning strategy: `"onnx"` derives cuts directly from the ONNX graph; `"intersection"` intersects ONNX graph nodes with a prior compiler dump to refine the cuts. |
+| `mdp_compiler_dump_path` | `str` | Path to the JSON produced by a prior compiler dump run. Required only when `mdp_strategy="intersection"`. |
+
+See [`qwen3_vl_mdp_compile.py`](qwen3_vl_mdp_compile.py) for a standalone compile-only script that validates MDP compilation for `Qwen/Qwen3-VL-30B-A3B-Instruct` using these options.
+
+### Example — ONNX strategy (recommended starting point)
+```python
+qeff_model.compile(
+    prefill_only=True,
+    mdp_ts_num_devices=4,
+    mdp_num_partitions=2,
+    mdp_strategy="onnx",
+)
+```
+
+### Example — intersection strategy (uses a prior compiler dump to refine partitions)
+```python
+qeff_model.compile(
+    prefill_only=True,
+    mdp_ts_num_devices=4,
+    mdp_num_partitions=2,
+    mdp_strategy="intersection",
+    mdp_compiler_dump_path="/path/to/compiler_dump.json",
+)
+```
+
 # Decode-only model
 ## Retain Sliding window length of KV for sliding window layers, default behavour when `prefill_seq_len=1` in compile API
  - This reduces the amount of DDR used by the model

--- a/examples/disagg_serving/qwen3_vl_mdp_compile.py
+++ b/examples/disagg_serving/qwen3_vl_mdp_compile.py
@@ -153,7 +153,7 @@ def main() -> None:
         mos=args.mos,
         mdp_ts_num_devices=args.mdp_ts_num_devices,  # total devices spread across all pipeline stages
         mdp_num_partitions=args.mdp_num_partitions,  # number of pipeline-parallel stages (partitions)
-        mdp_strategy=args.mdp_strategy,              # "onnx" (default) or "intersection" (needs compiler dump)
+        mdp_strategy=args.mdp_strategy,  # "onnx" (default) or "intersection" (needs compiler dump)
         mdp_compiler_dump_path=args.mdp_compiler_dump_path,  # required only for intersection strategy
         mxfp6_matmul=True,
         mxint8_kv_cache=True,

--- a/examples/disagg_serving/qwen3_vl_mdp_compile.py
+++ b/examples/disagg_serving/qwen3_vl_mdp_compile.py
@@ -1,0 +1,174 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+"""Compile-only validation: Qwen3-VL-30B language-prefill QPC with MDP.
+
+**Purpose — compile validation only.**
+This script is intended *solely* to verify that the Qwen3-VL language-prefill
+compile succeeds with Multi-Device Partitioning (MDP) options.  It does **not**
+run inference, create a ``QAICInferenceSession``, or execute any generated QPCs.
+Use it to confirm that the export + compile pipeline works end-to-end on your
+hardware configuration before integrating the QPC into a serving stack.
+
+The script exports and compiles the language-prefill partition of
+Qwen/Qwen3-VL-30B-A3B-Instruct for disaggregated serving.  It uses:
+
+  - ``mdp_ts_num_devices``  -- total number of AIC-100 devices across all
+                               pipeline stages (default: 4).
+  - ``mdp_num_partitions``  -- number of pipeline-parallel stages the model is
+                               split into for prefill (default: 2).
+  - ``mdp_strategy``        -- MDP partition-config generation strategy:
+                               ``onnx`` (default) enumerates every ONNX node;
+                               ``intersection`` requires a prior
+                               ``qaic-compile -mdp-dump-partition-config`` run
+                               and produces a compact JSON.
+  - ``mdp_compiler_dump_path`` -- path to the compiler-dump directory produced
+                               by the prior ``intersection`` run.  Required when
+                               ``--mdp_strategy intersection`` is chosen; the
+                               argparse validator below enforces this.
+
+Running this script will **load / download the HF model weights** and invoke
+the QEfficient export + compile pipeline.  Make sure:
+
+  * A valid QEfficient installation and Qualcomm Cloud AI 100 toolchain are
+    available in the active environment.
+  * ``HF_HUB_CACHE`` points to a location with sufficient disk space if you
+    want to redirect where the model is downloaded.
+  * ``QEFF_HOME`` controls where QPC artifacts are written (optional; defaults
+    to ``~/.cache/qeff``).
+
+No secrets or absolute environment-specific paths are embedded here.
+"""
+
+import argparse
+import sys
+
+import torch
+from transformers import AutoConfig
+
+from QEfficient import QEFFAutoModelForImageTextToText
+
+
+def parse_args() -> argparse.Namespace:
+    """Return parsed command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Compile Qwen3-VL-30B language-prefill QPC with MDP for disaggregated serving.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "--model_id",
+        default="Qwen/Qwen3-VL-30B-A3B-Instruct",
+        help="HuggingFace model identifier.",
+    )
+
+    parser.add_argument("--batch_size", type=int, default=1, help="Prefill batch size.")
+    parser.add_argument("--prefill_seq_len", type=int, default=128, help="Prefill sequence chunk length.")
+    parser.add_argument("--ctx_len", type=int, default=4096, help="Maximum context length (KV-cache slots).")
+    parser.add_argument("--height", type=int, default=354, help="Vision input height in pixels.")
+    parser.add_argument("--width", type=int, default=536, help="Vision input width in pixels.")
+    parser.add_argument("--num_cores", type=int, default=16, help="Number of AIC cores per device.")
+    parser.add_argument("--mos", type=int, default=1, help="Memory-over-subscription factor.")
+
+    parser.add_argument(
+        "--mdp_ts_num_devices",
+        type=int,
+        default=4,
+        help=(
+            "Total AIC-100 devices used across all pipeline stages. "
+            "Each stage receives mdp_ts_num_devices // mdp_num_partitions devices."
+        ),
+    )
+    parser.add_argument(
+        "--mdp_num_partitions",
+        type=int,
+        default=2,
+        help="Number of pipeline-parallel partitions for disaggregated prefill.",
+    )
+    parser.add_argument(
+        "--mdp_strategy",
+        choices=["onnx", "intersection"],
+        default="onnx",
+        help=(
+            "MDP partition-config generation strategy. "
+            "'onnx' enumerates every ONNX graph node (~19 MB JSON). "
+            "'intersection' filters to exact Glow IR names and requires "
+            "--mdp_compiler_dump_path."
+        ),
+    )
+    parser.add_argument(
+        "--mdp_compiler_dump_path",
+        default=None,
+        help=(
+            "Path to the directory produced by a prior "
+            "'qaic-compile -mdp-dump-partition-config' run. "
+            "Required when --mdp_strategy intersection is chosen."
+        ),
+    )
+
+    args = parser.parse_args()
+
+    if args.mdp_strategy == "intersection" and not args.mdp_compiler_dump_path:
+        parser.error(
+            "--mdp_compiler_dump_path is required when --mdp_strategy intersection is used. "
+            "Run 'qaic-compile -mdp-dump-partition-config' first to produce the dump directory, "
+            "then pass that path with --mdp_compiler_dump_path."
+        )
+
+    return args
+
+
+def main() -> None:
+    """Load model and compile language-prefill QPC with MDP options.
+
+    This function validates that the prefill compile step succeeds.  It
+    intentionally stops after ``compile()`` returns and prints the QPC path.
+    No ``QAICInferenceSession`` is created and no runtime inference is performed.
+    """
+    args = parse_args()
+
+    config = AutoConfig.from_pretrained(args.model_id)
+    config.dtype = "float16"
+
+    qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
+        args.model_id,
+        attn_implementation="eager",
+        kv_offload=True,
+        config=config,
+        dtype=torch.float16,
+        layerwise=False,
+    )
+
+    prefill_qpc_path = qeff_model.compile(
+        batch_size=args.batch_size,
+        prefill_seq_len=args.prefill_seq_len,
+        ctx_len=args.ctx_len,
+        height=args.height,
+        width=args.width,
+        num_cores=args.num_cores,
+        mos=args.mos,
+        mdp_ts_num_devices=args.mdp_ts_num_devices,  # total devices spread across all pipeline stages
+        mdp_num_partitions=args.mdp_num_partitions,  # number of pipeline-parallel stages (partitions)
+        mdp_strategy=args.mdp_strategy,              # "onnx" (default) or "intersection" (needs compiler dump)
+        mdp_compiler_dump_path=args.mdp_compiler_dump_path,  # required only for intersection strategy
+        mxfp6_matmul=True,
+        mxint8_kv_cache=True,
+        retain_full_kv=True,
+        split_model_io=True,
+        aic_enable_depth_first=True,
+        prefill_only=True,
+        enable_chunking=True,
+        skip_vision=True,
+        use_onnx_subfunctions=True,
+        layerwise=False,
+    )
+
+    print(f"Prefill QPC path: {prefill_qpc_path}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/transformers/models/causal_lm_models/check_causal_models.py
+++ b/tests/transformers/models/causal_lm_models/check_causal_models.py
@@ -56,6 +56,10 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
     qaic_config: Optional[dict] = None,
     retain_full_kv: Optional[bool] = None,
     compare_results: bool = False,
+    compile_only: bool = False,
+    mdp_num_partitions: Optional[int] = None,
+    mdp_strategy: Optional[str] = None,
+    use_onnx_subfunctions: bool = False,
 ):
     torch.manual_seed(42)
     replace_transformers_quantizers()
@@ -104,7 +108,7 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         else:
             pytorch_hf_tokens = api_runner.run_hf_model_on_pytorch(model_hf)
 
-    onnx_model_path = qeff_model.export()
+    onnx_model_path = qeff_model.export(use_onnx_subfunctions=use_onnx_subfunctions)
     if continuous_batching is False:
         ort_tokens = api_runner.run_kv_model_on_ort(onnx_model_path, is_tlm=is_tlm)
         gen_len = ort_tokens.shape[-1]
@@ -135,6 +139,12 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         }
         compiler_options["specializations"] = [prefill_spec, decode_spec]
 
+    mdp_compile_kwargs = {}
+    if mdp_num_partitions is not None:
+        mdp_compile_kwargs["mdp_num_partitions"] = mdp_num_partitions
+    if mdp_strategy is not None:
+        mdp_compile_kwargs["mdp_strategy"] = mdp_strategy
+
     qpc_path = qeff_model.compile(
         prefill_seq_len=prompt_len,
         ctx_len=ctx_len,
@@ -148,9 +158,15 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         prefill_only=prefill_only,
         batch_size=batch_size if continuous_batching else 1,
         full_batch_size=full_batch_size if continuous_batching else None,
+        use_onnx_subfunctions=use_onnx_subfunctions,
         **compiler_options,
+        **mdp_compile_kwargs,
     )
     assert os.path.isfile(os.path.join(os.path.dirname(qpc_path), "qconfig.json"))
+
+    if compile_only:
+        manual_cleanup(onnx_model_path)
+        return
 
     # Generate
     exec_info = qeff_model.generate(tokenizer, prompts=prompts)
@@ -200,6 +216,10 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         "batch_size": batch_size if continuous_batching else 1,
         "full_batch_size": full_batch_size if continuous_batching else None,
         "compiler_options": compiler_options,
+        "compile_only": compile_only,
+        "mdp_num_partitions": mdp_num_partitions,
+        "mdp_strategy": mdp_strategy,
+        "use_onnx_subfunctions": use_onnx_subfunctions,
     }
     assert dump_and_compare_results(
         model_name,

--- a/tests/transformers/models/causal_lm_models/test_causal_lm_models.py
+++ b/tests/transformers/models/causal_lm_models/test_causal_lm_models.py
@@ -53,6 +53,26 @@ def test_few_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup)
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name=model_name, n_layer=n_layer, manual_cleanup=manual_cleanup)
 
 
+@pytest.mark.few_layers
+@pytest.mark.on_qaic
+@pytest.mark.llm_model
+@pytest.mark.parametrize("use_onnx_subfunctions", [False, True])
+@pytest.mark.parametrize("model_name", test_models_causal)
+def test_few_causal_lm_onnx_mdp_compile_only(model_name, use_onnx_subfunctions, manual_cleanup):
+    if model_name in ModelConfig.SKIPPED_MODELS:
+        pytest.skip("Test skipped for this model due to issues in HF.")
+    n_layer = get_custom_n_layers(model_name)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name,
+        n_layer=n_layer,
+        manual_cleanup=manual_cleanup,
+        compile_only=True,
+        mdp_num_partitions=2,
+        mdp_strategy="onnx",
+        use_onnx_subfunctions=use_onnx_subfunctions,
+    )
+
+
 @pytest.mark.dummy_layers
 @pytest.mark.on_qaic
 @pytest.mark.llm_model

--- a/tests/transformers/models/image_text_to_text/test_image_text_to_text_models.py
+++ b/tests/transformers/models/image_text_to_text/test_image_text_to_text_models.py
@@ -43,6 +43,9 @@ with open(CONFIG_PATH, "r") as f:
     multimodal_models = config_data["image_text_models"]
 test_mm_models = [model_config["model_name"] for model_config in multimodal_models]
 model_config_dict = {model["model_name"]: model for model in multimodal_models}
+test_mm_moe_models = [
+    model["model_name"] for model in multimodal_models if "moe" in model.get("model_type", "")
+]
 
 NEW_GENERATION_TOKENS = 10
 
@@ -58,6 +61,10 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
     config: Optional[AutoConfig] = None,
     torch_dtype: Optional[torch.dtype] = torch.float32,
     compare_results: Optional[bool] = False,
+    compile_only: bool = False,
+    mdp_num_partitions: Optional[int] = None,
+    mdp_strategy: Optional[str] = None,
+    use_onnx_subfunctions: bool = False,
 ):
     prompt_len = model_config_dict[model_name]["prompt_len"]
     ctx_len = model_config_dict[model_name]["ctx_len"]
@@ -117,7 +124,14 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
         "mxfp6": False,
         "enable_qnn": enable_qnn,
         "qnn_config": qnn_config,
+        "use_onnx_subfunctions": use_onnx_subfunctions,
     }
+
+    mdp_compile_kwargs = {}
+    if mdp_num_partitions is not None:
+        mdp_compile_kwargs["mdp_num_partitions"] = mdp_num_partitions
+    if mdp_strategy is not None:
+        mdp_compile_kwargs["mdp_strategy"] = mdp_strategy
 
     if model_name in ModelConfig.INTERNVL_MODELS:
         tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True, use_fast=False)
@@ -239,11 +253,22 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
     #     "Tokens don't match for pytorch HF output and pytorch KV output"
     # )
 
-    _ = qeff_model.export()
+    _ = qeff_model.export(use_onnx_subfunctions=use_onnx_subfunctions)
     # ort_tokens = api_runner.run_vlm_kv_model_on_ort(onnx_model_path)
     # assert (pytorch_hf_tokens == ort_tokens).all(), "Tokens don't match for pytorch HF output and ORT output"
 
+    if mdp_compile_kwargs and model_name not in ModelConfig.INTERNVL_MODELS and model_name not in ModelConfig.MOLMO_MODELS:
+        compile_kwargs["skip_vision"] = True
+        compile_kwargs.update(mdp_compile_kwargs)
+    elif mdp_compile_kwargs:
+        compile_kwargs.update(mdp_compile_kwargs)
+
     qeff_model.compile(**compile_kwargs)
+
+    if compile_only:
+        manual_cleanup(qeff_model.onnx_path)
+        return
+
     streamer = TextStreamer(processor.tokenizer)
     print("QPC Outputs (QAIC):")
     exec_info = qeff_model.generate(inputs=inputs, generation_len=NEW_GENERATION_TOKENS, streamer=streamer)
@@ -304,6 +329,30 @@ def test_few_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(model_name, kv_off
         num_hidden_layers=model_config_dict[model_name]["num_layers"],
         kv_offload=kv_offload,
         manual_cleanup=manual_cleanup,
+    )
+
+
+@pytest.mark.few_layers
+@pytest.mark.on_qaic
+@pytest.mark.multimodal
+@pytest.mark.parametrize("model_name", test_mm_moe_models)
+@pytest.mark.parametrize("kv_offload", [True, False])
+def test_few_image_text_to_text_onnx_mdp_compile_only(model_name, kv_offload, manual_cleanup):
+    if model_name in ModelConfig.SKIPPED_MODELS:
+        pytest.skip("Test skipped for this model due to some issues.")
+    if model_name in ModelConfig.DUAL_QPC_MODELS and not kv_offload:
+        pytest.skip("These models require kv_offload=True for testing.")
+
+    torch.manual_seed(42)
+    check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name,
+        num_hidden_layers=model_config_dict[model_name]["num_layers"],
+        kv_offload=kv_offload,
+        manual_cleanup=manual_cleanup,
+        compile_only=True,
+        mdp_num_partitions=2,
+        mdp_strategy="onnx",
+        use_onnx_subfunctions=True,
     )
 
 

--- a/tests/transformers/models/image_text_to_text/test_image_text_to_text_models.py
+++ b/tests/transformers/models/image_text_to_text/test_image_text_to_text_models.py
@@ -43,9 +43,7 @@ with open(CONFIG_PATH, "r") as f:
     multimodal_models = config_data["image_text_models"]
 test_mm_models = [model_config["model_name"] for model_config in multimodal_models]
 model_config_dict = {model["model_name"]: model for model in multimodal_models}
-test_mm_moe_models = [
-    model["model_name"] for model in multimodal_models if "moe" in model.get("model_type", "")
-]
+test_mm_moe_models = [model["model_name"] for model in multimodal_models if "moe" in model.get("model_type", "")]
 
 NEW_GENERATION_TOKENS = 10
 
@@ -257,7 +255,11 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
     # ort_tokens = api_runner.run_vlm_kv_model_on_ort(onnx_model_path)
     # assert (pytorch_hf_tokens == ort_tokens).all(), "Tokens don't match for pytorch HF output and ORT output"
 
-    if mdp_compile_kwargs and model_name not in ModelConfig.INTERNVL_MODELS and model_name not in ModelConfig.MOLMO_MODELS:
+    if (
+        mdp_compile_kwargs
+        and model_name not in ModelConfig.INTERNVL_MODELS
+        and model_name not in ModelConfig.MOLMO_MODELS
+    ):
         compile_kwargs["skip_vision"] = True
         compile_kwargs.update(mdp_compile_kwargs)
     elif mdp_compile_kwargs:

--- a/tests/unit_test/base/test_modeling_qeff_base.py
+++ b/tests/unit_test/base/test_modeling_qeff_base.py
@@ -11,10 +11,19 @@ CPU-only tests that do NOT require QAIC hardware.
 Run with: pytest tests/unit_test/base/ -n auto -v
 """
 
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, List, Optional
+from unittest.mock import patch
+
+import onnx
 import pytest
 import torch
+from onnx import TensorProto, helper
 from transformers import GPT2Config, GPT2LMHeadModel, LlamaConfig, LlamaForCausalLM
 
+from QEfficient.compile.mdp_generator import _layer_partition_bounds
 from QEfficient.transformers.models.modeling_auto import QEFFAutoModelForCausalLM
 
 VOCAB_SIZE = 500
@@ -343,3 +352,275 @@ class TestQEFFBaseModelGetOnnxPath:
         onnx_path_1 = qeff.get_onnx_path()
         onnx_path_2 = qeff.get_onnx_path()
         assert str(onnx_path_1) == str(onnx_path_2)
+
+
+def _bounds_to_layer_counts(bounds: List[int], total_layers: int) -> List[int]:
+    """Convert exclusive-upper-bound list from _layer_partition_bounds to per-partition layer counts."""
+    pts = [0] + bounds + [total_layers]
+    return [pts[i + 1] - pts[i] for i in range(len(pts) - 1)]
+
+
+def _build_synthetic_gpt2_onnx(num_layers: int, out_path: Path) -> None:
+    """Write a minimal ONNX graph whose nodes carry 'h.N' transformer-layer names.
+
+    The graph has topology: embed_tokens -> h.0/* -> h.1/* -> ... -> lm_head.
+    No external data or weights are needed.  generate_disagg_mdp_partition_config
+    parses node names via _get_layer_num, so this is sufficient to exercise the
+    ONNX strategy end-to-end without loading a real model.
+    """
+    nodes: List[Any] = []
+    nodes.append(helper.make_node("Identity", inputs=["input_ids"], outputs=["embed_out"], name="embed_tokens"))
+    prev_out = "embed_out"
+    for layer_idx in range(num_layers):
+        attn_out = f"attn_out_{layer_idx}"
+        mlp_out = f"mlp_out_{layer_idx}"
+        nodes.append(
+            helper.make_node("Identity", inputs=[prev_out], outputs=[attn_out], name=f"h.{layer_idx}/attn")
+        )
+        nodes.append(helper.make_node("Identity", inputs=[attn_out], outputs=[mlp_out], name=f"h.{layer_idx}/mlp"))
+        prev_out = mlp_out
+    nodes.append(helper.make_node("Identity", inputs=[prev_out], outputs=["logits"], name="lm_head"))
+
+    graph = helper.make_graph(
+        nodes,
+        "synthetic_gpt2_graph",
+        [helper.make_tensor_value_info("input_ids", TensorProto.FLOAT, [1, 8])],
+        [helper.make_tensor_value_info("logits", TensorProto.FLOAT, [1, 8, 500])],
+    )
+    onnx_model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 17)])
+    onnx.save(onnx_model, str(out_path))
+
+
+def _fake_subprocess_run(command: List[str], **kwargs: Any) -> subprocess.CompletedProcess:
+    """Monkeypatch for subprocess.run: create programqpc.bin at the -aic-binary-dir path."""
+    binary_dir: Optional[Path] = None
+    for arg in command:
+        if arg.startswith("-aic-binary-dir="):
+            binary_dir = Path(arg.split("=", 1)[1])
+            break
+    if binary_dir is not None:
+        binary_dir.mkdir(parents=True, exist_ok=True)
+        (binary_dir / "programqpc.bin").write_bytes(b"FAKE_QPC")
+    return subprocess.CompletedProcess(args=command, returncode=0, stdout=b"", stderr=b"")
+
+
+@pytest.mark.cpu_only
+@pytest.mark.mdp
+class TestMdpLayerPartitionBounds:
+    """Unit tests for _layer_partition_bounds balanced remainder distribution (ONNX strategy only)."""
+
+    def test_8_layers_3_partitions_counts(self):
+        """8 layers / 3 partitions -> layer counts [3, 3, 2]."""
+        bounds = _layer_partition_bounds(8, 3)
+        counts = _bounds_to_layer_counts(bounds, 8)
+        assert counts == [3, 3, 2], f"Expected [3, 3, 2], got {counts}"
+
+    def test_10_layers_4_partitions_counts(self):
+        """10 layers / 4 partitions -> layer counts [2, 3, 3, 2]."""
+        bounds = _layer_partition_bounds(10, 4)
+        counts = _bounds_to_layer_counts(bounds, 10)
+        assert counts == [2, 3, 3, 2], f"Expected [2, 3, 3, 2], got {counts}"
+
+    def test_max_minus_min_le_1_for_8_3(self):
+        """max - min layer count <= 1 for 8/3 case (balanced distribution invariant)."""
+        counts = _bounds_to_layer_counts(_layer_partition_bounds(8, 3), 8)
+        assert max(counts) - min(counts) <= 1
+
+    def test_max_minus_min_le_1_for_10_4(self):
+        """max - min layer count <= 1 for 10/4 case (balanced distribution invariant)."""
+        counts = _bounds_to_layer_counts(_layer_partition_bounds(10, 4), 10)
+        assert max(counts) - min(counts) <= 1
+
+    def test_last_partition_receives_base_allocation_8_3(self):
+        """Last partition receives only the base (floor) allocation for 8/3."""
+        num_layers, num_partitions = 8, 3
+        base = num_layers // num_partitions
+        counts = _bounds_to_layer_counts(_layer_partition_bounds(num_layers, num_partitions), num_layers)
+        assert counts[-1] == base, f"Expected last partition to have base={base}, got {counts[-1]}"
+
+    def test_last_partition_receives_base_allocation_10_4(self):
+        """Last partition receives only the base (floor) allocation for 10/4."""
+        num_layers, num_partitions = 10, 4
+        base = num_layers // num_partitions
+        counts = _bounds_to_layer_counts(_layer_partition_bounds(num_layers, num_partitions), num_layers)
+        assert counts[-1] == base, f"Expected last partition to have base={base}, got {counts[-1]}"
+
+    def test_remainder_goes_to_middle_partitions_for_10_4(self):
+        """Remainder layers (2) go to middle partitions (indices 1 and 2) before index 0 for 10/4."""
+        bounds = _layer_partition_bounds(10, 4)
+        counts = _bounds_to_layer_counts(bounds, 10)
+        base = 10 // 4
+        middle_extras = sum(1 for c in counts[1:-1] if c > base)
+        first_extras = 1 if counts[0] > base else 0
+        assert middle_extras == 2, f"Expected 2 middle partitions with extra layer, got {middle_extras}"
+        assert first_extras == 0, f"Expected first partition to have base count, got {counts[0]}"
+
+    def test_evenly_divisible_has_zero_spread_12_4(self):
+        """12 layers / 4 partitions divides evenly; all counts equal base."""
+        counts = _bounds_to_layer_counts(_layer_partition_bounds(12, 4), 12)
+        assert counts == [3, 3, 3, 3], f"Expected [3, 3, 3, 3], got {counts}"
+
+    def test_two_partition_remainder_goes_to_first_5_2(self):
+        """5 layers / 2 partitions -> [3, 2]: remainder goes to first (no middle zone)."""
+        counts = _bounds_to_layer_counts(_layer_partition_bounds(5, 2), 5)
+        assert counts == [3, 2], f"Expected [3, 2], got {counts}"
+
+    def test_bounds_length_equals_num_partitions_minus_one(self):
+        """_layer_partition_bounds returns a list of length num_partitions - 1."""
+        for num_layers, num_partitions in [(8, 3), (10, 4), (12, 4), (5, 2)]:
+            bounds = _layer_partition_bounds(num_layers, num_partitions)
+            assert len(bounds) == num_partitions - 1, (
+                f"Expected {num_partitions - 1} bounds for {num_layers}/{num_partitions}, got {len(bounds)}"
+            )
+
+    def test_total_layers_preserved(self):
+        """Sum of per-partition layer counts equals num_layers for all test cases."""
+        for num_layers, num_partitions in [(8, 3), (10, 4), (12, 4), (5, 2), (9, 4)]:
+            counts = _bounds_to_layer_counts(_layer_partition_bounds(num_layers, num_partitions), num_layers)
+            assert sum(counts) == num_layers, (
+                f"Expected sum={num_layers} for {num_layers}/{num_partitions}, got {sum(counts)}"
+            )
+
+
+@pytest.mark.cpu_only
+@pytest.mark.mdp
+class TestMdpCompileIntegration:
+    """CPU-only compile integration tests for the ONNX MDP strategy.
+
+    Uses a synthetic ONNX graph (no HF Hub download) and monkeypatches
+    subprocess.run so no real qaic-compile binary is invoked.
+    """
+
+    @pytest.fixture()
+    def compile_workspace(self, tmp_path: Path):
+        """Provide a workspace with a synthetic ONNX and an empty compile directory."""
+        onnx_path = tmp_path / "model.onnx"
+        _build_synthetic_gpt2_onnx(num_layers=2, out_path=onnx_path)
+        compile_dir = tmp_path / "compile_out"
+        compile_dir.mkdir(parents=True, exist_ok=True)
+        return tmp_path, onnx_path, compile_dir
+
+    def _run_mdp_compile(
+        self,
+        compile_workspace,
+        mdp_ts_num_devices: int = 4,
+        mdp_num_partitions: int = 2,
+        mdp_strategy: str = "onnx",
+    ) -> tuple:
+        """Build QEFFAutoModelForCausalLM, monkeypatch subprocess, run compile, return artifacts."""
+        tmp_path, onnx_path, compile_dir = compile_workspace
+        model_hf, _ = make_tiny_gpt2()
+        qeff = QEFFAutoModelForCausalLM(model_hf)
+
+        with patch("QEfficient.base.modeling_qeff.subprocess.run", side_effect=_fake_subprocess_run):
+            qeff._compile(
+                onnx_path=str(onnx_path),
+                compile_dir=str(compile_dir),
+                mdp_ts_num_devices=mdp_ts_num_devices,
+                mdp_num_partitions=mdp_num_partitions,
+                mdp_strategy=mdp_strategy,
+            )
+
+        return compile_dir, onnx_path, qeff
+
+    def test_mdp_disagg_json_is_created(self, compile_workspace):
+        """mdp_disagg_4d_2p.json is written to compile_dir when mdp_num_partitions=2."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        disagg_files = list(compile_dir.glob("mdp_disagg_4d_2p.json"))
+        assert len(disagg_files) == 1, "Expected exactly one mdp_disagg_4d_2p.json in compile_dir"
+
+    def test_mdp_disagg_json_has_two_partitions(self, compile_workspace):
+        """mdp_disagg_4d_2p.json contains exactly two partitions."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        disagg_path = compile_dir / "mdp_disagg_4d_2p.json"
+        with open(disagg_path) as fh:
+            mdp_data = json.load(fh)
+        assert len(mdp_data["partitions"]) == 2
+
+    def test_mdp_disagg_partition0_devices_are_0_1(self, compile_workspace):
+        """Partition0 in mdp_disagg_4d_2p.json is assigned devices [0, 1]."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        with open(compile_dir / "mdp_disagg_4d_2p.json") as fh:
+            mdp_data = json.load(fh)
+        partition0_device_ids = [d["deviceId"] for d in mdp_data["partitions"][0]["devices"]]
+        assert partition0_device_ids == [0, 1], f"Expected [0, 1], got {partition0_device_ids}"
+
+    def test_mdp_disagg_partition1_devices_are_2_3(self, compile_workspace):
+        """Partition1 in mdp_disagg_4d_2p.json is assigned devices [2, 3]."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        with open(compile_dir / "mdp_disagg_4d_2p.json") as fh:
+            mdp_data = json.load(fh)
+        partition1_device_ids = [d["deviceId"] for d in mdp_data["partitions"][1]["devices"]]
+        assert partition1_device_ids == [2, 3], f"Expected [2, 3], got {partition1_device_ids}"
+
+    def test_hashed_compile_params_command_references_mdp_json(self, compile_workspace):
+        """-mdp-load-partition-config flag in hashed_compile_params.json points at the disagg JSON."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        hashed_path = next(compile_dir.glob("**/hashed_compile_params.json"), None)
+        assert hashed_path is not None, "hashed_compile_params.json not found under compile_dir"
+        with open(hashed_path) as fh:
+            hashed = json.load(fh)
+        command_str = " ".join(str(c) for c in hashed["command"])
+        assert "-mdp-load-partition-config=" in command_str, (
+            "-mdp-load-partition-config flag missing from compile command"
+        )
+        assert "mdp_disagg_4d_2p.json" in command_str, (
+            "mdp_disagg_4d_2p.json not referenced in -mdp-load-partition-config"
+        )
+
+    def test_hashed_compile_params_contains_mdp_num_partitions(self, compile_workspace):
+        """hashed_compile_params.json records mdp_num_partitions=2."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        hashed_path = next(compile_dir.glob("**/hashed_compile_params.json"), None)
+        assert hashed_path is not None, "hashed_compile_params.json not found under compile_dir"
+        with open(hashed_path) as fh:
+            hashed = json.load(fh)
+        assert hashed.get("mdp_num_partitions") == 2, (
+            f"Expected mdp_num_partitions=2, got {hashed.get('mdp_num_partitions')}"
+        )
+
+    def test_hashed_compile_params_contains_mdp_strategy_onnx(self, compile_workspace):
+        """hashed_compile_params.json records mdp_strategy='onnx'."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        hashed_path = next(compile_dir.glob("**/hashed_compile_params.json"), None)
+        assert hashed_path is not None, "hashed_compile_params.json not found under compile_dir"
+        with open(hashed_path) as fh:
+            hashed = json.load(fh)
+        assert hashed.get("mdp_strategy") == "onnx", (
+            f"Expected mdp_strategy='onnx', got {hashed.get('mdp_strategy')}"
+        )
+
+    def test_hashed_compile_params_contains_mdp_ts_json(self, compile_workspace):
+        """hashed_compile_params.json records mdp_ts_json (the generated MDP dict)."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        hashed_path = next(compile_dir.glob("**/hashed_compile_params.json"), None)
+        assert hashed_path is not None, "hashed_compile_params.json not found under compile_dir"
+        with open(hashed_path) as fh:
+            hashed = json.load(fh)
+        assert "mdp_ts_json" in hashed, "mdp_ts_json key missing from hashed_compile_params.json"
+        assert hashed["mdp_ts_json"] is not None, "mdp_ts_json value is None in hashed_compile_params.json"
+        assert "partitions" in hashed["mdp_ts_json"], "mdp_ts_json missing 'partitions' key"
+
+    def test_qconfig_compiler_config_contains_mdp_num_partitions(self, compile_workspace):
+        """qconfig.json compiler_config contains mdp_num_partitions=2."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        qconfig_path = next(compile_dir.glob("**/qconfig.json"), None)
+        assert qconfig_path is not None, "qconfig.json not found under compile_dir"
+        with open(qconfig_path) as fh:
+            qconfig = json.load(fh)
+        compiler_cfg = qconfig.get("qpc_config", {}).get("compiler_config", {})
+        assert compiler_cfg.get("mdp_num_partitions") == 2, (
+            f"Expected mdp_num_partitions=2 in qconfig compiler_config, got {compiler_cfg.get('mdp_num_partitions')}"
+        )
+
+    def test_qconfig_compiler_config_contains_mdp_strategy_onnx(self, compile_workspace):
+        """qconfig.json compiler_config contains mdp_strategy='onnx'."""
+        compile_dir, _, _ = self._run_mdp_compile(compile_workspace)
+        qconfig_path = next(compile_dir.glob("**/qconfig.json"), None)
+        assert qconfig_path is not None, "qconfig.json not found under compile_dir"
+        with open(qconfig_path) as fh:
+            qconfig = json.load(fh)
+        compiler_cfg = qconfig.get("qpc_config", {}).get("compiler_config", {})
+        assert compiler_cfg.get("mdp_strategy") == "onnx", (
+            f"Expected mdp_strategy='onnx' in qconfig compiler_config, got {compiler_cfg.get('mdp_strategy')}"
+        )

--- a/tests/unit_test/base/test_modeling_qeff_base.py
+++ b/tests/unit_test/base/test_modeling_qeff_base.py
@@ -374,9 +374,7 @@ def _build_synthetic_gpt2_onnx(num_layers: int, out_path: Path) -> None:
     for layer_idx in range(num_layers):
         attn_out = f"attn_out_{layer_idx}"
         mlp_out = f"mlp_out_{layer_idx}"
-        nodes.append(
-            helper.make_node("Identity", inputs=[prev_out], outputs=[attn_out], name=f"h.{layer_idx}/attn")
-        )
+        nodes.append(helper.make_node("Identity", inputs=[prev_out], outputs=[attn_out], name=f"h.{layer_idx}/attn"))
         nodes.append(helper.make_node("Identity", inputs=[attn_out], outputs=[mlp_out], name=f"h.{layer_idx}/mlp"))
         prev_out = mlp_out
     nodes.append(helper.make_node("Identity", inputs=[prev_out], outputs=["logits"], name="lm_head"))
@@ -586,9 +584,7 @@ class TestMdpCompileIntegration:
         assert hashed_path is not None, "hashed_compile_params.json not found under compile_dir"
         with open(hashed_path) as fh:
             hashed = json.load(fh)
-        assert hashed.get("mdp_strategy") == "onnx", (
-            f"Expected mdp_strategy='onnx', got {hashed.get('mdp_strategy')}"
-        )
+        assert hashed.get("mdp_strategy") == "onnx", f"Expected mdp_strategy='onnx', got {hashed.get('mdp_strategy')}"
 
     def test_hashed_compile_params_contains_mdp_ts_json(self, compile_workspace):
         """hashed_compile_params.json records mdp_ts_json (the generated MDP dict)."""

--- a/tests/unit_test/conftest.py
+++ b/tests/unit_test/conftest.py
@@ -30,6 +30,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "input_handler: InputHandler utility test")
     config.addinivalue_line("markers", "diffusers: QEfficient diffusers module test")
     config.addinivalue_line("markers", "llm_model: mark test as a pure LLM model inference test")
+    config.addinivalue_line("markers", "mdp: Multi-Device Partitioning test")
 
 
 def pytest_collection_modifyitems(items):


### PR DESCRIPTION
This PR adds MDP generation required for disaggregated serving for Prefill. Supports both Pipeline Prefill + Tensor Slicing and passing custom cores to the MDP generator. Also adds support for VLMs, compiler 'stages' option, and layerwise export.