### PR TITLE
Fix for gemma3 issue (#1101)

### DIFF
--- a/QEfficient/transformers/models/gemma3/modeling_gemma3.py
+++ b/QEfficient/transformers/models/gemma3/modeling_gemma3.py
@@ -299,21 +299,11 @@ class QEffGemma3DecoderLayer(Gemma3DecoderLayer):
     ) -> tuple[torch.FloatTensor, Optional[tuple[torch.FloatTensor, torch.FloatTensor]]]:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
-        # past_seen_tokens = past_key_value.get_seq_length() if past_key_value is not None else 0
-        # Only create QEff-specific attention mask when using a QEff cache (has sliding_window_len).
-        # For standard DynamicCache (e.g. during model.generate()), use the passed-in attention_mask.
-        if past_key_value is not None and hasattr(past_key_value, "sliding_window_len"):
-            if self.self_attn.is_sliding:
-                attention_mask = _create_causal_mask(
-                    position_ids=position_ids,
-                    target_length=past_key_value.sliding_window_len,
-                    sliding_window=past_key_value.sliding_window_len,
-                )
-            else:
-                attention_mask = _create_causal_mask(
-                    position_ids=position_ids,
-                    target_length=past_key_value.key_cache[self.config._sliding_window_pattern - 1].shape[-2],
-                )
+        # `attention_mask` is built once at the model level in ``QEffGemma3TextModel.forward``
+        # and passed in keyed by layer_type (sliding_attention / full_attention).
+        # Building it here would emit a ``torch.arange`` inside the decoder-layer subfunction
+        # during ONNX subfunction export, which the AIC compiler rejects because the ``Range``
+        # ``limit`` input becomes a function parameter rather than a constant.
 
         hidden_states, self_attn_weights = self.self_attn(
             hidden_states=hidden_states,
@@ -429,7 +419,8 @@ class QEffGemma3TextModel(Gemma3TextModel):
 
         # Build per-layer-type causal masks using _create_causal_mask for the model.generate() path
         # (DynamicCache from model.generate(), or None on first prefill).
-        # For QEffSlidingWindowCache the masks are created per-layer inside QEffGemma3DecoderLayer.
+        # For QEffSlidingWindowCache the masks are built here at the model level (keyed by layer_type)
+        # so that no torch.arange is emitted inside a decoder-layer subfunction during ONNX export.
         if not isinstance(past_key_values, QEffSlidingWindowCache):
             sliding_window = self.config.sliding_window
             past_seen = past_key_values.get_seq_length() if past_key_values is not None else 0
@@ -446,7 +437,23 @@ class QEffGemma3TextModel(Gemma3TextModel):
                 ),
             }
         else:
-            _causal_mask_mapping = None
+            # QEffSlidingWindowCache path (ONNX export / on-device runtime).
+            # Replicate the per-layer-type mask logic that previously lived inside
+            # QEffGemma3DecoderLayer.forward, but build it once here so that the
+            # torch.arange inside _create_causal_mask stays outside any subfunction.
+            sliding_window_len = past_key_values.sliding_window_len
+            full_ctx_len = past_key_values.key_cache[self.config._sliding_window_pattern - 1].shape[-2]
+            _causal_mask_mapping = {
+                "sliding_attention": _create_causal_mask(
+                    position_ids=position_ids,
+                    target_length=sliding_window_len,
+                    sliding_window=sliding_window_len,
+                ),
+                "full_attention": _create_causal_mask(
+                    position_ids=position_ids,
+                    target_length=full_ctx_len,
+                ),
+            }
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/examples/image_text_to_text/models/gemma_vision/gemma3/gemma3_example.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma3/gemma3_example.py
@@ -89,6 +89,7 @@ else:
         aic_enable_depth_first=True,
         mos=1,
         node_precision_info=npi_file_full_path,
+        split_model_io=True,
     )
 
     ### IMAGE + TEXT ###

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -579,6 +579,51 @@ def test_causal_subfunction_export_smoke(tmp_path):
 
 
 @pytest.mark.llm_model
