### PR TITLE
cleaned up layerwise API and added CustomLoader (#1105)

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -30,6 +30,12 @@ from QEfficient.base.pytorch_transforms import PytorchTransform
 from QEfficient.blocking.blocking_configurator import build_transformer_blocking_config_for_transform
 from QEfficient.compile.qnn_compiler import compile as qnn_compile
 from QEfficient.generation.cloud_infer import QAICInferenceSession
+from QEfficient.transformers.models._layerwise import (
+    get_layerwise_end,
+    get_layerwise_start,
+    get_layerwise_total_layers,
+    is_layerwise_active,
+)
 from QEfficient.transformers.models.pytorch_transforms import (
     BlockingAttentionTransform,
     ReplicateKVHeadTransform,
@@ -103,10 +109,6 @@ class QEFFBaseModel(ABC):
     :_onnx_transforms: ONNX transformations to be applied after ONNX export.
     """
 
-    _start = 0
-    _end = 0
-    _total_layers = None
-    _layerwise_active = False
     _pytorch_transforms: List[PytorchTransform]
     _onnx_transforms = [BaseOnnxTransform]
 
@@ -430,7 +432,7 @@ class QEFFBaseModel(ABC):
             input_names = aligned_input_names
 
         try:
-            with layerwise_safe_onnx_export_patches():
+            with layerwise_safe_onnx_export_patches(enabled=is_layerwise_active(self.model)):
                 torch.onnx.export(
                     self.model,
                     (),
@@ -461,7 +463,7 @@ class QEFFBaseModel(ABC):
 
             # Keep this strictly layerwise-scoped so regular non-layerwise export
             # remains backward compatible.
-            if QEFFBaseModel._layerwise_active:
+            if is_layerwise_active(self.model):
                 _restore_retained_state_output_names(model, output_names)
 
             # Add metadata to the model
@@ -556,8 +558,8 @@ class QEFFBaseModel(ABC):
         **export_kwargs,
     ) -> str:
         cache_probe = export_kwargs.pop("_layerwise_cache_probe", False)
-        idx = int(QEFFBaseModel._start)
-        end_idx = int(getattr(QEFFBaseModel, "_end", idx + 1))
+        idx = int(get_layerwise_start(self.model))
+        end_idx = int(get_layerwise_end(self.model) or idx + 1)
         if end_idx <= idx:
             raise ValueError(f"Invalid export window: start={idx}, end={end_idx}")
 
@@ -574,7 +576,7 @@ class QEFFBaseModel(ABC):
         # under the export root (new layout) or final_data/ (legacy layout),
         # skip per-window export entirely. This preserves hash-stable reruns
         # without re-exporting layer shards.
-        total_layers = int(getattr(QEFFBaseModel, "_total_layers", 0) or 0)
+        total_layers = int(get_layerwise_total_layers(self.model))
         cached_merged_paths = []
         if total_layers > 0:
             cached_merged_paths.append(export_dir / f"merged_0-{total_layers}.onnx")
@@ -745,7 +747,7 @@ class QEFFBaseModel(ABC):
             dynamic_axes = {rename_map.get(k, k): v for k, v in dynamic_axes.items()}
             input_names = aligned_input_names
         if not os.path.isfile(layer_onnx_path):
-            with layerwise_safe_onnx_export_patches(enabled=bool(prefill_only)):
+            with layerwise_safe_onnx_export_patches(enabled=bool(prefill_only) and is_layerwise_active(self.model)):
                 torch.onnx.export(
                     self.model,
                     (),
@@ -893,7 +895,7 @@ class QEFFBaseModel(ABC):
                     kv_cache_prefix=kv_cache_prefix,
                     **compiler_options,
                 )
-        if QEFFBaseModel._layerwise_active:
+        if is_layerwise_active(getattr(self, "model", None)):
             if onnx_path is None:
                 return None
             onnx_path = Path(onnx_path)

--- a/QEfficient/exporter/export_utils.py
+++ b/QEfficient/exporter/export_utils.py
@@ -92,7 +92,7 @@ def export_onnx(
     os.makedirs(f"{gen_models_path}_tmp", exist_ok=True)
     try:
         info("Exporting to ONNX...")
-        with layerwise_safe_onnx_export_patches():
+        with layerwise_safe_onnx_export_patches(enabled=False):
             torch.onnx.export(
                 pt_model,
                 tuple(pt_inputs),

--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -719,10 +719,11 @@ class QEffTextGenerationBase:
         next_token_id = self._fetch_next_token_id(outputs)
 
         # Store the generated values.
-        self.decode_input_ids[decode_batch_id or slice(None)] = next_token_id
-        self.decode_pos_ids[decode_batch_id or slice(None)] = position_ids
-        self.generated_ids[decode_batch_id or slice(None), 0] = next_token_id.squeeze(1)
-        self.generation_len[decode_batch_id or slice(None)] = generation_len
+        decode_batch = decode_batch_id if decode_batch_id is not None else slice(None)
+        self.decode_input_ids[decode_batch] = next_token_id
+        self.decode_pos_ids[decode_batch] = position_ids
+        self.generated_ids[decode_batch, 0] = next_token_id.squeeze()
+        self.generation_len[decode_batch] = generation_len
         return next_token_id
 
     def run_prefill_for_all_inputs(self, prompt_queue, generation_len):
@@ -927,7 +928,7 @@ class QEffTextGenerationBase:
                         new_token_id = self.update_decode_input(outputs, position_ids, generation_len, decode_batch_id)
 
                         batch_id_map[decode_batch_id] = max(batch_id_map.values()) + 1
-                        self.generated_ids[batch_id_map[decode_batch_id], 0] = new_token_id.squeeze(1)
+                        self.generated_ids[batch_id_map[decode_batch_id], 0] = new_token_id.squeeze()
                         generated_id_current_index[decode_batch_id] = 1
 
                         self._set_output_buffers(

--- a/QEfficient/generation/vlm_generation.py
+++ b/QEfficient/generation/vlm_generation.py
@@ -285,10 +285,11 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
             next_token_id = next_token_id[:, -1:]
 
         # Store the generated values.
-        self.decode_input_ids[decode_batch_id or slice(None)] = next_token_id
-        self.decode_pos_ids[:, decode_batch_id] = position_ids.squeeze(1)
-        self.generated_ids[decode_batch_id or slice(None), 0] = next_token_id.squeeze(1)
-        self.generation_len[decode_batch_id or slice(None)] = generation_len
+        decode_batch = decode_batch_id if decode_batch_id is not None else slice(None)
+        self.decode_input_ids[decode_batch] = next_token_id
+        self.decode_pos_ids[:, decode_batch] = position_ids.squeeze(1)
+        self.generated_ids[decode_batch, 0] = next_token_id.squeeze()
+        self.generation_len[decode_batch] = generation_len
         return next_token_id
 
     def _execute_chunked_prefill(

--- a/QEfficient/transformers/models/_layerwise.py
+++ b/QEfficient/transformers/models/_layerwise.py
@@ -10,18 +10,20 @@ Layer-wise export/compile orchestration for selected MoE architectures.
 
 Provisional API. Scheduled for removal once first-class multi-window export lands.
 Today only ``qwen3_vl_moe``, ``qwen3_5_moe`` and ``qwen3_moe`` carry the
-windowing hooks (``_start``/``_end`` class attributes) that this driver relies
-on; calling :func:`run_layerwise` for any other architecture will raise.
+windowing hooks that this driver relies on; calling :func:`run_layerwise` for
+any other architecture will raise.
 """
 
 from __future__ import annotations
 
 import functools
+import gc
 import random
 import shutil
 import time
 import warnings
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from numbers import Integral
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -32,10 +34,11 @@ import torch
 import transformers
 
 import QEfficient
+from QEfficient.transformers.models.custom_loader import CustomLoader
 from QEfficient.utils.logging_utils import logger
 
-# Architectures whose modeling files declare _start/_end class attributes the
-# layer-wise driver pokes. Keep this list narrow on purpose - adding a new
+# Architectures whose modeling files declare layerwise window hooks. Keep this
+# list narrow on purpose - adding a new
 # architecture must come with the corresponding modeling-file hooks.
 _LAYERWISE_SUPPORTED_MODEL_TYPES = frozenset(
     {
@@ -54,23 +57,153 @@ _LAYERWISE_SUPPORTED_MODEL_TYPES = frozenset(
 # the unreachable rows past 32K is lossless.
 _LAYERWISE_ROPE_MAX_POSITIONS = 76800
 
-# Process-local layer-wise window state. We deliberately avoid setting class
-# attributes on transformers.modeling_utils.PreTrainedModel - those would leak
-# to every HF model in the process and survive past the layer-wise run. The
-# patched HF hooks (shard filter, model-init nuller) close over this dict so
-# they can be installed once and behave as no-ops whenever ``active`` is False.
-_LAYERWISE_STATE: Dict[str, int] = {
-    "active": 0,
-    "start": 0,
-    "end": 0,
-    "total_layers": 0,
-    "text_start": 0,
-    "text_end": 0,
-    "text_total_layers": 0,
-    "force_full_init": 0,
-}
+_LAYERWISE_CONTEXT_ATTR = "_qeff_layerwise_context"
 
 _DEPRECATION_WARNED = False
+
+
+@dataclass
+class LayerwiseContext:
+    """Per-model layerwise state attached to QEff model instances."""
+
+    model_id: str
+    window_size: int
+    model_type: str
+    total_layers: int
+    load_kwargs: Dict[str, Any] = field(default_factory=dict)
+    enabled: bool = True
+    active: bool = False
+    start: int = 0
+    end: int = 0
+    force_full_init: bool = False
+
+    def __post_init__(self) -> None:
+        self.window_size = _validate_layerwise_window_size(self.window_size)
+        self.total_layers = int(self.total_layers)
+
+    @property
+    def is_first_window(self) -> bool:
+        return self.active and self.start == 0
+
+    @property
+    def is_last_window(self) -> bool:
+        return self.active and self.end >= self.total_layers
+
+    def build_windows(self) -> List[Tuple[int, int]]:
+        return _build_layer_windows(self.total_layers, self.window_size)
+
+    def set_window(self, start: int, end: int) -> None:
+        self.start = int(start)
+        self.end = int(end)
+        self.active = True
+
+    def reset_window(self) -> None:
+        self.start = 0
+        self.end = 0
+        self.active = False
+        self.force_full_init = False
+
+
+def _validate_layerwise_window_size(window_size: int) -> int:
+    if window_size is None:
+        raise ValueError(
+            "layerwise=True requires `layerwise_window_size` to be a positive integer. "
+            "Got None. Pass an explicit value (for example, layerwise_window_size=1)."
+        )
+    if isinstance(window_size, bool) or not isinstance(window_size, Integral):
+        raise TypeError(
+            "layerwise=True requires `layerwise_window_size` to be a positive integer. "
+            f"Got {type(window_size).__name__}: {window_size!r}."
+        )
+    window_size = int(window_size)
+    if window_size <= 0:
+        raise ValueError(
+            f"layerwise=True requires `layerwise_window_size` to be a positive integer. Got {window_size}."
+        )
+    return window_size
+
+
+def create_layerwise_context(
+    *,
+    model_id: str,
+    config,
+    window_size: int = 1,
+    load_kwargs: Optional[Dict[str, Any]] = None,
+) -> LayerwiseContext:
+    """Build a validated layerwise context from a model id/config pair."""
+
+    model_type = assert_layerwise_supported(config)
+    return LayerwiseContext(
+        model_id=model_id,
+        window_size=window_size,
+        model_type=model_type,
+        total_layers=_resolve_text_total_layers(config),
+        load_kwargs=dict(load_kwargs or {}),
+    )
+
+
+def attach_layerwise_context(module, context: LayerwiseContext, *, recursive: bool = True) -> None:
+    """Attach layerwise context to a module, optionally to every child module."""
+
+    if module is None:
+        return
+    if recursive and hasattr(module, "modules"):
+        for submodule in module.modules():
+            setattr(submodule, _LAYERWISE_CONTEXT_ATTR, context)
+        return
+    try:
+        setattr(module, _LAYERWISE_CONTEXT_ATTR, context)
+    except AttributeError:
+        return
+
+
+def _attach_context_to_qeff_model(qeff_model, context: LayerwiseContext) -> None:
+    """Attach context to common QEff wrapper layouts."""
+
+    if qeff_model is None:
+        return
+    if hasattr(qeff_model, "lang_model") and hasattr(qeff_model.lang_model, "model"):
+        attach_layerwise_context(qeff_model.lang_model.model, context)
+    elif hasattr(qeff_model, "model"):
+        attach_layerwise_context(qeff_model.model, context)
+    else:
+        attach_layerwise_context(qeff_model, context)
+
+
+def get_layerwise_context(module=None) -> Optional[LayerwiseContext]:
+    """Return the instance-attached layerwise context, if any."""
+
+    if isinstance(module, LayerwiseContext):
+        return module if module.enabled else None
+    context = getattr(module, _LAYERWISE_CONTEXT_ATTR, None) if module is not None else None
+    if context is not None and context.enabled:
+        return context
+    return None
+
+
+def has_layerwise_context(module) -> bool:
+    context = getattr(module, _LAYERWISE_CONTEXT_ATTR, None) if module is not None else None
+    return bool(context is not None and context.enabled)
+
+
+@contextmanager
+def suspend_layerwise_context(module):
+    """Temporarily disable layerwise routing for a wrapper/module tree."""
+
+    context = get_layerwise_context(module)
+    if context is None:
+        yield
+        return
+
+    previous_enabled = context.enabled
+    previous_active = context.active
+    context.enabled = False
+    context.active = False
+    try:
+        yield
+    finally:
+        context.enabled = previous_enabled
+        context.active = previous_active
 
 
 def _maybe_warn_deprecation() -> None:
@@ -108,7 +241,7 @@ def assert_layerwise_supported(config) -> str:
     )
 
 
-def is_layerwise_active() -> bool:
+def is_layerwise_active(module=None) -> bool:
     """True only while the layer-wise export driver is running.
 
     The driver flips this on inside :func:`_layerwise_export_env`. Outside that
@@ -116,35 +249,58 @@ def is_layerwise_active() -> bool:
     modeling forwards short-circuit every window branch and behave exactly as
     they did before layer-wise support was added.
     """
-    return bool(_LAYERWISE_STATE["active"])
+    context = get_layerwise_context(module)
+    if context is not None:
+        return bool(context.enabled and context.active)
+    return False
 
 
-def resolve_layer_window(model_cls, total_layers: int) -> Tuple[int, int]:
+def resolve_layer_window(module_or_cls=None, total_layers: int = 0) -> Tuple[int, int]:
     """Return the ``[start, end)`` decoder-layer window to run this forward.
 
-    When layer-wise export is inactive this always returns ``(0, total_layers)``
-    regardless of any ``_start``/``_end`` class attributes, so the default path
-    is independent of (possibly stale) window state left on the modeling class.
-    When the driver is active it honors the window it poked onto ``model_cls``.
+    When layer-wise export is inactive this always returns ``(0, total_layers)``.
+    When the driver is active it honors the attached context window.
     """
-    if not is_layerwise_active():
-        return 0, total_layers
-    start = int(getattr(model_cls, "_start", 0) or 0)
-    end = getattr(model_cls, "_end", 0) or 0
-    end = int(end) if end else total_layers
-    return start, end
+    context = get_layerwise_context(module_or_cls)
+    if context is not None:
+        if not context.active:
+            return 0, total_layers
+        end = context.end if context.end else total_layers
+        return int(context.start), int(end)
+    return 0, total_layers
 
 
-def is_last_layer_window(model_cls, total_layers: int) -> bool:
+def is_last_layer_window(module_or_cls=None, total_layers: int = 0) -> bool:
     """True if this forward owns the final decoder window (applies final norm / lm_head).
 
     Always True on the default path; on the layer-wise path it is True only for
-    the window whose ``_end`` reaches the total layer count.
+    the window whose end reaches the total layer count.
     """
-    if not is_layerwise_active():
-        return True
-    _, end = resolve_layer_window(model_cls, total_layers)
-    return end >= total_layers
+    context = get_layerwise_context(module_or_cls)
+    if context is not None:
+        return True if not context.active else context.end >= total_layers
+    return True
+
+
+def get_layerwise_start(module=None) -> int:
+    context = get_layerwise_context(module)
+    if context is not None and context.active:
+        return int(context.start)
+    return 0
+
+
+def get_layerwise_end(module=None) -> int:
+    context = get_layerwise_context(module)
+    if context is not None and context.active:
+        return int(context.end)
+    return 0
+
+
+def get_layerwise_total_layers(module=None) -> int:
+    context = get_layerwise_context(module)
+    if context is not None:
+        return int(context.total_layers)
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -152,34 +308,10 @@ def is_last_layer_window(model_cls, total_layers: int) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _ensure_pretrained_window_attrs() -> None:
-    """No-op kept for compatibility with prior call sites.
-
-    Layer-wise window state lives in the module-local ``_LAYERWISE_STATE``
-    dict (see top of file); we no longer pollute ``PreTrainedModel`` with
-    class attributes.
-    """
-    return
-
-
 def _build_layer_windows(total_layers: int, window_size: int) -> List[Tuple[int, int]]:
     if total_layers <= 0:
         raise ValueError(f"Invalid total_layers={total_layers}; expected > 0.")
-    if window_size is None:
-        raise ValueError(
-            "layerwise=True requires `layerwise_window_size` to be a positive integer. "
-            "Got None. Pass an explicit value (for example, layerwise_window_size=1)."
-        )
-    if isinstance(window_size, bool) or not isinstance(window_size, Integral):
-        raise TypeError(
-            "layerwise=True requires `layerwise_window_size` to be a positive integer. "
-            f"Got {type(window_size).__name__}: {window_size!r}."
-        )
-    window_size = int(window_size)
-    if window_size <= 0:
-        raise ValueError(
-            f"layerwise=True requires `layerwise_window_size` to be a positive integer. Got {window_size}."
-        )
+    window_size = _validate_layerwise_window_size(window_size)
     windows: List[Tuple[int, int]] = []
     start = 0
     while start < total_layers:
@@ -203,32 +335,11 @@ def _checkpoint_has_shard_index(model_id: str) -> bool:
     return False
 
 
-def _get_text_layers_container(model):
-    if (
-        hasattr(model, "model")
-        and hasattr(model.model, "language_model")
-        and hasattr(model.model.language_model, "layers")
-    ):
-        return model.model.language_model.layers
-    if hasattr(model, "model") and hasattr(model.model, "layers"):
-        return model.model.layers
-    if hasattr(model, "language_model") and hasattr(model.language_model, "layers"):
-        return model.language_model.layers
-    if hasattr(model, "layers"):
-        return model.layers
-    return None
-
-
-def _null_outside_window_layers(model, *, apply_text: bool = True) -> None:
-    if not apply_text:
-        return
-    text_start = int(_LAYERWISE_STATE["text_start"] or _LAYERWISE_STATE["start"])
-    text_end = int(_LAYERWISE_STATE["text_end"] or _LAYERWISE_STATE["end"])
-    text_layers = _get_text_layers_container(model)
-    if text_layers is not None and text_end > text_start:
-        for idx, _ in enumerate(text_layers):
-            if idx < text_start or idx >= text_end:
-                text_layers[idx] = None
+def _active_window_bounds(module=None, context: Optional[LayerwiseContext] = None) -> Tuple[int, int]:
+    context = context or get_layerwise_context(module)
+    if context is not None and context.active:
+        return int(context.start), int(context.end)
+    return 0, 0
 
 
 def _find_language_model(model):
@@ -265,9 +376,12 @@ def _slim_for_window_export(qeff_model, *, ctx_len: Optional[int]) -> None:
     if lm is None:
         return
 
-    text_start = int(_LAYERWISE_STATE["text_start"] or _LAYERWISE_STATE["start"])
-    text_end = int(_LAYERWISE_STATE["text_end"] or _LAYERWISE_STATE["end"])
-    text_total = int(_LAYERWISE_STATE["text_total_layers"] or _LAYERWISE_STATE["total_layers"] or 0)
+    text_start, text_end = _active_window_bounds(inner)
+    context = get_layerwise_context(inner)
+    if context is not None:
+        text_total = int(context.total_layers)
+    else:
+        text_total = 0
 
     # 1) Truncate sin_cached / cos_cached to a fixed cap (32K rows) instead
     #    of ctx_len. A constant cap keeps the export hash invariant when the
@@ -330,124 +444,26 @@ def _slim_for_window_export(qeff_model, *, ctx_len: Optional[int]) -> None:
             )
 
 
-def _install_window_patch(model_cls) -> None:
-    if getattr(model_cls, "_window_patch_installed", False):
-        return
-    original_init = model_cls.__init__
-
-    @functools.wraps(original_init)
-    def patched_init(self, *args, **kwargs):
-        original_init(self, *args, **kwargs)
-        # Only nullify decoder layers when the layer-wise driver is actively
-        # exporting; idle calls to from_pretrained must behave normally.
-        if _LAYERWISE_STATE["active"] and not _LAYERWISE_STATE["force_full_init"]:
-            _null_outside_window_layers(self, apply_text=True)
-
-    model_cls.__init__ = patched_init
-    model_cls._window_patch_installed = True
-
-
-def _install_shard_window_patch() -> None:
-    if getattr(transformers.modeling_utils, "_window_shard_patch_installed", False):
-        return
-
-    original_get_checkpoint_shard_files = transformers.modeling_utils.get_checkpoint_shard_files
-
-    @functools.wraps(original_get_checkpoint_shard_files)
-    def patched_get_checkpoint_shard_files(*args, **kwargs):
-        shard_files, metadata = original_get_checkpoint_shard_files(*args, **kwargs)
-        # Honor the module-local state instead of polluting PreTrainedModel.
-        # When layerwise is not active this reduces to a no-op for any HF
-        # caller that happens to load checkpoint shards in this process.
-        if not _LAYERWISE_STATE["active"]:
-            return shard_files, metadata
-        weight_map = metadata.get("weight_map")
-        if not weight_map:
-            return shard_files, metadata
-
-        start = int(_LAYERWISE_STATE["start"])
-        end = int(_LAYERWISE_STATE["end"])
-        text_start = int(_LAYERWISE_STATE["text_start"] or start)
-        text_end = int(_LAYERWISE_STATE["text_end"] or end)
-        if text_end <= text_start:
-            return shard_files, metadata
-
-        selected_text_prefixes = tuple(
-            [f"model.layers.{i}." for i in range(text_start, text_end)]
-            + [f"model.language_model.layers.{i}." for i in range(text_start, text_end)]
-        )
-        filtered_weight_map: Dict[str, str] = {}
-        for checkpoint_key, shard_name in weight_map.items():
-            if checkpoint_key.startswith("model.layers.") or checkpoint_key.startswith("model.language_model.layers."):
-                if checkpoint_key.startswith(selected_text_prefixes):
-                    filtered_weight_map[checkpoint_key] = shard_name
-                continue
-            filtered_weight_map[checkpoint_key] = shard_name
-
-        if not filtered_weight_map:
-            return shard_files, metadata
-
-        shard_name_to_path = {path.split("/")[-1]: path for path in shard_files}
-        filtered_shard_names = sorted(set(filtered_weight_map.values()))
-        filtered_shard_files = [shard_name_to_path[name] for name in filtered_shard_names if name in shard_name_to_path]
-        if not filtered_shard_files:
-            return shard_files, metadata
-
-        metadata["weight_map"] = filtered_weight_map
-        metadata["all_checkpoint_keys"] = list(filtered_weight_map.keys())
-        return filtered_shard_files, metadata
-
-    transformers.modeling_utils.get_checkpoint_shard_files = patched_get_checkpoint_shard_files
-    transformers.modeling_utils._window_shard_patch_installed = True
+def _set_layer_windows(
+    text_start: int,
+    text_end: int,
+    text_total_layers: int,
+    context: LayerwiseContext,
+) -> None:
+    del text_total_layers
+    if context is None:
+        raise ValueError("_set_layer_windows requires a LayerwiseContext.")
+    context.force_full_init = False
+    if text_end > text_start:
+        context.set_window(text_start, text_end)
+    else:
+        context.reset_window()
 
 
-def _set_layer_windows(text_start: int, text_end: int, text_total_layers: int) -> None:
-    # Update the module-local state used by patched HF hooks. We deliberately
-    # do NOT set class attributes on transformers.modeling_utils.PreTrainedModel
-    # here - that would leak to every HF model in the process.
-    _LAYERWISE_STATE["start"] = text_start
-    _LAYERWISE_STATE["end"] = text_end
-    _LAYERWISE_STATE["total_layers"] = text_total_layers
-    _LAYERWISE_STATE["text_start"] = text_start
-    _LAYERWISE_STATE["text_end"] = text_end
-    _LAYERWISE_STATE["text_total_layers"] = text_total_layers
-    _LAYERWISE_STATE["force_full_init"] = 0
-
-    # The QEff modeling classes themselves expose _start/_end/_total_layers as
-    # part of their windowing contract (they are read inside their forward
-    # implementations). Those are ours to set.
-    qeff_vl_mod = getattr(QEfficient.transformers.models, "qwen3_vl_moe", None)
-    if qeff_vl_mod is not None:
-        cls = getattr(qeff_vl_mod.modeling_qwen3_vl_moe, "QEffQwen3VLMoeTextModel", None)
-        if cls is not None:
-            cls._start = text_start
-            cls._end = text_end
-            cls._total_layers = text_total_layers
-
-    qeff_35_mod = getattr(QEfficient.transformers.models, "qwen3_5_moe", None)
-    if qeff_35_mod is not None:
-        for class_name in ("QEffQwen3_5MoeTextModel", "QEffQwen3_5MoeModel"):
-            cls = getattr(qeff_35_mod.modeling_qwen3_5_moe, class_name, None)
-            if cls is not None:
-                cls._start = text_start
-                cls._end = text_end
-                cls._total_layers = text_total_layers
-
-    qeff_3_mod = getattr(QEfficient.transformers.models, "qwen3_moe", None)
-    if qeff_3_mod is not None:
-        cls = getattr(qeff_3_mod.modeling_qwen3_moe, "QEffQwen3MoeModel", None)
-        if cls is not None:
-            cls._start = text_start
-            cls._end = text_end
-            cls._total_layers = text_total_layers
-
-    QEfficient.base.modeling_qeff.QEFFBaseModel._start = text_start
-    QEfficient.base.modeling_qeff.QEFFBaseModel._end = text_end
-    QEfficient.base.modeling_qeff.QEFFBaseModel._total_layers = text_total_layers
-
-
-def _reset_layer_windows() -> None:
-    _set_layer_windows(0, 0, 0)
+def _reset_layer_windows(context: LayerwiseContext) -> None:
+    if context is None:
+        raise ValueError("_reset_layer_windows requires a LayerwiseContext.")
+    context.reset_window()
 
 
 def _resolve_export_root(onnx_path: Path) -> Path:
@@ -570,58 +586,22 @@ def _cached_layerwise_onnx_path(qeff_model, compile_kwargs: Dict[str, Any]) -> O
     return Path(cached) if cached is not None else None
 
 
-def _install_window_patches_for(model_type: str) -> None:
-    """Install the HF __init__/shard patches needed for the given model_type.
-
-    The shard-file patch makes ``from_pretrained`` skip checkpoint shards that
-    only contain weights for layers outside the active window, so loading an
-    N-layer model in a window of size 1 reads ~1/N of the disk. The init
-    patch nulls the unused decoder layers right after the model is built so
-    the full layer list is never instantiated in memory.
-    """
-    _install_shard_window_patch()
-    candidates = []
-    qwen3_vl_moe_mod = getattr(getattr(transformers.models, "qwen3_vl_moe", None), "modeling_qwen3_vl_moe", None)
-    if qwen3_vl_moe_mod is not None and "qwen3_vl_moe" in model_type:
-        candidates.extend(
-            cls
-            for name in ("Qwen3VLMoeForConditionalGeneration", "Qwen3VLMoeForCausalLM")
-            if (cls := getattr(qwen3_vl_moe_mod, name, None)) is not None
-        )
-    qwen3_5_moe_mod = getattr(getattr(transformers.models, "qwen3_5_moe", None), "modeling_qwen3_5_moe", None)
-    if qwen3_5_moe_mod is not None and model_type in {"qwen3_5_moe", "qwen3_5_moe_text"}:
-        candidates.extend(
-            cls
-            for name in ("Qwen3_5MoeForConditionalGeneration", "Qwen3_5MoeForCausalLM")
-            if (cls := getattr(qwen3_5_moe_mod, name, None)) is not None
-        )
-    qwen3_moe_mod = getattr(getattr(transformers.models, "qwen3_moe", None), "modeling_qwen3_moe", None)
-    if qwen3_moe_mod is not None and model_type in {"qwen3_moe"}:
-        candidates.extend(
-            cls for name in ("Qwen3MoeForCausalLM",) if (cls := getattr(qwen3_moe_mod, name, None)) is not None
-        )
-    for cls in candidates:
-        _install_window_patch(cls)
-
-
 @contextmanager
-def _layerwise_export_env():
-    """Toggle the layerwise-active flag on QEFFBaseModel for the inner block.
+def _layerwise_export_env(context: LayerwiseContext):
+    """Preserve a LayerwiseContext's mutable export-window fields."""
 
-    No environment variables are touched - the flag is a pure in-process class
-    attribute, which keeps the API self-contained and lets concurrent Python
-    interpreters (e.g. test workers) operate independently.
-    """
-    base = QEfficient.base.modeling_qeff.QEFFBaseModel
-    prev_active = getattr(base, "_layerwise_active", False)
-    prev_state_active = _LAYERWISE_STATE["active"]
-    base._layerwise_active = True
-    _LAYERWISE_STATE["active"] = 1
+    if context is None:
+        raise ValueError("Layerwise export requires a LayerwiseContext.")
+    prev_context_state = (
+        context.active,
+        context.start,
+        context.end,
+        context.force_full_init,
+    )
     try:
         yield
     finally:
-        base._layerwise_active = prev_active
-        _LAYERWISE_STATE["active"] = prev_state_active
+        context.active, context.start, context.end, context.force_full_init = prev_context_state
 
 
 def _resolve_text_total_layers(config) -> int:
@@ -646,6 +626,7 @@ def run_layerwise(
     probe_qeff_model=None,
     window_size: int = 1,
     final_compile: bool = True,
+    context: Optional[LayerwiseContext] = None,
 ) -> Any:
     """Drive the per-window export loop and (optionally) the final stitched compile.
 
@@ -680,17 +661,24 @@ def run_layerwise(
     Either the qpc_paths dict (final_compile=True) or the merged ONNX path
     (final_compile=False).
     """
-    _maybe_warn_deprecation()
     model_type = assert_layerwise_supported(config)
 
-    text_total_layers = _resolve_text_total_layers(config)
+    if context is None:
+        _maybe_warn_deprecation()
+        context = create_layerwise_context(
+            model_id=model_id,
+            config=config,
+            window_size=window_size,
+        )
+    elif not context.enabled:
+        raise ValueError("Layerwise context is disabled.")
+
+    text_total_layers = int(context.total_layers)
+    window_size = int(context.window_size)
     text_cfg = getattr(config, "text_config", config)
     text_cfg.num_hidden_layers = text_total_layers
 
-    _ensure_pretrained_window_attrs()
-    _install_window_patches_for(model_type)
-
-    windows = _build_layer_windows(text_total_layers, window_size)
+    windows = context.build_windows()
     logger.info(
         "Layerwise export start: model_type=%s total_layers=%d window_size=%d windows=%d "
         "torch_threads=%d torch_interop_threads=%d",
@@ -730,7 +718,12 @@ def run_layerwise(
                 random.setstate(init_rng_snapshot["python"])
                 np.random.set_state(init_rng_snapshot["numpy"])
                 torch.random.set_rng_state(init_rng_snapshot["torch"])
-                return qeff_factory(model_id, config)
+                loader = CustomLoader(
+                    model_id, layer_indices=range(context.start, context.end), load_kwargs=context.load_kwargs
+                )
+                qeff_model = loader.load_with(qeff_factory, model_id, config)
+                _attach_context_to_qeff_model(qeff_model, context)
+                return qeff_model
             finally:
                 random.setstate(prev_python_state)
                 np.random.set_state(prev_numpy_state)
@@ -739,13 +732,18 @@ def run_layerwise(
     else:
 
         def _build_window_model():
-            return qeff_factory(model_id, config)
+            loader = CustomLoader(
+                model_id, layer_indices=range(context.start, context.end), load_kwargs=context.load_kwargs
+            )
+            qeff_model = loader.load_with(qeff_factory, model_id, config)
+            _attach_context_to_qeff_model(qeff_model, context)
+            return qeff_model
 
     try:
-        with _layerwise_export_env():
-            _set_layer_windows(0, min(window_size, text_total_layers), text_total_layers)
+        with _layerwise_export_env(context):
+            _set_layer_windows(0, min(window_size, text_total_layers), text_total_layers, context=context)
             if needs_deterministic_init:
-                _LAYERWISE_STATE["force_full_init"] = 1
+                context.force_full_init = True
             cached_probe = probe_qeff_model or _build_window_model()
             cached_onnx_path = _cached_layerwise_onnx_path(cached_probe, compile_kwargs)
             if cached_onnx_path is not None:
@@ -758,14 +756,12 @@ def run_layerwise(
                     break
                 window_t0 = time.perf_counter()
                 logger.info("Layerwise window export start: [%d, %d)", text_start, text_end)
-                _set_layer_windows(text_start, text_end, text_total_layers)
+                _set_layer_windows(text_start, text_end, text_total_layers, context=context)
                 if needs_deterministic_init:
-                    _LAYERWISE_STATE["force_full_init"] = 1
+                    context.force_full_init = True
 
                 qeff_model = _build_window_model()
                 last_qeff_model = qeff_model
-                if hasattr(qeff_model, "model"):
-                    _null_outside_window_layers(qeff_model.model, apply_text=True)
                 _slim_for_window_export(qeff_model, ctx_len=compile_kwargs.get("ctx_len"))
 
                 window_kwargs = dict(compile_kwargs)
@@ -799,8 +795,12 @@ def run_layerwise(
                     text_end,
                     time.perf_counter() - window_t0,
                 )
+                if hasattr(qeff_model, "model"):
+                    CustomLoader.to_meta(qeff_model.model)
+                del qeff_model
+                gc.collect()
     finally:
-        _reset_layer_windows()
+        _reset_layer_windows(context=context)
 
     if first_onnx_path is None:
         raise RuntimeError("Layer-wise export produced no ONNX shards.")
@@ -829,7 +829,10 @@ def run_layerwise(
     final_kwargs = dict(compile_kwargs)
     if hasattr(last_qeff_model, "lang_model"):
         final_kwargs["lang_onnx_path"] = str(canonical_onnx)
+        context_owner = getattr(last_qeff_model.lang_model, "model", last_qeff_model.lang_model)
     else:
         final_kwargs["onnx_path"] = str(canonical_onnx)
+        context_owner = getattr(last_qeff_model, "model", last_qeff_model)
     final_kwargs.setdefault("skip_lang", False)
-    return last_qeff_model.compile(**final_kwargs)
+    with suspend_layerwise_context(context_owner):
+        return last_qeff_model.compile(**final_kwargs)

--- a/QEfficient/transformers/models/custom_loader.py
+++ b/QEfficient/transformers/models/custom_loader.py
@@ -1,0 +1,263 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+"""Utilities for selectively loading Hugging Face checkpoint weights."""
+
+from __future__ import annotations
+
+import gc
+import re
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Optional, Pattern, Sequence
+
+import torch
+import transformers
+
+_LAYER_INDEX_PATTERNS = (
+    re.compile(r"(?:^|\.)model\.language_model\.layers\.(\d+)\."),
+    re.compile(r"(?:^|\.)language_model\.layers\.(\d+)\."),
+    re.compile(r"(?:^|\.)model\.layers\.(\d+)\."),
+    re.compile(r"^layers\.(\d+)\."),
+)
+
+_LAYER_MODULE_PATTERNS = (
+    re.compile(r"(?:^|\.)model\.language_model\.layers\.(\d+)$"),
+    re.compile(r"(?:^|\.)language_model\.layers\.(\d+)$"),
+    re.compile(r"(?:^|\.)model\.layers\.(\d+)$"),
+    re.compile(r"(?:^|\.)layers\.(\d+)$"),
+)
+
+
+@dataclass(frozen=True)
+class WeightSelectionPolicy:
+    """Predicate object deciding which checkpoint keys are visible to HF loading."""
+
+    layer_indices: Optional[frozenset[int]] = None
+    layer_key_patterns: Sequence[Pattern[str]] = _LAYER_INDEX_PATTERNS
+    keep_key_patterns: Sequence[Pattern[str]] = field(default_factory=tuple)
+    keep_non_layer_keys: bool = True
+
+    @classmethod
+    def from_layer_indices(
+        cls,
+        layer_indices: Optional[Iterable[int]],
+        *,
+        layer_key_patterns: Optional[Sequence[str | Pattern[str]]] = None,
+        keep_key_patterns: Optional[Sequence[str | Pattern[str]]] = None,
+        keep_non_layer_keys: bool = True,
+    ) -> "WeightSelectionPolicy":
+        return cls(
+            layer_indices=None if layer_indices is None else frozenset(int(idx) for idx in layer_indices),
+            layer_key_patterns=_compile_patterns(layer_key_patterns) or _LAYER_INDEX_PATTERNS,
+            keep_key_patterns=_compile_patterns(keep_key_patterns),
+            keep_non_layer_keys=keep_non_layer_keys,
+        )
+
+    def include_key(self, key: str) -> bool:
+        if self.layer_indices is None:
+            return True
+        if any(pattern.search(key) for pattern in self.keep_key_patterns):
+            return True
+        layer_idx = self.layer_index_for_key(key)
+        if layer_idx is None:
+            return self.keep_non_layer_keys
+        return layer_idx in self.layer_indices
+
+    def layer_index_for_key(self, key: str) -> Optional[int]:
+        for pattern in self.layer_key_patterns:
+            match = pattern.search(key)
+            if match:
+                return int(match.group(1))
+        return None
+
+    def filter_state_dict(self, state_dict: Dict[str, Any]) -> Dict[str, Any]:
+        if self.layer_indices is None:
+            return state_dict
+        return {key: value for key, value in state_dict.items() if self.include_key(key)}
+
+    def filter_weight_map(self, weight_map: Dict[str, str]) -> Dict[str, str]:
+        if self.layer_indices is None:
+            return dict(weight_map)
+        return {key: value for key, value in weight_map.items() if self.include_key(key)}
+
+
+def _compile_patterns(patterns: Optional[Sequence[str | Pattern[str]]]) -> tuple[Pattern[str], ...]:
+    if not patterns:
+        return ()
+    return tuple(re.compile(pattern) if isinstance(pattern, str) else pattern for pattern in patterns)
+
+
+class _FilteredSafeOpen:
+    """Proxy around safetensors.safe_open that hides unselected keys."""
+
+    def __init__(self, file_pointer, policy: WeightSelectionPolicy):
+        self._file_pointer = file_pointer
+        self._policy = policy
+
+    def keys(self):
+        return [key for key in self._file_pointer.keys() if self._policy.include_key(key)]
+
+    def get_slice(self, key):
+        return self._file_pointer.get_slice(key)
+
+    def get_tensor(self, key):
+        return self._file_pointer.get_tensor(key)
+
+    def metadata(self):
+        return self._file_pointer.metadata()
+
+    def __enter__(self):
+        entered = self._file_pointer.__enter__()
+        if entered is not self._file_pointer:
+            self._file_pointer = entered
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return self._file_pointer.__exit__(exc_type, exc_value, traceback)
+
+    def __getattr__(self, name):
+        return getattr(self._file_pointer, name)
+
+
+class CustomLoader:
+    """Selective loader that keeps Hugging Face's normal weight-loading machinery."""
+
+    def __init__(
+        self,
+        model_id: str | Path,
+        layer_indices: Optional[Iterable[int]] = None,
+        *,
+        layer_key_patterns: Optional[Sequence[str | Pattern[str]]] = None,
+        keep_key_patterns: Optional[Sequence[str | Pattern[str]]] = None,
+        load_kwargs: Optional[Dict[str, Any]] = None,
+        keep_non_layer_keys: bool = True,
+    ) -> None:
+        self.model_id = str(model_id)
+        self.load_kwargs = dict(load_kwargs or {})
+        self.policy = WeightSelectionPolicy.from_layer_indices(
+            layer_indices,
+            layer_key_patterns=layer_key_patterns,
+            keep_key_patterns=keep_key_patterns,
+            keep_non_layer_keys=keep_non_layer_keys,
+        )
+
+    @contextmanager
+    def scoped_loading(self):
+        """Temporarily filter checkpoint visibility inside Transformers loading."""
+
+        modeling_utils = transformers.modeling_utils
+        original_get_checkpoint_shard_files = modeling_utils.get_checkpoint_shard_files
+        original_load_state_dict = modeling_utils.load_state_dict
+        original_safe_open = modeling_utils.safe_open
+
+        def patched_get_checkpoint_shard_files(*args, **kwargs):
+            shard_files, metadata = original_get_checkpoint_shard_files(*args, **kwargs)
+            weight_map = metadata.get("weight_map") if metadata else None
+            if not weight_map:
+                return shard_files, metadata
+
+            filtered_weight_map = self.policy.filter_weight_map(weight_map)
+            if not filtered_weight_map:
+                return shard_files, metadata
+
+            shard_name_to_path = {path.split("/")[-1]: path for path in shard_files}
+            filtered_shard_names = sorted(set(filtered_weight_map.values()))
+            filtered_shard_files = [
+                shard_name_to_path[name] for name in filtered_shard_names if name in shard_name_to_path
+            ]
+            if not filtered_shard_files:
+                return shard_files, metadata
+
+            filtered_metadata = dict(metadata)
+            filtered_metadata["weight_map"] = filtered_weight_map
+            filtered_metadata["all_checkpoint_keys"] = list(filtered_weight_map.keys())
+            return filtered_shard_files, filtered_metadata
+
+        def patched_safe_open(*args, **kwargs):
+            return _FilteredSafeOpen(original_safe_open(*args, **kwargs), self.policy)
+
+        def patched_load_state_dict(*args, **kwargs):
+            state_dict = original_load_state_dict(*args, **kwargs)
+            return self.policy.filter_state_dict(state_dict)
+
+        modeling_utils.get_checkpoint_shard_files = patched_get_checkpoint_shard_files
+        modeling_utils.safe_open = patched_safe_open
+        modeling_utils.load_state_dict = patched_load_state_dict
+        try:
+            yield self
+        finally:
+            modeling_utils.get_checkpoint_shard_files = original_get_checkpoint_shard_files
+            modeling_utils.safe_open = original_safe_open
+            modeling_utils.load_state_dict = original_load_state_dict
+
+    def load_model(self, hf_auto_class, **from_pretrained_kwargs):
+        kwargs = dict(self.load_kwargs)
+        kwargs.update(from_pretrained_kwargs)
+        with self.scoped_loading():
+            model = hf_auto_class.from_pretrained(self.model_id, **kwargs)
+        self.to_meta_unselected_layers(model)
+        return model
+
+    def load_with(self, load_fn: Callable[..., Any], *args, **kwargs):
+        with self.scoped_loading():
+            model = load_fn(*args, **kwargs)
+        self.to_meta_unselected_layers(model)
+        return model
+
+    def load_into(self, model, load_fn: Callable[..., Any], *args, **kwargs):
+        del model
+        return self.load_with(load_fn, *args, **kwargs)
+
+    @staticmethod
+    def build_meta_model(hf_auto_class, model_id: str | Path, *, config=None, **from_config_kwargs):
+        if config is None:
+            config_kwargs = {
+                key: from_config_kwargs.pop(key)
+                for key in ("trust_remote_code", "revision", "token", "subfolder", "cache_dir")
+                if key in from_config_kwargs
+            }
+            config = transformers.AutoConfig.from_pretrained(model_id, **config_kwargs)
+        torch_dtype = from_config_kwargs.pop("torch_dtype", from_config_kwargs.pop("dtype", torch.float32))
+        with torch.device("meta"):
+            if hasattr(hf_auto_class, "from_config"):
+                return hf_auto_class.from_config(config, torch_dtype=torch_dtype, **from_config_kwargs)
+            if hasattr(hf_auto_class, "_from_config"):
+                return hf_auto_class._from_config(config, torch_dtype=torch_dtype, **from_config_kwargs)
+            return hf_auto_class(config, **from_config_kwargs)
+
+    @staticmethod
+    def to_meta(model, *, recurse: bool = True, clear_cuda_cache: bool = False):
+        model.to_empty(device="meta", recurse=recurse)
+        gc.collect()
+        if clear_cuda_cache and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        return model
+
+    def to_meta_unselected_layers(self, model, *, clear_cuda_cache: bool = False):
+        if self.policy.layer_indices is None or not hasattr(model, "named_modules"):
+            return model
+        moved_modules = set()
+        for module_name, module in model.named_modules():
+            layer_idx = _layer_index_for_module_name(module_name)
+            if layer_idx is None or layer_idx in self.policy.layer_indices or id(module) in moved_modules:
+                continue
+            module.to_empty(device="meta", recurse=True)
+            moved_modules.add(id(module))
+        gc.collect()
+        if clear_cuda_cache and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        return model
+
+
+def _layer_index_for_module_name(module_name: str) -> Optional[int]:
+    for pattern in _LAYER_MODULE_PATTERNS:
+        match = pattern.search(module_name)
+        if match:
+            return int(match.group(1))
+    return None

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -16,6 +16,7 @@ import onnx
 import torch
 import torch.nn as nn
 from transformers import (
+    AutoConfig,
     AutoImageProcessor,
     AutoModel,
     AutoModelForCausalLM,
@@ -46,6 +47,8 @@ from QEfficient.transformers.modeling_utils import (
     SPECIALIZED_DISAGG_SERVING_MODEL_ARCH,
     _configure_proxy_for_model,
 )
+from QEfficient.transformers.models import _layerwise
+from QEfficient.transformers.models.custom_loader import CustomLoader
 from QEfficient.transformers.models.pytorch_transforms import (
     CustomOpsTransform,
     KVCacheExternalModuleMapperTransform,
@@ -145,12 +148,8 @@ def _build_layerwise_vision_export_model(hf_auto_class, pretrained_model_name_or
     every decoder layer up front. Language ONNX/QPC export still goes through
     the regular layerwise driver, which reloads each window independently.
     """
-    from QEfficient.transformers.models import _layerwise
-
     config = kwargs.get("config", None)
     if config is None:
-        from transformers import AutoConfig
-
         config_kwargs = {
             key: kwargs[key]
             for key in ("trust_remote_code", "revision", "token", "subfolder", "cache_dir")
@@ -158,17 +157,24 @@ def _build_layerwise_vision_export_model(hf_auto_class, pretrained_model_name_or
         }
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
         kwargs["config"] = config
-    model_type = _layerwise.assert_layerwise_supported(config)
+    _layerwise.assert_layerwise_supported(config)
     total_layers = _layerwise._resolve_text_total_layers(config)
-    _layerwise._ensure_pretrained_window_attrs()
-    _layerwise._install_window_patches_for(model_type)
+    context = _layerwise.create_layerwise_context(
+        model_id=str(pretrained_model_name_or_path),
+        config=config,
+        window_size=1,
+        load_kwargs=kwargs,
+    )
 
-    with _layerwise._layerwise_export_env():
-        _layerwise._set_layer_windows(0, min(1, total_layers), total_layers)
+    loader = CustomLoader(
+        pretrained_model_name_or_path, layer_indices=range(0, min(1, total_layers)), load_kwargs=kwargs
+    )
+    with _layerwise._layerwise_export_env(context):
+        _layerwise._set_layer_windows(0, min(1, total_layers), total_layers, context=context)
         try:
-            return hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
+            return loader.load_model(hf_auto_class)
         finally:
-            _layerwise._reset_layer_windows()
+            _layerwise._reset_layer_windows(context=context)
 
 
 def _build_meta_model(hf_auto_class, pretrained_model_name_or_path, kwargs):
@@ -180,18 +186,59 @@ def _build_meta_model(hf_auto_class, pretrained_model_name_or_path, kwargs):
     and buffer is a meta tensor — zero RAM. The layer-wise driver later
     rebuilds a real per-window model when ``compile()``/``export()`` runs.
     """
-    from transformers import AutoConfig
-
     config = kwargs.get("config", None)
     if config is None:
         config_kwargs = {
             k: kwargs[k] for k in ("trust_remote_code", "revision", "token", "subfolder", "cache_dir") if k in kwargs
         }
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
-    torch_dtype = kwargs.get("torch_dtype", torch.float32)
-    with torch.device("meta"):
-        model = hf_auto_class.from_config(config, torch_dtype=torch_dtype)
-    return model
+        kwargs["config"] = config
+    return CustomLoader.build_meta_model(
+        hf_auto_class,
+        pretrained_model_name_or_path,
+        config=config,
+        torch_dtype=kwargs.get("torch_dtype", torch.float32),
+    )
+
+
+def _ensure_config_for_layerwise(pretrained_model_name_or_path, kwargs):
+    config = kwargs.get("config", None)
+    if config is not None:
+        return config
+    config_kwargs = {
+        key: kwargs[key]
+        for key in ("trust_remote_code", "revision", "token", "subfolder", "cache_dir")
+        if key in kwargs
+    }
+    config = AutoConfig.from_pretrained(pretrained_model_name_or_path, **config_kwargs)
+    kwargs["config"] = config
+    return config
+
+
+def _warn_compile_export_layerwise_deprecated() -> None:
+    warnings.warn(
+        "Passing `layerwise` or `layerwise_window_size` to export()/compile() is deprecated. "
+        "Configure layerwise mode with from_pretrained(..., layerwise=True, layerwise_window_size=...) instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def _resolve_layerwise_compile_export_request(model, layerwise, layerwise_window_size):
+    context = _layerwise.get_layerwise_context(model)
+    if layerwise is not None or layerwise_window_size is not None:
+        _warn_compile_export_layerwise_deprecated()
+    if layerwise and context is None:
+        raise ValueError(
+            "layerwise=True at export()/compile() can no longer enable layerwise mode. "
+            "Reload the model with from_pretrained(..., layerwise=True, layerwise_window_size=...)."
+        )
+    if context is not None and layerwise_window_size is not None and int(layerwise_window_size) != context.window_size:
+        raise ValueError(
+            "`layerwise_window_size` at export()/compile() conflicts with the from_pretrained() layerwise context. "
+            f"Got {layerwise_window_size}, expected {context.window_size}."
+        )
+    return context
 
 
 def _compile_io_name(name: str, *, use_onnx_subfunctions: bool) -> str:
@@ -291,6 +338,10 @@ class QEFFTransformersBase(QEFFBaseModel):
 
     def __repr__(self) -> str:
         return self.__class__.__name__ + "\n" + self.model.__repr__()
+
+    @property
+    def layerwise(self) -> bool:
+        return _layerwise.has_layerwise_context(self.model)
 
     @classmethod
     @with_replaced_quantizers
@@ -1300,7 +1351,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
             self.hash_params["prefill_only"] = False
             self.__update_prefill_transform(False, retain_full_kv=kwargs.get("retain_full_kv", False))
 
-        if QEfficient.base.modeling_qeff.QEFFBaseModel._layerwise_active:
+        if _layerwise.is_layerwise_active(self.model):
             return self._export_layerwise(
                 inputs,
                 output_names=output_names,
@@ -1443,6 +1494,10 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         # previous transform function.
         self.lang_model.model, _ = SamplerTransform.apply(self.lang_model.model, qaic_config, **kwargs)
 
+    @property
+    def layerwise(self) -> bool:
+        return _layerwise.has_layerwise_context(self.lang_model.model)
+
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path: str, qaic_config: Optional[dict] = None, **kwargs):
         """
@@ -1512,8 +1567,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         prefill_seq_len: Optional[int] = None,
         prefill_only: bool = False,
         enable_chunking: bool = False,
-        layerwise: bool = False,
-        layerwise_window_size: int = 1,
+        layerwise: Optional[bool] = None,
+        layerwise_window_size: Optional[int] = None,
         kv_cache_prefix: Optional[str] = None,
         **kwargs,
     ) -> str:
@@ -1538,7 +1593,12 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             A list containing the paths to the generated ONNX graph files for both components.
         """
         layerwise_cache_probe = kwargs.pop("_layerwise_cache_probe", False)
-        if layerwise:
+        layerwise_context = _resolve_layerwise_compile_export_request(
+            self.lang_model.model, layerwise, layerwise_window_size
+        )
+        if layerwise_context is not None and not layerwise_context.active:
+            if prefill_only is not True:
+                raise ValueError("Layerwise export is supported only with prefill_only=True.")
             return self._run_layerwise_export(
                 export_dir=export_dir,
                 use_onnx_subfunctions=use_onnx_subfunctions,
@@ -1547,7 +1607,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 prefill_seq_len=prefill_seq_len,
                 prefill_only=prefill_only,
                 enable_chunking=enable_chunking,
-                layerwise_window_size=layerwise_window_size,
+                layerwise_window_size=layerwise_context.window_size,
+                _layerwise_context=layerwise_context,
                 kv_cache_prefix=kv_cache_prefix,
                 **kwargs,
             )
@@ -1586,15 +1647,11 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 qaic_config=self.lang_model.model.qaic_config,
             )
 
-        layerwise_export = QEFFBaseModel._layerwise_active
+        layerwise_context = _layerwise.get_layerwise_context(self.lang_model.model)
+        layerwise_export = _layerwise.is_layerwise_active(self.lang_model.model)
 
         should_export = not skip_vision and (
-            not layerwise_export
-            or (
-                layerwise_export
-                and QEfficient.base.modeling_qeff.QEFFBaseModel._end
-                == QEfficient.base.modeling_qeff.QEFFBaseModel._total_layers
-            )
+            not layerwise_export or (layerwise_context is not None and layerwise_context.is_last_window)
         )
         if should_export and not layerwise_cache_probe:
             self.vision_model.export(
@@ -1717,8 +1774,9 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         layerwise_window_size,
         **kwargs,
     ):
-        from QEfficient.transformers.models import _layerwise
 
+        lang_module = getattr(self.lang_model, "model", self.lang_model)
+        context = kwargs.pop("_layerwise_context", None) or _layerwise.get_layerwise_context(lang_module)
         model_id = self._pretrained_model_name_or_path
         if model_id is None:
             raise RuntimeError(
@@ -1741,8 +1799,9 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             qeff_factory=self._build_layerwise_factory(),
             compile_kwargs=compile_kwargs,
             probe_qeff_model=self,
-            window_size=layerwise_window_size,
+            window_size=context.window_size if context is not None else layerwise_window_size,
             final_compile=False,
+            context=context,
         )
 
     def _run_layerwise_compile(
@@ -1751,8 +1810,9 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         layerwise_window_size,
         **compile_kwargs,
     ):
-        from QEfficient.transformers.models import _layerwise
 
+        lang_module = getattr(self.lang_model, "model", self.lang_model)
+        context = compile_kwargs.pop("_layerwise_context", None) or _layerwise.get_layerwise_context(lang_module)
         model_id = self._pretrained_model_name_or_path
         if model_id is None:
             raise RuntimeError(
@@ -1766,8 +1826,9 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             qeff_factory=self._build_layerwise_factory(),
             compile_kwargs=compile_kwargs,
             probe_qeff_model=self,
-            window_size=layerwise_window_size,
+            window_size=context.window_size if context is not None else layerwise_window_size,
             final_compile=True,
+            context=context,
         )
         self.qpc_paths = qpc_paths
         if isinstance(qpc_paths, dict):
@@ -1804,8 +1865,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         prefill_only=None,
         enable_chunking=False,
         qaic_config: Optional[dict] = None,
-        layerwise: bool = False,
-        layerwise_window_size: int = 1,
+        layerwise: Optional[bool] = None,
+        layerwise_window_size: Optional[int] = None,
         kv_cache_prefix: Optional[str] = None,
         **compiler_options,
     ) -> str:
@@ -1866,7 +1927,10 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         if skip_lang and skip_vision:
             raise ValueError("Expected at least one of 'skip_lang' or 'skip_vision' to be False")
 
-        if layerwise:
+        layerwise_context = _resolve_layerwise_compile_export_request(
+            self.lang_model.model, layerwise, layerwise_window_size
+        )
+        if layerwise_context is not None and not layerwise_context.active:
             if skip_lang and not skip_vision:
                 vision_wrapper = self._build_layerwise_vision_wrapper()
                 qpc_paths = vision_wrapper.compile(
@@ -1920,7 +1984,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 prefill_only=prefill_only,
                 enable_chunking=enable_chunking,
                 qaic_config=qaic_config,
-                layerwise_window_size=layerwise_window_size,
+                layerwise_window_size=layerwise_context.window_size,
+                _layerwise_context=layerwise_context,
                 kv_cache_prefix=kv_cache_prefix,
                 **compiler_options,
             )
@@ -2628,8 +2693,6 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
 
         kwargs.update({"attn_implementation": "eager", "low_cpu_mem_usage": False})
 
-        from transformers import AutoConfig
-
         config = AutoConfig.from_pretrained(pretrained_model_name_or_path, trust_remote_code=True)
         config._attn_implementation = "eager"
         config.vision_config.use_flash_attn = "false"
@@ -3241,6 +3304,7 @@ class QEFFAutoModelForImageTextToText:
         continuous_batching: bool = False,
         qaic_config: Optional[dict] = None,
         layerwise: bool = False,
+        layerwise_window_size: int = 1,
         **kwargs,
     ):
         """
@@ -3293,7 +3357,20 @@ class QEFFAutoModelForImageTextToText:
         )
 
         _resolve_torch_dtype(kwargs)
+        layerwise_context = None
         if layerwise:
+            if kv_offload is False:
+                raise NotImplementedError(
+                    "layerwise=True is currently supported only for ImageTextToText dual-QPC mode."
+                )
+
+            config = _ensure_config_for_layerwise(pretrained_model_name_or_path, kwargs)
+            layerwise_context = _layerwise.create_layerwise_context(
+                model_id=pretrained_model_name_or_path,
+                config=config,
+                window_size=layerwise_window_size,
+                load_kwargs=kwargs,
+            )
             # Layer-wise mode: build the outer model on the meta device so the
             # caller's ``from_pretrained`` does not pull the full checkpoint
             # into RAM. compile()/export() rebuilds a real per-window model
@@ -3318,6 +3395,7 @@ class QEFFAutoModelForImageTextToText:
         # other way) and so the driver knows weights still need to be loaded.
         if layerwise:
             instance._layerwise_outer_meta = True
+            _layerwise.attach_layerwise_context(instance.lang_model.model, layerwise_context)
         return instance
 
 
@@ -3490,6 +3568,10 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
     def __repr__(self) -> str:
         return self.__class__.__name__ + "\n" + self.model.__repr__()
 
+    @property
+    def layerwise(self) -> bool:
+        return _layerwise.has_layerwise_context(self.model)
+
     @classmethod
     @with_replaced_quantizers
     def from_pretrained(
@@ -3499,6 +3581,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         qaic_config: Optional[dict] = None,
         max_seq_len_cached: Optional[int] = None,
         layerwise: bool = False,
+        layerwise_window_size: int = 1,
         *args,
         **kwargs,
     ):
@@ -3568,7 +3651,15 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         )
 
         _resolve_torch_dtype(kwargs)
+        layerwise_context = None
         if layerwise:
+            config = _ensure_config_for_layerwise(pretrained_model_name_or_path, kwargs)
+            layerwise_context = _layerwise.create_layerwise_context(
+                model_id=pretrained_model_name_or_path,
+                config=config,
+                window_size=layerwise_window_size,
+                load_kwargs=kwargs,
+            )
             # Layer-wise mode: build the outer model on the meta device. The
             # caller still gets a typed wrapper, but no checkpoint weights are
             # pulled into RAM. compile()/export() rebuilds a real per-window
@@ -3600,6 +3691,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         )
         if layerwise:
             instance._layerwise_outer_meta = True
+            _layerwise.attach_layerwise_context(instance.model, layerwise_context)
         return instance
 
     @property
@@ -3679,8 +3771,8 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
 
     def _run_layerwise(self, *, final_compile: bool, layerwise_window_size: int, **forward_kwargs):
         """Drive the layer-wise export/compile loop for CausalLM models."""
-        from QEfficient.transformers.models import _layerwise
 
+        context = forward_kwargs.pop("_layerwise_context", None) or _layerwise.get_layerwise_context(self.model)
         model_id = getattr(self.model, "pretrained_path", None)
         if model_id is None:
             raise RuntimeError(
@@ -3706,8 +3798,9 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             qeff_factory=_factory,
             compile_kwargs=forward_kwargs,
             probe_qeff_model=self,
-            window_size=layerwise_window_size,
+            window_size=context.window_size if context is not None else layerwise_window_size,
             final_compile=final_compile,
+            context=context,
         )
 
     def export(
@@ -3717,8 +3810,8 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         prefill_seq_len: Optional[int] = None,
         num_cores: int = constants.DEFAULT_AIC_NUM_CORES,
         moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
-        layerwise: bool = False,
-        layerwise_window_size: int = 1,
+        layerwise: Optional[bool] = None,
+        layerwise_window_size: Optional[int] = None,
         kv_cache_prefix: Optional[str] = None,
         **kwargs,
     ) -> str:
@@ -3747,10 +3840,14 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                 "Use the default non-prefill export path for standard CausalLM decode graphs."
             )
 
-        if layerwise:
+        layerwise_context = _resolve_layerwise_compile_export_request(self.model, layerwise, layerwise_window_size)
+        if layerwise_context is not None and not layerwise_context.active:
+            if prefill_only is not True:
+                raise ValueError("Layerwise export is supported only with prefill_only=True.")
             return self._run_layerwise(
                 final_compile=False,
-                layerwise_window_size=layerwise_window_size,
+                layerwise_window_size=layerwise_context.window_size,
+                _layerwise_context=layerwise_context,
                 export_dir=export_dir,
                 prefill_only=prefill_only,
                 prefill_seq_len=prefill_seq_len,
@@ -4006,7 +4103,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             output_names = apply_kv_cache_prefix(output_names, kv_cache_prefix)
             self.hash_params["kv_cache_prefix"] = kv_cache_prefix
 
-        if QEFFBaseModel._layerwise_active:
+        if _layerwise.is_layerwise_active(self.model):
             return self._export_layerwise(
                 example_inputs,
                 output_names=output_names,
@@ -4179,8 +4276,8 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         enable_chunking: Optional[bool] = False,
         moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
         retain_full_kv: Optional[bool] = None,
-        layerwise: bool = False,
-        layerwise_window_size: int = 1,
+        layerwise: Optional[bool] = None,
+        layerwise_window_size: Optional[int] = None,
         kv_cache_prefix: Optional[str] = None,
         **compiler_options,
     ) -> str:
@@ -4270,10 +4367,12 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             If `prefill_seq_len` is less than `num_speculative_tokens + 1` for TLM models.
 
         """
-        if layerwise:
+        layerwise_context = _resolve_layerwise_compile_export_request(self.model, layerwise, layerwise_window_size)
+        if layerwise_context is not None and not layerwise_context.active:
             return self._run_layerwise(
                 final_compile=True,
-                layerwise_window_size=layerwise_window_size,
+                layerwise_window_size=layerwise_context.window_size,
+                _layerwise_context=layerwise_context,
                 onnx_path=onnx_path,
                 compile_dir=compile_dir,
                 prefill_seq_len=prefill_seq_len,

--- a/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -57,6 +57,10 @@ from QEfficient.transformers.cache_utils import (
 )
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.transformers.models._layerwise import (
+    get_layerwise_context,
+    get_layerwise_end,
+    get_layerwise_start,
+    get_layerwise_total_layers,
     is_last_layer_window,
     is_layerwise_active,
     resolve_layer_window,
@@ -93,9 +97,10 @@ class QEffQwen3_5MoeDynamicCache(Cache):
     convolution and recurrent states.
     """
 
-    def __init__(self, config):
+    def __init__(self, config, layerwise_context=None):
         super().__init__(layers=[])
         self.config = config
+        self.layerwise_context = layerwise_context
         self.layer_types = list(config.layer_types)
         self.transformer_layers = [i for i, layer_type in enumerate(self.layer_types) if layer_type == "full_attention"]
         self.last_linear_layer = next(
@@ -113,12 +118,13 @@ class QEffQwen3_5MoeDynamicCache(Cache):
         cls,
         config,
         past_key_values: Optional[Tuple[Tuple[torch.FloatTensor, ...], ...]] = None,
+        layerwise_context=None,
     ) -> "QEffQwen3_5MoeDynamicCache":
-        cache = cls(config)
+        cache = cls(config, layerwise_context=layerwise_context)
         if past_key_values is None:
             return cache
 
-        if not is_layerwise_active():
+        if layerwise_context is None or not layerwise_context.active:
             # Default path: restore every layer, matching pre-layerwise behavior.
             for layer_idx, layer_state in enumerate(past_key_values):
                 if cache.layer_types[layer_idx] == "full_attention":
@@ -133,7 +139,7 @@ class QEffQwen3_5MoeDynamicCache(Cache):
                     cache.recurrent_states[layer_idx] = recurrent_state
             return cache
 
-        layer_idx = QEffQwen3_5MoeTextModel._start
+        layer_idx = int(layerwise_context.start)
         layer_state = past_key_values
         if len(past_key_values) == len(cache.layer_types) and isinstance(past_key_values[layer_idx], (tuple, list)):
             layer_state = past_key_values[layer_idx]
@@ -222,8 +228,8 @@ class QEffQwen3_5MoeDynamicCache(Cache):
             return self.conv_states[layer_idx] is not None
 
         # Layerwise path only materializes the active layer state.
-        if is_layerwise_active():
-            active_idx = QEffQwen3_5MoeTextModel._start
+        if self.layerwise_context is not None and self.layerwise_context.active:
+            active_idx = int(self.layerwise_context.start)
             if 0 <= active_idx < len(self.layer_types) and self.layer_types[active_idx] == "linear_attention":
                 return self.conv_states[active_idx] is not None
 
@@ -1016,10 +1022,6 @@ class QEffQwen3_5MoeDecoderLayer(Qwen3_5MoeDecoderLayer):
 
 
 class QEffQwen3_5MoeTextModel(Qwen3_5MoeTextModel):
-    _start = 0
-    _end = 0
-    _total_layers = None
-
     def __qeff_init__(self):
         self.rotary_emb = QEffQwen3_5MoeTextRotaryEmbedding(config=self.config)
         rope_rows = min(int(self.rotary_emb.sin_cached.shape[0]), QWEN3_5_MOE_ROPE_CACHE_EXPORT_CAP)
@@ -1054,20 +1056,23 @@ class QEffQwen3_5MoeTextModel(Qwen3_5MoeTextModel):
 
         return_legacy_cache = False
 
+        layerwise_context = get_layerwise_context(self)
         if past_key_values is not None and not isinstance(past_key_values, QEffQwen3_5MoeDynamicCache):
             return_legacy_cache = True
-            past_key_values = QEffQwen3_5MoeDynamicCache.from_legacy_cache(self.config, past_key_values)
+            past_key_values = QEffQwen3_5MoeDynamicCache.from_legacy_cache(
+                self.config, past_key_values, layerwise_context=layerwise_context
+            )
         elif use_cache and past_key_values is None:
-            past_key_values = QEffQwen3_5MoeDynamicCache(self.config)
+            past_key_values = QEffQwen3_5MoeDynamicCache(self.config, layerwise_context=layerwise_context)
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 
-        start, end = resolve_layer_window(QEffQwen3_5MoeTextModel, len(self.layers))
+        start, end = resolve_layer_window(self, len(self.layers))
         if cache_position is None:
             past_seen_tokens = past_key_values.get_seq_length(layer_idx=start) if past_key_values is not None else 0
             active_layer_type = self.config.layer_types[start] if start < len(self.config.layer_types) else None
-            if is_layerwise_active() and position_ids is not None and active_layer_type == "linear_attention":
+            if is_layerwise_active(self) and position_ids is not None and active_layer_type == "linear_attention":
                 text_position_ids = position_ids[0] if position_ids.ndim == 3 else position_ids
                 cache_position = text_position_ids[0].clamp_min(0)
             else:
@@ -1125,7 +1130,7 @@ class QEffQwen3_5MoeTextModel(Qwen3_5MoeTextModel):
 
             # break
 
-        if is_last_layer_window(QEffQwen3_5MoeTextModel, len(self.layers)):
+        if is_last_layer_window(self, len(self.layers)):
             hidden_states = self.norm(hidden_states)
         if output_hidden_states:
             all_hidden_states += (hidden_states,)
@@ -1133,8 +1138,8 @@ class QEffQwen3_5MoeTextModel(Qwen3_5MoeTextModel):
         if return_legacy_cache:
             past_key_values = past_key_values.to_legacy_cache()
 
-        if is_layerwise_active():
-            past_key_values = past_key_values[QEffQwen3_5MoeTextModel._start]
+        if is_layerwise_active(self):
+            past_key_values = past_key_values[get_layerwise_start(self)]
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=past_key_values if use_cache else None,
@@ -1259,10 +1264,6 @@ class QEffQwen3_5MoeForCausalLM(Qwen3_5MoeForCausalLM):
 
 
 class QEffQwen3_5MoeModel(Qwen3_5MoeModel):
-    _start = 0
-    _end = 0
-    _total_layers = None
-
     def forward(
         self,
         input_ids: torch.LongTensor = None,
@@ -1578,7 +1579,7 @@ class QEffQwen3_5MoeDecoderWrapper(nn.Module):
         else:
             inputs_embeds = inputs_embeds
 
-        if not is_layerwise_active():
+        if not is_layerwise_active(self):
             # Default (non-layerwise) path: image merge + full decoder + lm_head in
             # a single forward, identical to the pre-layerwise behavior/output contract.
             _, _, channel_size = inputs_embeds.shape
@@ -1604,7 +1605,7 @@ class QEffQwen3_5MoeDecoderWrapper(nn.Module):
             image_idx = (indices1.max() + 1).unsqueeze(0).unsqueeze(0)
             return logits, vision_embeds, image_idx, outputs.past_key_values[: len(past_key_values)]
 
-        if QEffQwen3_5MoeTextModel._start == 0:
+        if get_layerwise_start(self) == 0:
             B, S, _ = inputs_embeds.shape
             if input_ids is None:
                 input_ids = torch.zeros((B, S), dtype=torch.int64, device=inputs_embeds.device)
@@ -1633,7 +1634,7 @@ class QEffQwen3_5MoeDecoderWrapper(nn.Module):
             image_idx = (indices1.max() + 1).unsqueeze(0).unsqueeze(0)
             return logits, vision_embeds, image_idx, outputs.past_key_values
 
-        elif QEffQwen3_5MoeTextModel._end == QEffQwen3_5MoeTextModel._total_layers:
+        elif get_layerwise_end(self) == get_layerwise_total_layers(self):
             outputs = self.language_model(
                 inputs_embeds=inputs_embeds,
                 position_ids=position_ids,
@@ -1999,8 +2000,8 @@ class QEffQwen3_5MoeForConditionalGeneration(Qwen3_5MoeForConditionalGeneration)
 
         lang_inputs["past_key_values"] = [[] for _ in range(self.model.config.text_config.num_hidden_layers)]
         # Default path exports all layers; layerwise exports only the active window's layer.
-        if is_layerwise_active():
-            window_layers = [QEffQwen3_5MoeTextModel._start]
+        if is_layerwise_active(self.model):
+            window_layers = [get_layerwise_start(self.model)]
         else:
             window_layers = range(self.model.config.text_config.num_hidden_layers)
         # KV/state dummy dtype follows the model dtype so the export trace works

--- a/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -41,7 +41,12 @@ from QEfficient.customop.ctx_scatter_gather import (
 )
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
-from QEfficient.transformers.models._layerwise import is_last_layer_window, is_layerwise_active, resolve_layer_window
+from QEfficient.transformers.models._layerwise import (
+    get_layerwise_start,
+    is_last_layer_window,
+    is_layerwise_active,
+    resolve_layer_window,
+)
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
 
 
@@ -320,8 +325,8 @@ class QEffQwen3MoeAttention(Qwen3MoeAttention):
 
         past_seen_tokens = past_key_values.get_seq_length(self.layer_idx) if past_key_values is not None else 0
         blocking_config = getattr(self, "attn_blocking_config", AttentionBlockingConfig())
-        if is_layerwise_active():
-            self.layer_idx = self.layer_idx - getattr(QEffQwen3MoeModel, "_start", 0)
+        if is_layerwise_active(self):
+            self.layer_idx = self.layer_idx - get_layerwise_start(self)
         use_blocking = blocking_config is not None and (blocking_config.mode != BlockingMode.NONE)
         if use_blocking:
             attn_output, attn_weights = generic_blocked_attention_interface(
@@ -428,10 +433,6 @@ class QEffQwen3MoeDecoderLayer(Qwen3MoeDecoderLayer):
 
 
 class QEffQwen3MoeModel(Qwen3MoeModel):
-    _start = 0
-    _end = 0
-    _total_layers = None
-
     def __qeff_init__(self):
         self.rotary_emb = QEffQwen3MoeRotaryEmbedding(config=self.config)
         self.sin_cached = torch.nn.Parameter(self.rotary_emb.sin_cached)
@@ -463,7 +464,7 @@ class QEffQwen3MoeModel(Qwen3MoeModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         total_layers = len(self.layers)
-        start, end = resolve_layer_window(QEffQwen3MoeModel, total_layers)
+        start, end = resolve_layer_window(self, total_layers)
 
         past_key_values_length = 0
         if past_key_values is not None:
@@ -504,7 +505,7 @@ class QEffQwen3MoeModel(Qwen3MoeModel):
                 cos_cached=cos,
             )
 
-        if is_last_layer_window(QEffQwen3MoeModel, len(self.layers)):
+        if is_last_layer_window(self, len(self.layers)):
             hidden_states = self.norm(hidden_states)
 
         # add hidden states from the last decoder layer
@@ -565,7 +566,7 @@ class QEffQwen3MoeForCausalLM(Qwen3MoeForCausalLM):
         )
 
         hidden_states = outputs.last_hidden_state
-        if not is_last_layer_window(QEffQwen3MoeModel, len(self.model.layers)):
+        if not is_last_layer_window(self.model, len(self.model.layers)):
             logits = hidden_states
         else:
             logit_idx = position_ids.to(torch.int32).argmax(1, keepdim=True)

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -43,6 +43,10 @@ from QEfficient.blocking.attention_blocking import (
 from QEfficient.transformers.cache_utils import QEffDynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.transformers.models._layerwise import (
+    get_layerwise_context,
+    get_layerwise_end,
+    get_layerwise_start,
+    get_layerwise_total_layers,
     is_last_layer_window,
     is_layerwise_active,
     resolve_layer_window,
@@ -398,8 +402,8 @@ class QEffQwen3VLMoeTextAttention(Qwen3VLMoeTextAttention):
         key_states = self.k_norm(self.k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
         query_states, key_states = qeff_apply_rotary_pos_emb(query_states, key_states, cos_cached, sin_cached)
-        if is_layerwise_active():
-            self.layer_idx = self.layer_idx - getattr(QEffQwen3VLMoeTextModel, "_start", 0)
+        if is_layerwise_active(self):
+            self.layer_idx = self.layer_idx - get_layerwise_start(self)
         past_seen_tokens = past_key_values.get_seq_length(self.layer_idx) if past_key_values is not None else 0
         blocking_config = getattr(self, "attn_blocking_config", AttentionBlockingConfig())
         use_blocking = blocking_config is not None and (blocking_config.mode != BlockingMode.NONE)
@@ -527,10 +531,6 @@ class QEffQwen3VLMoeTextDecoderLayer(Qwen3VLMoeTextDecoderLayer):
 
 
 class QEffQwen3VLMoeTextModel(Qwen3VLMoeTextModel):
-    _start = 0
-    _end = 0
-    _total_layers = None
-
     def __qeff_init__(self):
         self.rotary_emb = QEffQwen3VLMoeTextRotaryEmbedding(config=self.config)
         # Export-only cap to avoid serializing oversized RoPE tables that are
@@ -601,7 +601,7 @@ class QEffQwen3VLMoeTextModel(Qwen3VLMoeTextModel):
         all_self_attns = () if output_attentions else None
 
         layer_idx = 0
-        start, end = resolve_layer_window(QEffQwen3VLMoeTextModel, len(self.layers))
+        start, end = resolve_layer_window(self, len(self.layers))
         layer_indices_to_run = kwargs.get("layer_indices_to_run", None)
 
         for layer_idx, decoder_layer in enumerate(self.layers):
@@ -641,7 +641,7 @@ class QEffQwen3VLMoeTextModel(Qwen3VLMoeTextModel):
                 )
             layer_idx += 1
 
-        if is_last_layer_window(QEffQwen3VLMoeTextModel, len(self.layers)):
+        if is_last_layer_window(self, len(self.layers)):
             hidden_states = self.norm(hidden_states)
         if output_hidden_states:
             all_hidden_states += (hidden_states,)
@@ -803,9 +803,6 @@ class QEffQwen3VLMoeTextExperts(Qwen3VLMoeTextExperts):
 
 
 class QEffQwen3VLDecoderWrapper(nn.Module):
-    _deepstack = None
-    _vision_mask = None
-
     def __init__(self, model):
         super().__init__()
         self.model = model
@@ -837,7 +834,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
         else:
             inputs_embeds = inputs_embeds
 
-        if not is_layerwise_active():
+        if not is_layerwise_active(self):
             # Default (non-layerwise) path: image merge + full decoder + lm_head in
             # a single forward, identical to the pre-layerwise behavior/output contract.
             B, N, C = inputs_embeds.shape
@@ -876,7 +873,8 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
             image_idx = (indices1.max() + 1).unsqueeze(0).unsqueeze(0)
             return logits, vision_embeds, deepstack_features, image_idx, outputs.past_key_values
 
-        if QEffQwen3VLMoeTextModel._start == 0:
+        layerwise_context = get_layerwise_context(self)
+        if get_layerwise_start(self) == 0:
             B, N, C = inputs_embeds.shape
             selected = input_ids == self.model.config.image_token_id
             indices1 = selected.to(torch.int64).cumsum(1) - 1
@@ -897,9 +895,10 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
             deepstack_visual_embeds = None
             if image_mask is not None:
                 visual_pos_masks = image_mask
-                QEffQwen3VLDecoderWrapper._vision_mask = visual_pos_masks
                 deepstack_visual_embeds = deepstack_features_expanded
-                QEffQwen3VLDecoderWrapper._deepstack = deepstack_visual_embeds
+                if layerwise_context is not None:
+                    layerwise_context.vision_mask = visual_pos_masks
+                    layerwise_context.deepstack_visual_embeds = deepstack_visual_embeds
 
             outputs = self.language_model(
                 inputs_embeds=inputs_embeds,
@@ -919,7 +918,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
             image_idx = (indices1.max() + 1).unsqueeze(0).unsqueeze(0)
             return logits, vision_embeds, deepstack_features, image_idx, outputs.past_key_values
 
-        elif QEffQwen3VLMoeTextModel._end == QEffQwen3VLMoeTextModel._total_layers:
+        elif get_layerwise_end(self) == get_layerwise_total_layers(self):
             outputs = self.language_model(
                 inputs_embeds=inputs_embeds,
                 position_ids=position_ids,
@@ -927,8 +926,8 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
                 comp_ctx_lengths=comp_ctx_lengths,
                 batch_index=batch_index,
                 use_cache=True,
-                visual_pos_masks=QEffQwen3VLDecoderWrapper._vision_mask,
-                deepstack_visual_embeds=QEffQwen3VLDecoderWrapper._deepstack,
+                visual_pos_masks=getattr(layerwise_context, "vision_mask", None),
+                deepstack_visual_embeds=getattr(layerwise_context, "deepstack_visual_embeds", None),
             )
             logit_index = position_ids[0].to(torch.int32).argmax(1, keepdim=True)
             hidden_states = outputs.last_hidden_state[torch.arange(position_ids[0].shape[0]).view(-1, 1), logit_index]
@@ -943,8 +942,8 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
                 comp_ctx_lengths=comp_ctx_lengths,
                 batch_index=batch_index,
                 use_cache=True,
-                visual_pos_masks=QEffQwen3VLDecoderWrapper._vision_mask,
-                deepstack_visual_embeds=QEffQwen3VLDecoderWrapper._deepstack,
+                visual_pos_masks=getattr(layerwise_context, "vision_mask", None),
+                deepstack_visual_embeds=getattr(layerwise_context, "deepstack_visual_embeds", None),
             )
             if outputs.last_hidden_state.shape[1] > 1:
                 hidden_states = outputs.last_hidden_state

--- a/QEfficient/utils/torch_patches.py
+++ b/QEfficient/utils/torch_patches.py
@@ -144,14 +144,6 @@ def _get_module_attributes(module):
     return attrs
 
 
-def _layerwise_safe_export_passes_enabled():
-    try:
-        from QEfficient.base.modeling_qeff import QEFFBaseModel
-    except Exception:
-        return False
-    return bool(getattr(QEFFBaseModel, "_layerwise_active", False))
-
-
 def _enable_safe_export_pass_patches(keep_passes=None):
     global _safe_export_patch_depth
 
@@ -184,13 +176,13 @@ def _disable_safe_export_pass_patches():
 def layerwise_safe_onnx_export_patches(enabled: bool = True, keep_passes=None):
     """Temporarily disable expensive ONNX exporter passes for layerwise prefill.
 
-    This is a no-op unless the caller explicitly enables it and the process is
-    inside the layerwise export context. Regular/non-layerwise export therefore
-    keeps the original PyTorch ONNX exporter behavior. DCE stays enabled by
-    default because some exported graphs need it to remove aten/prim nodes before
-    PyTorch serializes ONNX. ``keep_passes`` can retain additional passes.
+    This is a no-op unless the caller explicitly enables it. Regular/non-layerwise
+    export should pass ``enabled=False`` so it keeps the original PyTorch ONNX
+    exporter behavior. DCE stays enabled by default because some exported graphs
+    need it to remove aten/prim nodes before PyTorch serializes ONNX.
+    ``keep_passes`` can retain additional passes.
     """
-    if not enabled or not _layerwise_safe_export_passes_enabled():
+    if not enabled:
         yield
         return
 

--- a/skills_studio/AGENTS.md
+++ b/skills_studio/AGENTS.md
@@ -14,6 +14,10 @@ while preserving PyTorch ↔ ONNX ↔ on-device parity.
   - Or directly: `ruff check --fix .` then `ruff format .`
 - Run tests: `pytest -n auto <path-or-expr>`
   - Narrow first with `-k '<expr>'`, then widen once green.
+  - Always run the appropriate tests after refactoring code, adding features,
+    onboarding models, or making comparable behavioral changes.
+  - If no suitable tests exist for newly added code, add focused tests in the
+    appropriate existing test location before validating the change.
   - Tests are tagged with markers (see `pyproject.toml`): `on_qaic`, `cli`, `finetune`,
     `multimodal`, `qnn`, `diffusion_models`, `regular`, `nightly`, `vllm`, `wan`, `flux`.
   - `on_qaic` / `qnn` tests require QAIC hardware and will not run on plain CPU hosts.
@@ -44,19 +48,22 @@ while preserving PyTorch ↔ ONNX ↔ on-device parity.
   from SOLID for compatibility, performance, export constraints, or minimal-risk
   integration, call that out to the user with the reason.
 - Always use signed-off commits with `git commit -s`.
-- Keep code standards high: follow PEP 8 for Python, avoid commented-out code,
-  and never leave breakpoints, ad-hoc debug prints, or temporary debugging hooks.
+- Keep code standards high: follow PEP 8 for Python, including naming variables,
+  classes, functions, and modules appropriately and maintaining clean import order.
+  Avoid commented-out code, and never leave breakpoints, ad-hoc debug prints, or
+  temporary debugging hooks.
 - Do not add new test files when an existing test (or the quickcheck gate) can carry the regression.
 
 ## Required user inputs
 - Ask the user for the virtualenv path only when there is a real need to execute Python-dependent commands, such as `python`, `pip`, `pytest`, `ruff`, or `pre-commit`; otherwise do not ask.
 - Ask the user for `HF_HUB_CACHE` before downloading or loading any model.
-- Ask the user for `QEFF_HOME` before export/compile work that produces QEff artifacts.
+- Set `HF_HUB_ENABLE_HF_TRANSFER=1` whenever downloading models from Hugging Face.
+- Ask the user for `QEFF_HOME` before export/compile work that produces QEff artifacts only when the correct location is ambiguous; otherwise choose an appropriate local path and proceed.
 
 ## Contribution policy
 - Follow the fork → branch → PR flow in `CONTRIBUTING.md`; sync from `upstream/main`.
-- Before committing, run the relevant linter/formatter for the files changed and
-  address the findings instead of committing avoidable style issues.
+- Always run the relevant linter and formatter at the end of code changes, and
+  address the findings instead of leaving avoidable style issues.
 - A human submitter must understand and be able to defend every AI-assisted change
   end-to-end, and must review every changed line and run the relevant tests.
 - Disclose AI assistance and the exact test commands run in the PR description.

--- a/tests/configs/image_text_model_configs.json
+++ b/tests/configs/image_text_model_configs.json
@@ -618,7 +618,7 @@
       "prompt_len": 128,
       "ctx_len": 4096,
       "img_size": 1540,
-      "img_url": "https://picsum.photos/id/237/536/354",
+      "img_url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/ai2d-demo.jpg",
       "text_prompt": "Can you describe the image in detail.",
       "num_layers": 1,
       "additional_params": {

--- a/tests/diffusers/diffusers_utils.py
+++ b/tests/diffusers/diffusers_utils.py
@@ -11,12 +11,34 @@ Provides essential functions for MAD validation, image validation
 hash verification, and other testing utilities.
 """
 
+import gc
 import os
 from typing import Any, Dict, Tuple, Union
 
 import numpy as np
 import torch
 from PIL import Image
+
+
+def release_qpc_session(module_obj) -> None:
+    """Deactivate and drop a module's QAIC session so device resources are released between tests."""
+    qpc_session = getattr(module_obj, "qpc_session", None)
+    if qpc_session is None:
+        return
+    try:
+        qpc_session.deactivate()
+    finally:
+        module_obj.qpc_session = None
+        del qpc_session
+        gc.collect()
+
+
+def release_pipeline_qpc_sessions(pipeline, module_names) -> None:
+    """Release QAIC sessions for the named modules if they exist on the pipeline."""
+    for module_name in module_names:
+        module_obj = getattr(pipeline, module_name, None)
+        if module_obj is not None:
+            release_qpc_session(module_obj)
 
 
 class DiffusersTestUtils:

--- a/tests/diffusers/test_flux.py
+++ b/tests/diffusers/test_flux.py
@@ -23,7 +23,12 @@ from QEfficient.diffusers.pipelines.pipeline_utils import (
 )
 from QEfficient.generation.cloud_infer import QAICInferenceSession
 from QEfficient.utils._utils import load_json
-from tests.diffusers.diffusers_utils import DiffusersTestUtils, MADValidator
+from tests.diffusers.diffusers_utils import (
+    DiffusersTestUtils,
+    MADValidator,
+    release_pipeline_qpc_sessions,
+    release_qpc_session,
+)
 
 # Test Configuration for 256x256 resolution with 2 layers # update mad tolerance
 CONFIG_PATH = "tests/diffusers/flux_test_config.json"
@@ -125,8 +130,8 @@ def flux_pipeline_call_with_mad_validation(
         max_sequence_length=max_sequence_length,
     )
     # Deactivate text encoder qpc sessions
-    pipeline.text_encoder.qpc_session.deactivate()
-    pipeline.text_encoder_2.qpc_session.deactivate()
+    release_qpc_session(pipeline.text_encoder)
+    release_qpc_session(pipeline.text_encoder_2)
 
     # MAD Validation for Text Encoders
     print(" Performing MAD validation for text encoders...")
@@ -273,7 +278,7 @@ def flux_pipeline_call_with_mad_validation(
             if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % pipeline.scheduler.order == 0):
                 progress_bar.update()
 
-    pipeline.transformer.qpc_session.deactivate()  # deactivate transformer qpc session
+    release_qpc_session(pipeline.transformer)
     # Step 8: Decode latents to images
     if output_type == "latent":
         image = latents
@@ -304,7 +309,7 @@ def flux_pipeline_call_with_mad_validation(
         image = pipeline.vae_decode.qpc_session.run(inputs)
         end_decode_time = time.time()
         vae_decode_perf = end_decode_time - start_decode_time
-        pipeline.vae_decode.qpc_session.deactivate()  # deactivate vae decoder qpc session
+        release_qpc_session(pipeline.vae_decode)
 
         # VAE MAD validation
         mad_validator.validate_module_mad(image_torch.detach().cpu().numpy(), image["sample"], "vae_decoder")
@@ -496,6 +501,8 @@ def _run_flux_pipeline_test_case(
     except Exception as e:
         print(f"\nTEST FAILED: {e}")
         raise
+    finally:
+        release_pipeline_qpc_sessions(pipeline, ["text_encoder", "text_encoder_2", "transformer", "vae_decode"])
 
 
 @pytest.mark.flux

--- a/tests/diffusers/test_wan.py
+++ b/tests/diffusers/test_wan.py
@@ -29,7 +29,12 @@ from QEfficient.diffusers.pipelines.pipeline_utils import (
 from QEfficient.generation.cloud_infer import QAICInferenceSession
 from QEfficient.utils import constants
 from QEfficient.utils._utils import load_json
-from tests.diffusers.diffusers_utils import DiffusersTestUtils, MADValidator
+from tests.diffusers.diffusers_utils import (
+    DiffusersTestUtils,
+    MADValidator,
+    release_pipeline_qpc_sessions,
+    release_qpc_session,
+)
 
 # Test Configuration for 48 x 64 resolution with 1 layer
 CONFIG_PATH = "tests/diffusers/wan_test_config.json"
@@ -365,10 +370,10 @@ def wan_pipeline_call_with_mad_validation(
     )
 
     if pipeline.use_unified:
-        pipeline.transformer.qpc_session.deactivate()  # deactivate transformer qpc session
+        release_qpc_session(pipeline.transformer)
     else:
-        pipeline.transformer_high.qpc_session.deactivate()
-        pipeline.transformer_low.qpc_session.deactivate()
+        release_qpc_session(pipeline.transformer_high)
+        release_qpc_session(pipeline.transformer_low)
     # Step 9: Decode latents to video QAIC VAE decoder
     latents = latents.to(pipeline.vae_decoder.model.dtype)
     latents_mean = (
@@ -399,7 +404,7 @@ def wan_pipeline_call_with_mad_validation(
     video = pipeline.vae_decoder.qpc_session.run(inputs)
     end_decode_time = time.perf_counter()
     vae_decoder_perf = end_decode_time - start_decode_time
-    pipeline.vae_decoder.qpc_session.deactivate()  # deactivate vae decoder qpc session
+    release_qpc_session(pipeline.vae_decoder)
 
     # VAE decoder MAD validation
     print(" Performing MAD validation for VAE decoder...")
@@ -667,6 +672,8 @@ def _run_wan_pipeline_test_case(
     except Exception as e:
         print(f"\nTEST FAILED: {e}")
         raise
+    finally:
+        release_pipeline_qpc_sessions(pipeline, ["transformer", "transformer_high", "transformer_low", "vae_decoder"])
 
 
 if __name__ == "__main__":

--- a/tests/diffusers/test_wan_i2v.py
+++ b/tests/diffusers/test_wan_i2v.py
@@ -29,7 +29,12 @@ from QEfficient.diffusers.pipelines.pipeline_utils import (
 from QEfficient.generation.cloud_infer import QAICInferenceSession
 from QEfficient.utils import constants
 from QEfficient.utils._utils import load_json
-from tests.diffusers.diffusers_utils import DiffusersTestUtils, MADValidator
+from tests.diffusers.diffusers_utils import (
+    DiffusersTestUtils,
+    MADValidator,
+    release_pipeline_qpc_sessions,
+    release_qpc_session,
+)
 
 # Test Configuration for I2V with dynamic sizing
 CONFIG_PATH = "tests/diffusers/wan_i2v_test_config.json"
@@ -249,7 +254,7 @@ def wan_i2v_pipeline_call_with_mad_validation(
     mad_validator.validate_module_mad(
         pytorch_image_latents[0].detach().cpu().numpy(), latents.detach().cpu().numpy(), "vae_encoder", "image encoding"
     )
-    pipeline.vae_encoder.qpc_session.deactivate()  # deactivate vae encoder qpc session
+    release_qpc_session(pipeline.vae_encoder)
 
     # Step 7: Setup transformer inference session
     if pipeline.transformer.qpc_session is None:
@@ -381,7 +386,7 @@ def wan_i2v_pipeline_call_with_mad_validation(
             if i == len(timesteps) - 1 or ((i + 1) > num_warmup_steps and (i + 1) % pipeline.scheduler.order == 0):
                 progress_bar.update()
 
-    pipeline.transformer.qpc_session.deactivate()  # deactivate transformer qpc session
+    release_qpc_session(pipeline.transformer)
     # Handle final conditioning for expand_timesteps mode
     if pipeline.model.config.expand_timesteps:
         latents = (1 - first_frame_mask) * condition + first_frame_mask * latents
@@ -417,7 +422,7 @@ def wan_i2v_pipeline_call_with_mad_validation(
     video = pipeline.vae_decoder.qpc_session.run(inputs)
     end_decode_time = time.perf_counter()
     vae_decoder_perf = end_decode_time - start_decode_time
-    pipeline.vae_decoder.qpc_session.deactivate()  # deactivate vae decoder qpc session
+    release_qpc_session(pipeline.vae_decoder)
 
     # VAE decoder MAD validation
     print(" Performing MAD validation for VAE decoder...")
@@ -639,6 +644,8 @@ def test_wan_i2v_pipeline(wan_i2v_pipeline):
     except Exception as e:
         print(f"\nTEST FAILED: {e}")
         raise
+    finally:
+        release_pipeline_qpc_sessions(pipeline, ["vae_encoder", "transformer", "vae_decoder"])
 
 
 if __name__ == "__main__":

--- a/tests/transformers/caching/test_prefix_caching.py
+++ b/tests/transformers/caching/test_prefix_caching.py
@@ -81,8 +81,8 @@ def prefix_caching_inference(model_name, qpc_path):
         decode_inputs["input_ids"] = next_token_id
         decode_inputs["position_ids"] += 1
 
-    assert np.all(generator._qaic_model.generated_ids[0, :gen_len2] == [int(val[0]) for val in generation_outputs])
-    assert np.all(generator._qaic_model.generated_ids[1, :gen_len2] == [int(val[1]) for val in generation_outputs])
+    assert np.all(generator._qaic_model.generated_ids[0, :gen_len2] == [int(val[0, 0]) for val in generation_outputs])
+    assert np.all(generator._qaic_model.generated_ids[1, :gen_len2] == [int(val[1, 0]) for val in generation_outputs])
 
     ##############################
     # Now rerun with cached prefix on 0th index with prompt3 and use -1 for 1st index
@@ -179,7 +179,7 @@ def prefix_caching_inference(model_name, qpc_path):
         decode_inputs["position_ids"][1][0] += 1
 
     assert np.all(
-        prompts_exec_info.generated_ids[1][:247] == [int(val[1]) for val in generation_outputs_prefill_cached][:247]
+        prompts_exec_info.generated_ids[1][:247] == [int(val[1, 0]) for val in generation_outputs_prefill_cached][:247]
     )
 
 

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -32,6 +32,7 @@ import onnx
 import onnxruntime as ort
 import pytest
 import torch
+import transformers
 from transformers import (
     AutoConfig,
     AutoModel,
@@ -42,7 +43,10 @@ from transformers import (
     AutoTokenizer,
     Qwen2Config,
 )
+from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
 
+from QEfficient.transformers.models import _layerwise
+from QEfficient.transformers.models.custom_loader import CustomLoader, WeightSelectionPolicy
 from QEfficient.transformers.models.modeling_auto import (
     QEFFAutoModel,
     QEFFAutoModelForCausalLM,
@@ -50,6 +54,7 @@ from QEfficient.transformers.models.modeling_auto import (
     QEFFAutoModelForImageTextToText,
     QEFFAutoModelForSequenceClassification,
     QEFFAutoModelForSpeechSeq2Seq,
+    _resolve_layerwise_compile_export_request,
 )
 from QEfficient.transformers.quantizers.auto import replace_transformers_quantizers
 from QEfficient.utils._utils import _infer_specialization_name, to_named_specializations
@@ -1438,7 +1443,6 @@ LAYERWISE_TINY_MODEL_IDS = {
 @pytest.mark.llm_model
 def test_layerwise_window_helpers():
     """Pure-Python coverage of the windowing helpers - no model load required."""
-    from QEfficient.transformers.models import _layerwise
 
     assert _layerwise._build_layer_windows(4, 1) == [(0, 1), (1, 2), (2, 3), (3, 4)]
     assert _layerwise._build_layer_windows(5, 2) == [(0, 2), (2, 4), (4, 5)]
@@ -1449,9 +1453,55 @@ def test_layerwise_window_helpers():
 
 
 @pytest.mark.llm_model
+def test_layerwise_context_helpers_are_instance_scoped():
+
+    config = type("Config", (), {"model_type": "qwen3_moe", "num_hidden_layers": 4})()
+    context_a = _layerwise.create_layerwise_context(model_id="a", config=config, window_size=2)
+    context_b = _layerwise.create_layerwise_context(model_id="b", config=config, window_size=1)
+    module_a = torch.nn.Linear(1, 1)
+    module_b = torch.nn.Linear(1, 1)
+
+    _layerwise.attach_layerwise_context(module_a, context_a)
+    _layerwise.attach_layerwise_context(module_b, context_b)
+    context_a.set_window(0, 2)
+    context_b.set_window(2, 3)
+
+    assert _layerwise.has_layerwise_context(module_a)
+    assert _layerwise.has_layerwise_context(module_b)
+    assert _layerwise.resolve_layer_window(module_a, 4) == (0, 2)
+    assert _layerwise.resolve_layer_window(module_b, 4) == (2, 3)
+    assert not _layerwise.is_last_layer_window(module_a, 4)
+    assert not _layerwise.is_last_layer_window(module_b, 4)
+
+    context_b.set_window(3, 4)
+    assert _layerwise.is_last_layer_window(module_b, 4)
+
+
+@pytest.mark.llm_model
+def test_layerwise_compile_requires_from_pretrained_context():
+
+    module = torch.nn.Linear(1, 1)
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError, match="from_pretrained"):
+            _resolve_layerwise_compile_export_request(module, True, None)
+
+
+@pytest.mark.llm_model
+def test_layerwise_window_size_conflict_rejected():
+
+    config = type("Config", (), {"model_type": "qwen3_moe", "num_hidden_layers": 4})()
+    context = _layerwise.create_layerwise_context(model_id="dummy", config=config, window_size=2)
+    module = torch.nn.Linear(1, 1)
+    _layerwise.attach_layerwise_context(module, context)
+
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError, match="conflicts"):
+            _resolve_layerwise_compile_export_request(module, None, 1)
+
+
+@pytest.mark.llm_model
 def test_layerwise_supported_guard_rejects_unrelated_model():
     """layerwise=True must hard-fail on architectures without windowing hooks."""
-    from QEfficient.transformers.models import _layerwise
 
     config = AutoConfig.from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM")
     with pytest.raises(NotImplementedError, match="layerwise=True is only supported"):
@@ -1605,10 +1655,8 @@ def test_layerwise_matches_default_path_for_qwen3_moe():
     in a single forward (default path) must match running the same layers one
     window at a time and chaining the hidden states (layerwise path), bit for bit.
     """
-    from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
 
     import QEfficient
-    from QEfficient.transformers.models import _layerwise
 
     cfg = Qwen3MoeConfig(
         hidden_size=64,
@@ -1651,10 +1699,12 @@ def test_layerwise_matches_default_path_for_qwen3_moe():
 
     # Layerwise path: window size 1, chaining hidden states across windows.
     hidden_states = inner.embed_tokens(ids)
+    context = _layerwise.create_layerwise_context(model_id="dummy", config=cfg, window_size=1)
+    _layerwise.attach_layerwise_context(inner, context)
     try:
-        with _layerwise._layerwise_export_env():
+        with _layerwise._layerwise_export_env(context):
             for window in range(num_layers):
-                _layerwise._set_layer_windows(window, window + 1, num_layers)
+                _layerwise._set_layer_windows(window, window + 1, num_layers, context=context)
                 with torch.no_grad():
                     out = inner(
                         inputs_embeds=hidden_states,
@@ -1664,24 +1714,20 @@ def test_layerwise_matches_default_path_for_qwen3_moe():
                     )
                 hidden_states = out.last_hidden_state
     finally:
-        _layerwise._reset_layer_windows()
+        _layerwise._reset_layer_windows(context=context)
 
     assert torch.equal(default_out.last_hidden_state, hidden_states), (
         "layerwise windowed forward diverged from the default single-shot forward"
     )
 
-    # The default path must leave the mutable window state untouched.
-    from QEfficient.transformers.models.qwen3_moe.modeling_qwen3_moe import QEffQwen3MoeModel
-
-    assert QEffQwen3MoeModel._start == 0
-    assert QEffQwen3MoeModel._end == 0
+    # The default path must leave the instance context inactive after reset.
+    assert context.active is False
 
 
 @pytest.mark.llm_model
 def test_layerwise_matches_default_path_for_qwen3_5_moe():
     """Qwen3.5-MoE decoder wrapper must preserve logits with layerwise windows."""
     import QEfficient
-    from QEfficient.transformers.models import _layerwise
 
     config = AutoConfig.from_pretrained(LAYERWISE_TINY_MODEL_IDS["qwen3_5_moe"])
     config.torch_dtype = "float32"
@@ -1704,10 +1750,12 @@ def test_layerwise_matches_default_path_for_qwen3_5_moe():
 
     hidden_states = None
     total_layers = qeff_model.model.config.text_config.num_hidden_layers
+    context = _layerwise.create_layerwise_context(model_id="dummy", config=config, window_size=1)
+    _layerwise.attach_layerwise_context(wrapper, context)
     try:
-        with _layerwise._layerwise_export_env():
+        with _layerwise._layerwise_export_env(context):
             for window in range(total_layers):
-                _layerwise._set_layer_windows(window, window + 1, total_layers)
+                _layerwise._set_layer_windows(window, window + 1, total_layers, context=context)
                 call_kwargs = {
                     "position_ids": lang_inputs["position_ids"],
                     "past_key_values": lang_inputs["past_key_values"],
@@ -1725,7 +1773,7 @@ def test_layerwise_matches_default_path_for_qwen3_5_moe():
                     window_out = wrapper(**call_kwargs)
                 hidden_states = window_out[0]
     finally:
-        _layerwise._reset_layer_windows()
+        _layerwise._reset_layer_windows(context=context)
 
     assert torch.equal(default_out[0], hidden_states), "Qwen3.5-MoE layerwise logits diverged from default logits"
 
@@ -1734,7 +1782,6 @@ def test_layerwise_matches_default_path_for_qwen3_5_moe():
 def test_layerwise_matches_default_path_for_qwen3_vl_moe():
     """Qwen3-VL-MoE decoder wrapper must preserve logits with layerwise windows."""
     import QEfficient
-    from QEfficient.transformers.models import _layerwise
 
     model_id = LAYERWISE_TINY_MODEL_IDS["qwen3_vl_moe"]
     try:
@@ -1759,10 +1806,12 @@ def test_layerwise_matches_default_path_for_qwen3_vl_moe():
 
     hidden_states = None
     total_layers = qeff_model.model.config.text_config.num_hidden_layers
+    context = _layerwise.create_layerwise_context(model_id="dummy", config=config, window_size=1)
+    _layerwise.attach_layerwise_context(wrapper, context)
     try:
-        with _layerwise._layerwise_export_env():
+        with _layerwise._layerwise_export_env(context):
             for window in range(total_layers):
-                _layerwise._set_layer_windows(window, window + 1, total_layers)
+                _layerwise._set_layer_windows(window, window + 1, total_layers, context=context)
                 call_kwargs = {k: v for k, v in lang_inputs.items() if k not in ("input_ids", "inputs_embeds")}
                 if window == 0:
                     call_kwargs["input_ids"] = lang_inputs["input_ids"]
@@ -1773,7 +1822,7 @@ def test_layerwise_matches_default_path_for_qwen3_vl_moe():
                     window_out = wrapper(**call_kwargs)
                 hidden_states = window_out[0]
     finally:
-        _layerwise._reset_layer_windows()
+        _layerwise._reset_layer_windows(context=context)
 
     assert torch.equal(default_out[0], hidden_states), "Qwen3-VL-MoE layerwise logits diverged from default logits"
 
@@ -1820,7 +1869,6 @@ def test_split_layer_graph_keeps_qwen3_5_linear_states(tmp_path):
 
 @pytest.mark.llm_model
 def test_layerwise_supported_guard_accepts_qwen3_vl_moe():
-    from QEfficient.transformers.models import _layerwise
 
     try:
         config = AutoConfig.from_pretrained(LAYERWISE_TINY_MODEL_ID)
@@ -1838,7 +1886,6 @@ def test_layerwise_supported_guard_accepts_qwen3_vl_moe():
 )
 def test_layerwise_supported_guard_accepts_all_supported(arch, model_id):
     """Guard must accept each architecture in the layerwise allowlist."""
-    from QEfficient.transformers.models import _layerwise
 
     try:
         config = AutoConfig.from_pretrained(model_id)
@@ -1852,11 +1899,9 @@ def test_layerwise_supported_guard_accepts_all_supported(arch, model_id):
 def test_layerwise_off_does_not_set_env_var(tmp_path):
     """Backward compat: layerwise must be controlled purely via the API,
     never via environment variables, and must be off by default."""
-    from QEfficient.base.modeling_qeff import QEFFBaseModel
-    from QEfficient.transformers.models import _layerwise  # noqa: F401
 
     assert os.environ.get("LAYERWISE_EXPORT") is None
-    assert QEFFBaseModel._layerwise_active is False
+    assert _layerwise.is_layerwise_active() is False
 
 
 @pytest.mark.llm_model
@@ -1877,7 +1922,9 @@ def test_layerwise_vision_wrapper_keeps_only_first_text_window():
 
     assert getattr(qeff_model, "_layerwise_outer_meta", False) is True
     assert layers[0] is not None
-    assert sum(layer is not None for layer in layers) == 1
+    assert any(param.device.type != "meta" for param in layers[0].parameters())
+    for layer in layers[1:]:
+        assert all(param.device.type == "meta" for param in layer.parameters())
     assert next(vision_wrapper.model.model.visual.parameters()).device.type != "meta"
 
     default_model = QEFFAutoModelForImageTextToText.from_pretrained(
@@ -1890,28 +1937,126 @@ def test_layerwise_vision_wrapper_keeps_only_first_text_window():
 
 
 @pytest.mark.llm_model
-def test_layerwise_context_manager_toggles_class_flag():
-    """The driver's context manager must flip the class flag and restore it,
-    even on exception, with no env-var side-effects."""
-    from QEfficient.base.modeling_qeff import QEFFBaseModel
-    from QEfficient.transformers.models import _layerwise
+def test_layerwise_context_manager_toggles_active_context():
+    """The driver's context manager must preserve context state with no env-var side-effects."""
 
-    assert QEFFBaseModel._layerwise_active is False
-    with _layerwise._layerwise_export_env():
-        assert QEFFBaseModel._layerwise_active is True
+    config = type("Config", (), {"model_type": "qwen3_moe", "num_hidden_layers": 1})()
+    context = _layerwise.create_layerwise_context(model_id="dummy", config=config, window_size=1)
+    assert _layerwise.is_layerwise_active() is False
+    with _layerwise._layerwise_export_env(context):
+        context.set_window(0, 1)
+        assert _layerwise.is_layerwise_active(context) is True
         assert "LAYERWISE_EXPORT" not in os.environ
-    assert QEFFBaseModel._layerwise_active is False
+    assert _layerwise.is_layerwise_active() is False
 
     try:
-        with _layerwise._layerwise_export_env():
+        with _layerwise._layerwise_export_env(context):
+            context.set_window(0, 1)
             raise RuntimeError("boom")
     except RuntimeError:
         pass
-    assert QEFFBaseModel._layerwise_active is False
+    assert _layerwise.is_layerwise_active() is False
 
 
 @pytest.mark.llm_model
-def test_layerwise_safe_export_pass_patch_is_noop_when_inactive():
+def test_layerwise_context_manager_restores_window_state():
+
+    config = type("Config", (), {"model_type": "qwen3_moe", "num_hidden_layers": 4})()
+    context = _layerwise.create_layerwise_context(model_id="dummy", config=config, window_size=1)
+    context.set_window(2, 3)
+    context.force_full_init = True
+
+    with _layerwise._layerwise_export_env(context):
+        _layerwise._set_layer_windows(0, 1, 4, context=context)
+        assert (_layerwise.get_layerwise_start(context), _layerwise.get_layerwise_end(context)) == (0, 1)
+        assert context.force_full_init is False
+
+    assert context.active is True
+    assert (context.start, context.end) == (2, 3)
+    assert context.force_full_init is True
+
+
+@pytest.mark.llm_model
+def test_layerwise_contexts_do_not_share_window_state():
+
+    config = type("Config", (), {"model_type": "qwen3_moe", "num_hidden_layers": 4})()
+    first = _layerwise.create_layerwise_context(model_id="first", config=config, window_size=1)
+    second = _layerwise.create_layerwise_context(model_id="second", config=config, window_size=2)
+    owner = type("Owner", (), {})()
+    _layerwise.attach_layerwise_context(owner, first, recursive=False)
+
+    with _layerwise._layerwise_export_env(second):
+        _layerwise._set_layer_windows(1, 3, 4, context=second)
+        assert _layerwise.resolve_layer_window(owner, 4) == (0, 4)
+        first.set_window(0, 1)
+        assert _layerwise.resolve_layer_window(owner, 4) == (0, 1)
+        assert _layerwise.resolve_layer_window(second, 4) == (1, 3)
+
+    assert second.active is False
+    assert first.active is True
+    assert (first.start, first.end) == (0, 1)
+
+
+@pytest.mark.llm_model
+def test_custom_loader_scoped_loading_restores_transformers_hooks():
+
+    loader = CustomLoader("dummy", layer_indices=[0])
+    original_shard_fn = transformers.modeling_utils.get_checkpoint_shard_files
+    original_safe_open = transformers.modeling_utils.safe_open
+    original_load_state_dict = transformers.modeling_utils.load_state_dict
+
+    with loader.scoped_loading():
+        assert transformers.modeling_utils.get_checkpoint_shard_files is not original_shard_fn
+        assert transformers.modeling_utils.safe_open is not original_safe_open
+        assert transformers.modeling_utils.load_state_dict is not original_load_state_dict
+
+    assert transformers.modeling_utils.get_checkpoint_shard_files is original_shard_fn
+    assert transformers.modeling_utils.safe_open is original_safe_open
+    assert transformers.modeling_utils.load_state_dict is original_load_state_dict
+
+
+@pytest.mark.llm_model
+def test_custom_loader_weight_policy_filters_layer_keys():
+
+    policy = WeightSelectionPolicy.from_layer_indices([1])
+
+    assert policy.include_key("model.layers.1.self_attn.q_proj.weight")
+    assert policy.include_key("model.language_model.layers.1.mlp.gate.weight")
+    assert not policy.include_key("model.layers.0.self_attn.q_proj.weight")
+    assert not policy.include_key("model.language_model.layers.2.mlp.gate.weight")
+    assert policy.include_key("model.embed_tokens.weight")
+
+
+@pytest.mark.llm_model
+def test_custom_loader_meta_apis_clear_weights_from_ram():
+
+    cfg = Qwen3MoeConfig(
+        hidden_size=16,
+        intermediate_size=32,
+        moe_intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        num_experts=2,
+        num_experts_per_tok=1,
+        vocab_size=32,
+        max_position_embeddings=32,
+        decoder_sparse_step=1,
+        norm_topk_prob=True,
+    )
+
+    meta_model = CustomLoader.build_meta_model(Qwen3MoeForCausalLM, "dummy", config=cfg, torch_dtype=torch.float32)
+    assert all(param.device.type == "meta" for param in meta_model.parameters())
+
+    real_model = Qwen3MoeForCausalLM(cfg)
+    assert any(param.device.type != "meta" for param in real_model.parameters())
+    CustomLoader.to_meta(real_model)
+    assert all(param.device.type == "meta" for param in real_model.parameters())
+
+
+@pytest.mark.llm_model
+def test_layerwise_safe_export_pass_patch_is_noop_when_disabled():
     from torch import _C
 
     from QEfficient.utils.torch_patches import layerwise_safe_onnx_export_patches
@@ -1919,7 +2064,7 @@ def test_layerwise_safe_export_pass_patch_is_noop_when_inactive():
     original_constant_prop = _C._jit_pass_constant_propagation
     original_constant_fold = _C._jit_pass_onnx_constant_fold
 
-    with layerwise_safe_onnx_export_patches():
+    with layerwise_safe_onnx_export_patches(enabled=False):
         assert _C._jit_pass_constant_propagation is original_constant_prop
         assert _C._jit_pass_onnx_constant_fold is original_constant_fold
 
@@ -1928,30 +2073,24 @@ def test_layerwise_safe_export_pass_patch_is_noop_when_inactive():
 
 
 @pytest.mark.llm_model
-def test_layerwise_safe_export_pass_patch_toggles_only_inside_layerwise_context():
+def test_layerwise_safe_export_pass_patch_toggles_only_when_enabled():
     from torch import _C
 
-    from QEfficient.transformers.models import _layerwise
     from QEfficient.utils.torch_patches import layerwise_safe_onnx_export_patches
 
     original_cse = _C._jit_pass_cse
     original_constant_fold = _C._jit_pass_onnx_constant_fold
     original_canonicalize = _C._jit_pass_canonicalize
 
-    with _layerwise._layerwise_export_env():
-        with layerwise_safe_onnx_export_patches():
-            assert _C._jit_pass_cse is not original_cse
-            assert _C._jit_pass_onnx_constant_fold is not original_constant_fold
-            assert _C._jit_pass_canonicalize is not original_canonicalize
-            assert _C._jit_pass_cse(None) is False
-            params = {"weight": object()}
-            assert _C._jit_pass_onnx_constant_fold(None, params, 17) is params
-            sentinel_graph = object()
-            assert _C._jit_pass_canonicalize(sentinel_graph) is sentinel_graph
-
-        assert _C._jit_pass_cse is original_cse
-        assert _C._jit_pass_onnx_constant_fold is original_constant_fold
-        assert _C._jit_pass_canonicalize is original_canonicalize
+    with layerwise_safe_onnx_export_patches(enabled=True):
+        assert _C._jit_pass_cse is not original_cse
+        assert _C._jit_pass_onnx_constant_fold is not original_constant_fold
+        assert _C._jit_pass_canonicalize is not original_canonicalize
+        assert _C._jit_pass_cse(None) is False
+        params = {"weight": object()}
+        assert _C._jit_pass_onnx_constant_fold(None, params, 17) is params
+        sentinel_graph = object()
+        assert _C._jit_pass_canonicalize(sentinel_graph) is sentinel_graph
 
     assert _C._jit_pass_cse is original_cse
     assert _C._jit_pass_onnx_constant_fold is original_constant_fold
@@ -1961,7 +2100,6 @@ def test_layerwise_safe_export_pass_patch_toggles_only_inside_layerwise_context(
 @pytest.mark.llm_model
 def test_layerwise_uses_probe_model_for_cached_export(monkeypatch, tmp_path):
     """A cached merged ONNX must avoid rebuilding per-window models."""
-    from QEfficient.transformers.models import _layerwise
 
     class DummyConfig:
         model_type = "qwen3_moe"
@@ -1985,7 +2123,6 @@ def test_layerwise_uses_probe_model_for_cached_export(monkeypatch, tmp_path):
         factory_called = True
         raise AssertionError("factory must not run when merged ONNX is cached")
 
-    monkeypatch.setattr(_layerwise, "_install_window_patches_for", lambda model_type: None)
     result = _layerwise.run_layerwise(
         model_id="dummy",
         config=DummyConfig(),
@@ -2001,7 +2138,6 @@ def test_layerwise_uses_probe_model_for_cached_export(monkeypatch, tmp_path):
 
 @pytest.mark.llm_model
 def test_layerwise_cache_miss_exports_all_windows(monkeypatch, tmp_path):
-    from QEfficient.transformers.models import _layerwise
 
     class DummyConfig:
         model_type = "qwen3_moe"
@@ -2016,20 +2152,18 @@ def test_layerwise_cache_miss_exports_all_windows(monkeypatch, tmp_path):
 
     class WindowModel:
         def __init__(self):
-            self.model = object()
+            self.model = torch.nn.Module()
             self.model_name = "Qwen3MoeModel"
 
         def compile(self, **kwargs):
-            start = _layerwise._LAYERWISE_STATE["text_start"]
-            end = _layerwise._LAYERWISE_STATE["text_end"]
+            start = _layerwise.get_layerwise_start(self.model)
+            end = _layerwise.get_layerwise_end(self.model)
             exported_windows.append((start, end))
             shard = tmp_path / "onnx_layerwise_tmp" / f"layer_{start}_{end}" / f"model_layer_tmp_{start}_{end}.onnx"
             shard.parent.mkdir(parents=True, exist_ok=True)
             shard.touch()
             return str(shard)
 
-    monkeypatch.setattr(_layerwise, "_install_window_patches_for", lambda model_type: None)
-    monkeypatch.setattr(_layerwise, "_null_outside_window_layers", lambda *args, **kwargs: None)
     monkeypatch.setattr(_layerwise, "_slim_for_window_export", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         _layerwise,
@@ -2058,7 +2192,6 @@ def test_layerwise_cache_miss_exports_all_windows(monkeypatch, tmp_path):
 
 @pytest.mark.llm_model
 def test_layerwise_cleanup_removes_intermediate_dirs(tmp_path):
-    from QEfficient.transformers.models import _layerwise
 
     final_data = tmp_path / "final_data"
     onnx_tmp = tmp_path / "onnx_layerwise_tmp"
@@ -2075,7 +2208,6 @@ def test_layerwise_cleanup_removes_intermediate_dirs(tmp_path):
 
 @pytest.mark.llm_model
 def test_layerwise_cached_merged_prefers_root_layout(tmp_path):
-    from QEfficient.transformers.models import _layerwise
 
     root_merged = tmp_path / "merged_0-48.onnx"
     legacy_merged = tmp_path / "final_data" / "merged_0-48.onnx"
@@ -2144,7 +2276,6 @@ def test_layerwise_merge_renames_decoder_function_variants_without_collisions():
 
 @pytest.mark.llm_model
 def test_layerwise_materializes_root_onnx_for_final_compile(monkeypatch, tmp_path):
-    from QEfficient.transformers.models import _layerwise
 
     class DummyConfig:
         model_type = "qwen3_vl_moe"
@@ -2171,8 +2302,6 @@ def test_layerwise_materializes_root_onnx_for_final_compile(monkeypatch, tmp_pat
     cached_path.touch()
     probe = ProbeModel(cached_path)
 
-    monkeypatch.setattr(_layerwise, "_install_window_patches_for", lambda model_type: None)
-
     result = _layerwise.run_layerwise(
         model_id="dummy",
         config=DummyConfig(),
@@ -2189,7 +2318,6 @@ def test_layerwise_materializes_root_onnx_for_final_compile(monkeypatch, tmp_pat
 
 @pytest.mark.llm_model
 def test_layerwise_cache_hit_under_final_data_is_canonicalized(monkeypatch, tmp_path):
-    from QEfficient.transformers.models import _layerwise
 
     class DummyConfig:
         model_type = "qwen3_vl_moe"
@@ -2216,7 +2344,6 @@ def test_layerwise_cache_hit_under_final_data_is_canonicalized(monkeypatch, tmp_
     cached_path.touch()
     probe = ProbeModel(cached_path)
 
-    monkeypatch.setattr(_layerwise, "_install_window_patches_for", lambda model_type: None)
     cleaned = []
     monkeypatch.setattr(
         _layerwise,
@@ -2304,7 +2431,6 @@ def test_runtime_aliases_internal_retained_state_outputs():
 
 @pytest.mark.llm_model
 def test_layerwise_compile_hydrates_outer_qpc_paths(monkeypatch, tmp_path):
-    from QEfficient.transformers.models import _layerwise
     from QEfficient.transformers.models.modeling_auto import _QEffAutoModelForImageTextToTextDualQPC
 
     qpc_path = tmp_path / "qpc"
@@ -2325,6 +2451,63 @@ def test_layerwise_compile_hydrates_outer_qpc_paths(monkeypatch, tmp_path):
 
 
 @pytest.mark.llm_model
+def test_layerwise_final_compile_suspends_context(monkeypatch, tmp_path):
+
+    class DummyConfig:
+        model_type = "qwen3_moe"
+        num_hidden_layers = 1
+
+    class DummyInner(torch.nn.Module):
+        pass
+
+    class WindowModel:
+        def __init__(self):
+            self.model = DummyInner()
+            self.model_name = "Qwen3MoeModel"
+            self.compile_calls = []
+
+        def compile(self, **kwargs):
+            self.compile_calls.append(kwargs)
+            if kwargs.pop("_layerwise_cache_probe", False):
+                return None
+            if "onnx_path" in kwargs:
+                assert not _layerwise.has_layerwise_context(self.model)
+                return "final-qpc"
+            start = _layerwise.get_layerwise_start(self.model)
+            end = _layerwise.get_layerwise_end(self.model)
+            shard = tmp_path / "onnx_layerwise_tmp" / f"layer_{start}_{end}" / f"model_layer_tmp_{start}_{end}.onnx"
+            shard.parent.mkdir(parents=True, exist_ok=True)
+            shard.touch()
+            return str(shard)
+
+    built_models = []
+
+    def _factory(*args, **kwargs):
+        model = WindowModel()
+        built_models.append(model)
+        return model
+
+    monkeypatch.setattr(_layerwise, "_slim_for_window_export", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        _layerwise,
+        "_stitch_layerwise_if_available",
+        lambda export_root, total_layers=None: str(export_root / "merged.onnx"),
+    )
+
+    result = _layerwise.run_layerwise(
+        model_id="dummy",
+        config=DummyConfig(),
+        qeff_factory=_factory,
+        compile_kwargs={},
+        window_size=1,
+        final_compile=True,
+    )
+
+    assert result == "final-qpc"
+    assert built_models[-1].compile_calls[-1]["onnx_path"].endswith("merged.onnx")
+
+
+@pytest.mark.llm_model
 def test_layerwise_compile_rejects_unsupported_model():
     """End-to-end smoke: invoking layerwise=True on llama bubbles the guard error."""
     try:
@@ -2336,7 +2519,6 @@ def test_layerwise_compile_rejects_unsupported_model():
     # CausalLM does not expose a layerwise= kwarg today; only DualQPC VLM does.
     # So this test guards via the helper directly to make the contract explicit
     # for future surface expansion.
-    from QEfficient.transformers.models import _layerwise
 
     with pytest.raises(NotImplementedError):
         _layerwise.assert_layerwise_supported(qeff_model.model.config)
@@ -2694,10 +2876,8 @@ def _capture_layerwise_export_names(qeff_model, *, window, total_layers, export_
 
     The spy raises to abort before the heavy ONNX transforms/disk writes — we only
     care about the buffer names the export was invoked with. Window state is always
-    restored in ``finally`` so the class-level flags never leak into other tests.
+    restored in ``finally`` so context state never leaks into other tests.
     """
-    from QEfficient.base.modeling_qeff import QEFFBaseModel
-    from QEfficient.transformers.models import _layerwise
 
     captured = {}
 
@@ -2711,28 +2891,32 @@ def _capture_layerwise_export_names(qeff_model, *, window, total_layers, export_
 
     orig_export = torch.onnx.export
     torch.onnx.export = _spy
+    context = _layerwise.create_layerwise_context(
+        model_id="dummy",
+        config=qeff_model.model.config,
+        window_size=1,
+    )
+    _layerwise.attach_layerwise_context(qeff_model.model, context)
     try:
-        with _layerwise._layerwise_export_env():
-            _layerwise._set_layer_windows(window, window + 1, total_layers)
-            QEFFBaseModel._start = window
-            QEFFBaseModel._end = window + 1
-            QEFFBaseModel._total_layers = total_layers
+        with _layerwise._layerwise_export_env(context):
+            _layerwise._set_layer_windows(window, window + 1, total_layers, context=context)
             try:
-                qeff_model.export(export_dir=str(export_dir), kv_cache_prefix=kv_cache_prefix)
+                qeff_model.export(
+                    export_dir=str(export_dir),
+                    kv_cache_prefix=kv_cache_prefix,
+                    prefill_only=True,
+                    prefill_seq_len=256,
+                )
             except _StopExport:
                 pass
     finally:
         torch.onnx.export = orig_export
-        _layerwise._reset_layer_windows()
-        QEFFBaseModel._start = 0
-        QEFFBaseModel._end = 0
-        QEFFBaseModel._total_layers = None
+        _layerwise._reset_layer_windows(context=context)
     assert "output_names" in captured, "torch.onnx.export was never reached"
     return captured
 
 
 def _tiny_qwen3_moe_causal():
-    from transformers.models.qwen3_moe.modeling_qwen3_moe import Qwen3MoeConfig, Qwen3MoeForCausalLM
 
     import QEfficient
 
@@ -2804,27 +2988,27 @@ def test_layerwise_export_with_kv_cache_prefix_subfunctions(tmp_path):
     passed. This asserts the *final transformed* per-window shard on disk carries the infix on both the
     retained-state outputs and the paired input buffers — i.e. the prefix is not lost by the transforms.
     """
-    from QEfficient.base.modeling_qeff import QEFFBaseModel
-    from QEfficient.transformers.models import _layerwise
 
     qeff_model, total_layers = _tiny_qwen3_moe_causal()
     export_dir = tmp_path / "subfn_prefixed"
+    context = _layerwise.create_layerwise_context(
+        model_id="dummy",
+        config=qeff_model.model.config,
+        window_size=1,
+    )
+    _layerwise.attach_layerwise_context(qeff_model.model, context)
     try:
-        with _layerwise._layerwise_export_env():
-            _layerwise._set_layer_windows(0, 1, total_layers)
-            QEFFBaseModel._start = 0
-            QEFFBaseModel._end = 1
-            QEFFBaseModel._total_layers = total_layers
+        with _layerwise._layerwise_export_env(context):
+            _layerwise._set_layer_windows(0, 1, total_layers, context=context)
             qeff_model.export(
                 export_dir=str(export_dir),
                 kv_cache_prefix="vllmKvCache",
                 use_onnx_subfunctions=True,
+                prefill_only=True,
+                prefill_seq_len=256,
             )
     finally:
-        _layerwise._reset_layer_windows()
-        QEFFBaseModel._start = 0
-        QEFFBaseModel._end = 0
-        QEFFBaseModel._total_layers = None
+        _layerwise._reset_layer_windows(context=context)
 
     # export_dir gets a hash suffix appended by export_wrapper; find the per-window shard under it.
     shards = list(tmp_path.glob("subfn_prefixed*/onnx_layerwise_tmp/layer_0_1/*_layer_tmp_0_1.onnx"))


### PR DESCRIPTION
- Moves layerwise state from global/class-level flags into per-instance LayerwiseContext, preventing stale state from leaking
    across models or exports.
- Adds CustomLoader to selectively load only the active layer window while keeping Hugging Face’s normal checkpoint loading
    flow.
- Updates CausalLM and ImageTextToText wrappers so layerwise mode is configured at from_pretrained(..., layerwise=True, layerwise_window_size=...); export() / compile() layerwise flags are now deprecated.
- Refreshes Qwen3 MoE, Qwen3.5 MoE, and Qwen3 VL MoE layerwise hooks to resolve windows/cache indices from the attached context
    instead of shared class attributes.
- Improves layerwise export/compile behavior with merged ONNX cache reuse, intermediate cleanup, final compile context
    suspension, and safer ONNX export patch gating.
- Expands quickcheck coverage for context scoping, window validation, selective loader filtering/meta APIs, export patch
    toggling, cache reuse, and final compile behavior.

---------