### PR TITLE
fix(mixtral): fix MXFP6 quantization and ONNX export issues for Mixtral_moe 

### DIFF
--- a/QEfficient/transformers/models/mixtral_moe/modeling_mixtral.py
+++ b/QEfficient/transformers/models/mixtral_moe/modeling_mixtral.py
@@ -13,7 +13,6 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 from transformers.cache_utils import Cache
-from transformers.integrations.moe import batched_mm_experts_forward
 from transformers.modeling_outputs import (
     MoeCausalLMOutputWithPast,
     MoeModelOutputWithPast,
@@ -22,10 +21,12 @@ from transformers.models.mixtral.modeling_mixtral import (
     MixtralAttention,
     MixtralConfig,
     MixtralDecoderLayer,
+    MixtralExperts,
     MixtralForCausalLM,
     MixtralModel,
     MixtralRotaryEmbedding,
     MixtralSparseMoeBlock,
+    MixtralTopKRouter,
     load_balancing_loss_func,
     repeat_kv,
     rotate_half,
@@ -40,6 +41,8 @@ from QEfficient.blocking.attention_blocking import (
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
+
+
 
 
 class QEffMixtralRotaryEmbedding(MixtralRotaryEmbedding):
@@ -191,81 +194,60 @@ MIXTRAL_ATTENTION_CLASSES = {
 }
 
 
+class QEffMixtralExperts(MixtralExperts):
+    def __qeff_init__(self):
+        intermediate_dim = self.intermediate_dim
+        self.gate_proj = nn.Parameter(
+            self.gate_up_proj[:, :intermediate_dim, :].detach().clone().transpose(1, 2)
+        )  # (num_experts, hidden_dim, intermediate_dim)
+        self.up_proj = nn.Parameter(
+            self.gate_up_proj[:, intermediate_dim:, :].detach().clone().transpose(1, 2)
+        )  # (num_experts, hidden_dim, intermediate_dim)
+        self.down_proj_t = nn.Parameter(
+            self.down_proj.detach().clone().transpose(1, 2)
+        )  # (num_experts, intermediate_dim, hidden_dim)
+
+
+class QEffMixtralTopKRouter(MixtralTopKRouter):
+    """
+    Replaces router_top_value.sum(dim=-1, keepdim=True) with torch.einsum,
+    consistent with QEffQwen3MoeTopKRouter, to avoid ReduceSum with computed
+    (non-constant) axes in ONNX opset 17 / PyTorch 2.7 export.
+    """
+
+    def forward(self, hidden_states):
+        hidden_states = hidden_states.reshape(-1, self.hidden_dim)
+        router_logits = F.linear(hidden_states, self.weight)
+        router_logits = torch.nn.functional.softmax(router_logits.float(), dim=-1)
+        router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=-1)
+        router_top_value = router_top_value / torch.einsum("bk->b", router_top_value).unsqueeze(-1)
+        return router_logits, router_top_value, router_indices
+
+
 class QEffMixtralSparseMoeBlock(MixtralSparseMoeBlock):
-    """
-    This implementation is
-    strictly equivalent to standard MoE with full capacity (no
-    dropped tokens). It's faster since it formulates MoE operations
-    in terms of block-sparse operations to accomodate imbalanced
-    assignments of tokens to experts, whereas standard MoE either
-    (1) drop tokens at the cost of reduced performance or (2) set
-    capacity factor to number of experts and thus waste computation
-    and memory on padding.
-    """
+    def __qeff_init__(self):
+        self.top_k = getattr(self.gate, "top_k", self.top_k)
+        self.num_experts = self.experts.num_experts
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        """Mixtral MoE forward compatible with both pre-v5 and v5 gate/experts APIs."""
-        batch_size, sequence_length, hidden_dim = hidden_states.shape
-        if self.training and getattr(self, "jitter_noise", 0) > 0:
-            hidden_states = hidden_states * torch.empty_like(hidden_states).uniform_(
-                1.0 - self.jitter_noise, 1.0 + self.jitter_noise
-            )
-        hidden_states = hidden_states.view(-1, hidden_dim)
-        gate_dtype = getattr(getattr(self.gate, "weight", None), "dtype", hidden_states.dtype)
-        gate_out = self.gate(hidden_states.to(gate_dtype))
-
-        if isinstance(gate_out, tuple) and len(gate_out) >= 3:
-            router_logits, routing_weights, selected_experts = gate_out[0], gate_out[1], gate_out[2]
-        else:
-            router_logits = gate_out[0] if isinstance(gate_out, tuple) else gate_out
-            routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
-            routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
-            routing_weights /= torch.einsum("bi->b", routing_weights)[:, None]
-            routing_weights = routing_weights.to(hidden_states.dtype)
-
-        # transformers>=5.3 uses MixtralExperts aggregate with call signature
-        # experts(hidden_states, top_k_index, top_k_weights)
-        if callable(self.experts) and not hasattr(self.experts, "__getitem__"):
-            experts_dtype = None
-            for param in self.experts.parameters():
-                experts_dtype = param.dtype
-                break
-            hidden_states_for_experts = hidden_states.to(experts_dtype) if experts_dtype else hidden_states
-            if torch.onnx.is_in_onnx_export():
-                # Avoid grouped-mm ONNX incompatibility (`aten::histc`) while keeping
-                # upstream experts math/parameter layout.
-                final_hidden_states = batched_mm_experts_forward(
-                    self.experts, hidden_states_for_experts, selected_experts, routing_weights
-                )
-            else:
-                final_hidden_states = self.experts(hidden_states_for_experts, selected_experts, routing_weights)
-            final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
-            return final_hidden_states, router_logits
-
-        # Backward compatible path for older expert containers.
-        final_hidden_states = torch.zeros_like(hidden_states)
-        B, K = selected_experts.shape
-        E = int(getattr(self, "num_experts", getattr(self.experts, "num_experts", self.gate.weight.shape[0])))
-        flat = selected_experts.reshape(-1)
-        mask = torch.zeros((B * K, E), dtype=torch.int64)
-        mask[torch.arange(B * K), flat] = 1
-        expert_mask = mask.view(B, K, E).permute(2, 1, 0)
-
-        for expert_idx in range(E):
-            expert_layer = self.experts[expert_idx]
-            expert_mask_tr = expert_mask[expert_idx].transpose(0, 1)
-            scale = torch.einsum("be,be->b", routing_weights, expert_mask_tr.to(self.gate.weight.dtype))[:, None]
-            current_hidden_states = expert_layer(hidden_states) * scale
-            current_hidden_states = torch.where(
-                torch.einsum("be,be->b", routing_weights, expert_mask_tr.to(routing_weights.dtype)).to(torch.bool)[
-                    :, None
-                ],
-                current_hidden_states,
-                torch.tensor(0.0),
-            )
-            final_hidden_states = final_hidden_states + current_hidden_states
-        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
-        return final_hidden_states, router_logits
+        B, S, H = hidden_states.shape
+        T = B * S
+        hidden_states = hidden_states.view(T, H)
+        router_logits, top_w, top_i = self.gate(hidden_states)
+        top_w = top_w.to(hidden_states.dtype)
+        idx = top_i.reshape(-1)
+        gate_proj = self.experts.gate_proj[idx]    # (S, H, I) — weight is 2nd BMM operand → MXFP6
+        up_proj = self.experts.up_proj[idx]        # (S, H, I)
+        down_proj = self.experts.down_proj_t[idx]  # (S, I, H)
+        expert_in = hidden_states.unsqueeze(1).expand(-1, self.top_k, -1).contiguous().view(-1, 1, H)
+        gate = torch.bmm(expert_in, gate_proj)
+        up = torch.bmm(expert_in, up_proj)
+        intermediate = up * self.experts.act_fn(gate)
+        experts_out = torch.bmm(intermediate, down_proj)
+        experts_out = experts_out.view(T, self.top_k, H)
+        experts_out = experts_out * top_w.unsqueeze(-1)
+        experts_out = torch.einsum("bnd->bd", experts_out)
+        return experts_out.view(B, S, H), router_logits
 
 
 class QeffMixtralDecoderLayer(MixtralDecoderLayer):
@@ -465,6 +447,12 @@ class QEffMixtralForCausalLM(MixtralForCausalLM):
     - add new args position idx for the cache_kwargs for kv retention
     - update the hidden_states, and fix for onnx model
     """
+
+    # Use minimal seq_len for ONNX tracing: the expert BMM gathers
+    # (S = seq_len * batch * top_k) copies of expert weight matrices, so a large
+    # tracing seq_len causes a ~15 GB gather per layer. seq_len is a dynamic axis
+    # so the compiled QPC still uses the real prefill_seq_len from compile().
+    ONNX_EXPORT_EXAMPLE_SEQ_LEN = 2
 
     def get_submodules_for_export(self) -> Type[nn.Module]:
         """

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -3761,7 +3761,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             )
 
         bs: int = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
-        seq_len: int = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
+        seq_len: int = getattr(self.model, "ONNX_EXPORT_EXAMPLE_SEQ_LEN", constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN)
 
         # increase seq_len if using a larger number of blocks
         if self.hash_params.get("blocking_kwargs", None):

--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -145,10 +145,12 @@ from transformers.models.mistral3.modeling_mistral3 import (
 from transformers.models.mixtral.modeling_mixtral import (
     MixtralAttention,
     MixtralDecoderLayer,
+    MixtralExperts,
     MixtralForCausalLM,
     MixtralModel,
     MixtralRMSNorm,
     MixtralSparseMoeBlock,
+    MixtralTopKRouter,
 )
 from transformers.models.mllama.modeling_mllama import (
     MllamaCrossAttentionDecoderLayer,
@@ -477,9 +479,11 @@ from QEfficient.transformers.models.mistral3.modeling_mistral3 import (
 from QEfficient.transformers.models.mixtral_moe.modeling_mixtral import (
     QEffMixtralAttention,
     QeffMixtralDecoderLayer,
+    QEffMixtralExperts,
     QEffMixtralForCausalLM,
     QEffMixtralModel,
     QEffMixtralSparseMoeBlock,
+    QEffMixtralTopKRouter,
 )
 from QEfficient.transformers.models.mllama.modeling_mllama import (
     QEffMllamaCrossAttentionDecoderLayer,
@@ -826,6 +830,8 @@ class KVCacheTransform(ModuleMappingTransform):
         Mistral3ForConditionalGeneration: QEffMistral3ForConditionalGeneration,
         Mistral3Model: QEffMistral3Model,
         # Mixtral
+        MixtralExperts: QEffMixtralExperts,
+        MixtralTopKRouter: QEffMixtralTopKRouter,
         MixtralAttention: QEffMixtralAttention,
         MixtralSparseMoeBlock: QEffMixtralSparseMoeBlock,
         MixtralDecoderLayer: QeffMixtralDecoderLayer,

--- a/examples/text_generation/continuous_batching.py
+++ b/examples/text_generation/continuous_batching.py
@@ -7,14 +7,14 @@
 
 import argparse
 
-from transformers import AutoTokenizer
+from transformers import AutoConfig, AutoTokenizer
 
 from QEfficient import QEFFAutoModelForCausalLM
 
 
 def main():
     parser = argparse.ArgumentParser(description="Continuous batching inference")
-    parser.add_argument("--model-name", type=str, default="Qwen/Qwen2-1.5B-Instruct", help="HuggingFace model ID")
+    parser.add_argument("--model-name", type=str, default="mistralai/Mixtral-8x7B-v0.1", help="HuggingFace model ID")
     parser.add_argument(
         "--prompts",
         type=str,
@@ -26,10 +26,11 @@ def main():
     parser.add_argument("--full-batch-size", type=int, default=4, help="Full batch size for continuous batching")
     parser.add_argument("--generation-len", type=int, default=100, help="Number of tokens to generate")
     parser.add_argument("--num-cores", type=int, default=16, help="Number of cores")
+    parser.add_argument("--num-layers", type=int, default=4, help="Override number of decoder layers (e.g. 4 for quick testing)")
     parser.add_argument(
         "--device-group",
         type=lambda device_ids: [int(x) for x in device_ids.strip("[]").split(",")],
-        default=None,
+        default=1,
         help="Device IDs (comma-separated) e.g. [0,1]",
     )
     args = parser.parse_args()
@@ -40,7 +41,14 @@ def main():
 
     # Load tokenizer and model with continuous batching enabled
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
-    model = QEFFAutoModelForCausalLM.from_pretrained(args.model_name, continuous_batching=True)
+
+    if args.num_layers is not None:
+        config = AutoConfig.from_pretrained(args.model_name)
+        config.num_hidden_layers = args.num_layers
+        print(f"Overriding num_hidden_layers to {args.num_layers}")
+        model = QEFFAutoModelForCausalLM.from_pretrained(args.model_name, config=config, continuous_batching=True)
+    else:
+        model = QEFFAutoModelForCausalLM.from_pretrained(args.model_name, continuous_batching=True)
 
     # Compile the model with full_batch_size for continuous batching
     qpc_path = model.compile(
@@ -48,7 +56,9 @@ def main():
         ctx_len=args.ctx_len,
         full_batch_size=args.full_batch_size,
         num_cores=args.num_cores,
-        num_devices=(1 if args.device_group is None else len(args.device_group)),
+        mxfp6_matmul=True,
+        use_onnx_subfunctions=True,
+        num_devices=(4 if args.device_group is None else len(args.device_group)),
     )
     print(f"Model compiled to: {qpc_path}")
 


### PR DESCRIPTION
- Add QEffMixtralExperts with __qeff_init__ to split gate_up_proj into gate_proj/up_proj and transpose weights to (H, I) layout so expert weights appear as the second BMM operand (input @ weight), enabling QAIC -mxfp6-matmul to quantize them. Without this, _batched_linear used weight-first BMM which QAIC does not quantize, causing ~144 GB DRAM instead of ~42 GB.

- Rewrite QEffMixtralSparseMoeBlock.forward() to mirror QEffQwen3MoeSparseMoeBlock: dynamic gather + BMM with weight as second operand, einsum accumulation.

- Add QEffMixtralTopKRouter to replace router .sum(dim=-1, keepdim=True) with torch.einsum consistent with QEffQwen3MoeTopKRouter, avoiding ReduceSum with non-constant axes in ONNX opset 17 / PyTorch 2.7.

- Set QEffMixtralForCausalLM.ONNX_EXPORT_EXAMPLE_SEQ_LEN = 2 to reduce the expert weight gather from ~15 GB to ~1 GB during ONNX tracing; seq_len is a dynamic axis so the compiled QPC uses real prefill_seq_len.

- Register MixtralExperts, MixtralTopKRouter transforms in pytorch_transforms.py.

- Add --num-layers arg to continuous_batching.py for quick layer-reduced testing.