+def test_gemma3_vlm_export_parity_with_and_without_subfunctions(tmp_path):
+    """Gemma3 VLM export keeps retained-state/output signatures stable across subfunction toggles.
+
+    This guards the Gemma3 cache-bridging export patch on the supported VLM path:
+    the historical working non-subfunction export remains the reference, and
+    enabling subfunctions must preserve the exported graph interface.
+    """
+    qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
+        VLM_TEXT_RUNTIME_MODEL_ID,
+        trust_remote_code=True,
+        kv_offload=True,
+    )
+
+    with_subfunctions_path = _exported_onnx_path(
+        qeff_model.export(
+            tmp_path / "gemma3-vlm-with-subfunctions",
+            use_onnx_subfunctions=True,
+            offload_pt_weights=False,
+        )
+    )
+    without_subfunctions_path = _exported_onnx_path(
+        qeff_model.export(
+            tmp_path / "gemma3-vlm-without-subfunctions",
+            use_onnx_subfunctions=False,
+            offload_pt_weights=False,
+        )
+    )
+
+    with_model = onnx.load(with_subfunctions_path, load_external_data=False)
+    without_model = onnx.load(without_subfunctions_path, load_external_data=False)
+
+    # Ensure the subfunction export path really emits decoder-block subfunctions
+    # for the Gemma3 language decoder, not just a graph with matching IO names.
+    with_subfunction_names = _decoder_block_subfunction_names(with_model, qeff_model.lang_model)
+    without_subfunction_names = _decoder_block_subfunction_names(without_model, qeff_model.lang_model)
+    assert with_subfunction_names, "Expected Gemma3 decoder-layer subfunctions with use_onnx_subfunctions=True"
+    assert not without_subfunction_names, (
+        "Did not expect Gemma3 decoder-layer subfunctions with use_onnx_subfunctions=False"
+    )
+
+    assert [value.name for value in with_model.graph.input] == [value.name for value in without_model.graph.input]
+    assert [value.name for value in with_model.graph.output] == [value.name for value in without_model.graph.output]
+
+
+@pytest.mark.llm_model
 @pytest.mark.parametrize(
     ("model_type", "config_kwargs"),
     sorted(TINY_MOE_PREFILL_SUBFUNCTION_CONFIGS.items()),


### PR DESCRIPTION
**Issue : When compiled w/ sub-function following error was thrown,** Error: [Operator-'Range_343', opset_version-17, ir_version-8] : Range: 'limit' input must be a constant tensor (found node "onnx::Range_1524").

**Fix :**
`attention_mask` is built once at the model level (see ``QEffGemma3TextModel.forward``) and passed in per layer-type. Building it here would emit a ``torch.arange`` inside the decoder-layer subfunction during ONNX subfunction export, which the AIC compiler rejects because the ``Range`` ``limit`` input becomes a function parameter rather than a constant.
In QEffGemma3TextModel.forward, the else branch for QEffSlidingWindowCache now builds the same two masks the old decoder-layer code built, but at the model level:
- "sliding_attention" → _create_causal_mask(target_length=sliding_window_len, sliding_window=sliding_window_len)
- "full_attention" → _create_causal_mask(target_length=key_cache[pattern-1].shape[-2]) The torch.arange inside _create_causal_mask now executes in the model-level forward, outside any subfunction boundary.

Also added spli-model-io flag in the example script to fix output issue.

**Testing :**

1. Was able to compile sucessfully w/ sub functions.
2. Test results w/o sub functions (legacy code), using example script, ["Here's a detailed description of the image:\n\n**Overall Impression:**\n\nThe image features a remarkably realistic-looking cat dressed in formal attire, creating a whimsical and charming scene. The cat appears to be the central focus, set within a lush garden environment.\n\n**The Cat:**\n\n* **Breed/Appearance:** The cat is a light orange tabby with white markings on its chest, face, and paws. It has large, expressive, bright blue eyes that are a striking feature.\n* **Attire:** The cat is impeccably dressed in a miniature suit. It wears a blue jacket with gold buttons, a white shirt with a brown bow tie, and a yellow vest. The suit is tailored to fit the cat's form, adding to the surreal and delightful quality of the image.\n* **Pose:** The cat is sitting upright, looking slightly upwards and to the right with a thoughtful or curious expression. Its posture is dignified and almost human-like.\n\n**Background and Setting:**\n\n* **Garden:** The cat is situated in a garden setting. There's a stone pathway leading into the background, and lush greenery surrounds the cat.\n* **Flowers:** White flowers are prominently featured in the foreground, adding a touch of freshness and vibrancy to the scene.\n* **Building:** In the background, a quaint, thatched-roof cottage is partially visible, suggesting a rural or countryside location.\n* **Lighting:** The lighting appears to be soft and natural, with a slightly diffused quality. This enhances the realism and creates a pleasant atmosphere.\n\n**Overall Style and Tone:**\n\n* **Realism:** The image is rendered with a high degree of realism, making the cat and its surroundings appear almost tangible.\n* **Whimsical:** Despite the realism, the concept of a cat dressed in a suit is inherently whimsical and playful.\n* **Charming:** The overall tone is charming and inviting, evoking a sense of wonder and delight.\n\nIn essence, the image is a beautifully crafted and imaginative portrayal of a cat in a human-like role, set within a picturesque garden environment."]
Average Prefill time a.k.a TTFT is= 1.59 sec         Decode is= 3.89 token/sec        
Total is= 3.88 token/sec        
Total (E2E) inference time is= 515.3 sec

3. W/ subfunctions we would need a separate NPI file.

---------