### PR TITLE
Subfunction fix w/o Layerwise

### DIFF
--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -233,7 +233,14 @@ class RenameFunctionOutputsTransform(BaseOnnxTransform):
                         else:
                             base = out_name[: -len("_InternalRetainedState")]
                             new = orig
-                            for token in ("past_key.", "past_value.", "compressed_kv.", "k_pe."):
+                            for token in (
+                                "past_key.",
+                                "past_value.",
+                                "compressed_kv.",
+                                "k_pe.",
+                                "recurrent_state.",
+                                "conv_state.",
+                            ):
                                 if not base.startswith(token):
                                     continue
                                 tail = base[len(token) :]

--- a/QEfficient/utils/export_utils.py
+++ b/QEfficient/utils/export_utils.py
@@ -182,7 +182,14 @@ def _setup_onnx_subfunctions(qeff_model, args, kwargs):
         kwargs["output_names"] = [
             re.sub("_RetainedState", "_InternalRetainedState", name)
             if name.endswith("_RetainedState")
-            and ("key" in name or "value" in name or "compressed_kv" in name or "k_pe" in name)
+            and (
+                "key" in name
+                or "value" in name
+                or "compressed_kv" in name
+                or "k_pe" in name
+                or "conv" in name
+                or "recurrent" in name
+            )
             else name
             for name in kwargs["output_names"]
         ]


### PR DESCRIPTION
This PR addresses a bug where output_names were not visible for convolutional and recurrent states when layer-wise processing is disabled and sub-functions are enabled.