### PR TITLE
Add MDP strategy guidance

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -960,9 +960,9 @@ class QEFFBaseModel(ABC):
             # Disaggregated (pipeline-parallel) MDP — delegate to focused helper.
             if not use_onnx_subfunctions and mdp_strategy is MdpStrategy.ONNX:
                 logger.warning(
-                    "mdp_strategy='onnx' enumerates every ONNX node (~19 MB JSON) and can compile "
-                    "extremely slowly for large models. Prefer mdp_strategy='intersection' with "
-                    "mdp_compiler_dump_path for a compact Glow-IR-aligned partition config."
+                    "mdp_strategy='onnx' enumerates all ONNX nodes, leading to slow compilation on large models. "
+                    "Prefer mdp_strategy='intersection' with mdp_compiler_dump_path for a compact, "
+                    "Glow-IR\u2013aligned partition config."
                 )
             num_cores = compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES)
             num_layers = getattr(self, "num_layers", None)

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -958,6 +958,12 @@ class QEFFBaseModel(ABC):
             mdp_ts_json = load_json(str(mdp_ts_json_path))
         elif mdp_num_partitions > 1:
             # Disaggregated (pipeline-parallel) MDP — delegate to focused helper.
+            if not use_onnx_subfunctions and mdp_strategy is MdpStrategy.ONNX:
+                logger.warning(
+                    "mdp_strategy='onnx' enumerates every ONNX node (~19 MB JSON) and can compile "
+                    "extremely slowly for large models. Prefer mdp_strategy='intersection' with "
+                    "mdp_compiler_dump_path for a compact Glow-IR-aligned partition config."
+                )
             num_cores = compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES)
             num_layers = getattr(self, "num_layers", None)
             if getattr(self, "model", None) and getattr(self.model, "language_model", None) and not num_layers:

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -962,7 +962,7 @@ class QEFFBaseModel(ABC):
                 logger.warning(
                     "mdp_strategy='onnx' enumerates all ONNX nodes, leading to slow compilation on large models. "
                     "Prefer mdp_strategy='intersection' with mdp_compiler_dump_path for a compact, "
-                    "Glow-IR\u2013aligned partition config."
+                    "Glow-IR-aligned partition config."
                 )
             num_cores = compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES)
             num_layers = getattr(self, "num_layers", None)

--- a/docs/source/features_enablement.md
+++ b/docs/source/features_enablement.md
@@ -86,3 +86,89 @@ dlm.compile()
 ```
 
 The `qaic_config` dictionary is fed during the instantiation of the model because slight changes to the ONNX graph are required. Once complete, the user can specify `num_speculative_tokens` to define the actual number of speculations that the TLM will take as input during the decode phase. As for the DLM, no new changes are required at the ONNX or compile level.
+
+---
+
+(id-mdp-multi-device-partitioning)=
+## Multi-Device Partitioning (MDP)
+
+MDP splits a model graph across multiple devices at compile time. A partition
+config is a JSON file listing the graph nodes assigned to each device.
+**Compilation time scales with the number of nodes in that config** — keeping
+the node list compact is critical for acceptable compile times.
+
+### MDP compile flows
+
+| Flow | Recommended? | Notes |
+|------|:---:|-------|
+| Final compile — QEff MDP with `mdp_strategy="onnx"` | ✅ Yes | Standard path; uses ONNX subfunction names as node keys. |
+| Compiler dump-only pass (`mdp_dump_partition_config`) | ✅ Yes (Step 1 only) | Produces a JSON used as input to intersection; no QPC emitted. Do **not** pass `mdp_num_partitions` here. |
+| Final intersection compile (`mdp_strategy="intersection"`) | ✅ Yes (no-subfunction models) | Trims QEff node list to compiler-known nodes before final compile. Preferred for no-subfunction flows. |
+| No-subfunction compile without intersection | ⚠️ Not recommended | Compiler MDP dump can have one entry per low-level op, making the node list enormous and compilation **extremely slow**. |
+| Passing `mdp_num_partitions` during the dump-only pass | ❌ Do not use | `mdp_num_partitions` triggers disaggregated MDP generation; omit it during the dump pass to get a plain compiler dump. |
+
+### MDP compile options reference
+
+| Option | Purpose | When to set | Warnings / Notes |
+|--------|---------|-------------|-----------------|
+| `num_devices` | Number of devices to compile for (tensor-slice MDP). | Always set to the number of target devices. | Controls `mdp_ts_num_devices` internally. |
+| `mdp_num_partitions` | Number of pipeline-parallel partitions (disaggregated MDP). | Set only during the final compile (Step 2), not the dump pass. | When `> 1`, triggers full node-list generation from the ONNX graph. |
+| `mdp_strategy` | Selects MDP node-list generation strategy: `"onnx"` or `"intersection"`. | Set to `"intersection"` when using a compiler dump for a no-subfunction model. | `"intersection"` requires `mdp_compiler_dump_path` to also be set. |
+| `mdp_compiler_dump_path` | Path to the compiler MDP dump produced in Step 1. | Set during the intersection compile (Step 2). | Required when `mdp_strategy="intersection"`. The compiler dump is **not** the desired final partitioning; it is used only to identify valid node names. |
+| `mdp_dump_partition_config` | Compiler option telling `qaic-compile` to write its own MDP layout to this path instead of producing a QPC. | Set only during the dump-only pass (Step 1). | Passed as a `**compiler_options` kwarg. Omit `mdp_num_partitions` when using this. |
+| `use_onnx_subfunctions` | Export the ONNX model with subgraph subfunctions, reducing node count. | Set `True` when ONNX subfunctions are acceptable for the model. | Without subfunctions the compiler dump grows very large; the intersection flow is then strongly recommended. |
+
+### Two-pass flow for no-subfunction models
+
+When a model is exported without ONNX subfunctions, the compiler MDP dump
+contains one entry per low-level operation rather than per subgraph. Passing
+that full node list directly to the compiler makes compilation **extremely slow**.
+
+Use this two-pass flow instead:
+
+1. **Dump pass** — generate the compiler MDP dump (no QPC produced).
+2. **Intersection compile** — QEff intersects its own MDP config with the
+   compiler dump, trimming it to only nodes the compiler recognises, then
+   performs the final compile.
+
+#### Step 1 — Generate the compiler MDP dump
+
+Pass `mdp_dump_partition_config` and **omit** `mdp_num_partitions`. The
+compiler writes its partition layout to the file; no QPC is produced. The
+resulting file is used only as input to intersection — it does not represent
+the desired final partitioning.
+
+```python
+from QEfficient import QEFFAutoModelForImageTextToText
+
+model = QEFFAutoModelForImageTextToText.from_pretrained("Qwen/Qwen3-VL-7B-Instruct")
+model.export()  # export without subfunctions
+
+# Dump pass: compiler writes its MDP layout; no QPC is produced.
+model.compile(
+    num_cores=16,
+    num_devices=4,
+    mdp_dump_partition_config="/path/to/compiler_mdp_dump.json",
+)
+```
+
+#### Step 2 — Intersection compile
+
+Set `mdp_num_partitions`, point `mdp_compiler_dump_path` at the dump from
+Step 1, and set `mdp_strategy="intersection"`. QEff generates its own MDP
+config, intersects it with the compiler dump, and performs the final compile.
+
+```python
+from QEfficient import QEFFAutoModelForImageTextToText
+
+model = QEFFAutoModelForImageTextToText.from_pretrained("Qwen/Qwen3-VL-7B-Instruct")
+
+# Intersection compile: QEff MDP intersected with the compiler dump.
+qpc_path = model.compile(
+    num_cores=16,
+    num_devices=4,
+    mdp_num_partitions=4,
+    mdp_compiler_dump_path="/path/to/compiler_mdp_dump.json",
+    mdp_strategy="intersection",
+)
+```

--- a/docs/source/features_enablement.md
+++ b/docs/source/features_enablement.md
@@ -138,37 +138,16 @@ compiler writes its partition layout to the file; no QPC is produced. The
 resulting file is used only as input to intersection — it does not represent
 the desired final partitioning.
 
-```python
-from QEfficient import QEFFAutoModelForImageTextToText
-
-model = QEFFAutoModelForImageTextToText.from_pretrained("Qwen/Qwen3-VL-7B-Instruct")
-model.export()  # export without subfunctions
-
-# Dump pass: compiler writes its MDP layout; no QPC is produced.
-model.compile(
-    num_cores=16,
-    num_devices=4,
-    mdp_dump_partition_config="/path/to/compiler_mdp_dump.json",
-)
-```
-
 #### Step 2 — Intersection compile
 
 Set `mdp_num_partitions`, point `mdp_compiler_dump_path` at the dump from
 Step 1, and set `mdp_strategy="intersection"`. QEff generates its own MDP
 config, intersects it with the compiler dump, and performs the final compile.
 
-```python
-from QEfficient import QEFFAutoModelForImageTextToText
+#### Complete working example
 
-model = QEFFAutoModelForImageTextToText.from_pretrained("Qwen/Qwen3-VL-7B-Instruct")
+A self-contained script demonstrating both the `mdp_strategy="onnx"` direct
+compile and the two-pass `mdp_strategy="intersection"` flow (including the
+dump-pass required to generate `mdp_compiler_dump_path`) is available here:
 
-# Intersection compile: QEff MDP intersected with the compiler dump.
-qpc_path = model.compile(
-    num_cores=16,
-    num_devices=4,
-    mdp_num_partitions=4,
-    mdp_compiler_dump_path="/path/to/compiler_mdp_dump.json",
-    mdp_strategy="intersection",
-)
-```
+[`examples/disagg_serving/qwen3_vl_mdp_compile.py`](../../examples/disagg_serving/qwen3_vl_mdp_compile.py)

--- a/docs/source/features_enablement.md
+++ b/docs/source/features_enablement.md
@@ -111,7 +111,7 @@ the node list compact is critical for acceptable compile times.
 
 | Option | Purpose | When to set | Warnings / Notes |
 |--------|---------|-------------|-----------------|
-| `num_devices` | Number of devices to compile for (tensor-slice MDP). | Always set to the number of target devices. | Controls `mdp_ts_num_devices` internally. |
+| `num_devices` | Number of devices to compile for | Always set to the number of target devices. | Controls overall number of devices |
 | `mdp_num_partitions` | Number of pipeline-parallel partitions (disaggregated MDP). | Set only during the final compile (Step 2), not the dump pass. | When `> 1`, triggers full node-list generation from the ONNX graph. |
 | `mdp_strategy` | Selects MDP node-list generation strategy: `"onnx"` or `"intersection"`. | Set to `"intersection"` when using a compiler dump for a no-subfunction model. | `"intersection"` requires `mdp_compiler_dump_path` to also be set. |
 | `mdp_compiler_dump_path` | Path to the compiler MDP dump produced in Step 1. | Set during the intersection compile (Step 2). | Required when `mdp_strategy="intersection"`. The compiler dump is **not** the desired final partitioning; it is used only to identify valid node names. |

--- a/examples/disagg_serving/qwen3_vl_mdp_compile.py
+++ b/examples/disagg_serving/qwen3_vl_mdp_compile.py
@@ -71,7 +71,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--mdp_strategy",
         choices=["onnx", "intersection", "both"],
-        default="intersection",
+        default="onnx",
         help=(
             "MDP compile strategy to run. "
             "'onnx': single compile pass using ONNX-derived partition config. "

--- a/examples/disagg_serving/qwen3_vl_mdp_compile.py
+++ b/examples/disagg_serving/qwen3_vl_mdp_compile.py
@@ -75,12 +75,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--mos", type=int, default=1, help="Memory-over-subscription factor.")
 
     parser.add_argument(
-        "--mdp_ts_num_devices",
+        "--num_devices",
         type=int,
         default=4,
         help=(
             "Total AIC-100 devices used across all pipeline stages. "
-            "Each stage receives mdp_ts_num_devices // mdp_num_partitions devices."
+            "Each stage receives num_devices // mdp_num_partitions devices."
         ),
     )
     parser.add_argument(
@@ -151,7 +151,7 @@ def main() -> None:
         width=args.width,
         num_cores=args.num_cores,
         mos=args.mos,
-        mdp_ts_num_devices=args.mdp_ts_num_devices,  # total devices spread across all pipeline stages
+        num_devices=args.num_devices,  # total devices spread across all pipeline stages
         mdp_num_partitions=args.mdp_num_partitions,  # number of pipeline-parallel stages (partitions)
         mdp_strategy=args.mdp_strategy,  # "onnx" (default) or "intersection" (needs compiler dump)
         mdp_compiler_dump_path=args.mdp_compiler_dump_path,  # required only for intersection strategy

--- a/examples/disagg_serving/qwen3_vl_mdp_compile.py
+++ b/examples/disagg_serving/qwen3_vl_mdp_compile.py
@@ -5,58 +5,22 @@
 #
 # -----------------------------------------------------------------------------
 
-"""Compile-only validation: Qwen3-VL-30B language-prefill QPC with MDP (intersection flow).
+"""Compile-only validation: Qwen3-VL language-prefill QPC with disaggregated MDP.
 
-**Purpose — compile validation only.**
-This script is intended *solely* to verify that the Qwen3-VL language-prefill
-compile succeeds with Multi-Device Partitioning (MDP) using the two-pass
-intersection strategy.  It does **not** run inference, create a
-``QAICInferenceSession``, or execute any generated QPCs.  Use it to confirm
-that the export + compile pipeline works end-to-end on your hardware
-configuration before integrating the QPC into a serving stack.
+Runs export + compile for the language-prefill component only; no inference is performed.
 
-**Two-pass intersection flow**
+MDP strategies:
+  onnx         — single pass, ONNX-derived partition config (~19 MB JSON, may compile slowly).
+  intersection — two-pass: Pass 1 dumps compiler node list, Pass 2 compiles with compact
+                 intersected config (~1-2 MB, Glow-IR-aligned; recommended for large models).
+  both         — run ONNX flow then intersection flow.
 
-The script performs two sequential compile calls against the same loaded model:
-
-Pass 1 — compiler dump
-    Calls ``compile()`` *without* ``mdp_num_partitions`` (defaults to 1) but
-    with ``mdp_dump_partition_config=<json_path>``.  This instructs the QAIC
-    compiler to write the exact Glow IR node names it sees into the JSON file
-    while still producing a (single-partition) QPC that is discarded.
-
-Pass 2 — intersection compile
-    Calls ``compile()`` with ``mdp_num_partitions``, ``mdp_strategy="intersection"``,
-    and ``mdp_compiler_dump_path=<json_path>`` pointing at the file written in
-    Pass 1.  The MDP generator intersects the ONNX-derived node superset with
-    the compiler dump, producing a compact partition config (~1-2 MB vs ~19 MB
-    for the ONNX-only strategy) that maps cleanly to hardware Glow IR names.
-
-.. warning::
-    MDP with ``use_onnx_subfunctions=False`` and **without** the intersection
-    strategy enumerates every node in the ONNX graph (~19 MB JSON).  Many of
-    those names do not match the Glow IR names the compiler actually uses,
-    which can produce a very large node list that makes compilation extremely
-    slow or causes it to stall.  This script always uses the two-pass
-    intersection flow (Pass 1 dump + Pass 2 intersection compile) to avoid
-    that problem.
-
-Running this script will **load / download the HF model weights** and invoke
-the QEfficient export + compile pipeline.  Make sure:
-
-  * A valid QEfficient installation and Qualcomm Cloud AI 100 toolchain are
-    available in the active environment.
-  * ``HF_HUB_CACHE`` points to a location with sufficient disk space if you
-    want to redirect where the model is downloaded.
-  * ``QEFF_HOME`` controls where QPC artifacts are written (optional; defaults
-    to ``~/.cache/qeff``).
-
-No secrets or absolute environment-specific paths are embedded here.
+Requires a valid QEfficient installation and Qualcomm Cloud AI 100 toolchain.
+Set HF_HUB_CACHE to control model download location; QEFF_HOME for QPC artifact output.
 """
 
 import argparse
 import sys
-import warnings
 
 import torch
 from transformers import AutoConfig
@@ -70,9 +34,9 @@ def parse_args() -> argparse.Namespace:
     """Return parsed command-line arguments."""
     parser = argparse.ArgumentParser(
         description=(
-            "Two-pass intersection compile for Qwen3-VL-30B language-prefill QPC with MDP. "
-            "Pass 1 dumps the compiler MDP node list; Pass 2 compiles the final QPC using "
-            "intersection to produce a compact partition config."
+            "Compile Qwen3-VL-30B language-prefill QPC with MDP. "
+            "Supports 'onnx' (direct compile), 'intersection' (two-pass compact compile), "
+            "or 'both' flows.  No inference is performed."
         ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
@@ -104,40 +68,85 @@ def parse_args() -> argparse.Namespace:
         "--mdp_num_partitions",
         type=int,
         default=2,
-        help="Number of pipeline-parallel partitions for disaggregated prefill (used in Pass 2).",
+        help="Number of pipeline-parallel partitions for disaggregated prefill.",
+    )
+    parser.add_argument(
+        "--mdp_strategy",
+        choices=["onnx", "intersection", "both"],
+        default="intersection",
+        help=(
+            "MDP compile strategy to run. "
+            "'onnx': single compile pass using ONNX-derived partition config. "
+            "'intersection': two-pass compile — Pass 1 dumps compiler node list, "
+            "Pass 2 compiles with the intersected compact config (recommended). "
+            "'both': run ONNX strategy then intersection strategy."
+        ),
     )
     parser.add_argument(
         "--mdp_compiler_dump_path",
         default=_DEFAULT_COMPILER_DUMP_JSON,
         help=(
-            "Path for the compiler MDP dump JSON file. "
+            "Path for the compiler MDP dump JSON file used by the intersection strategy. "
             "Pass 1 writes this file; Pass 2 reads it. "
-            "Relative paths are resolved from the current working directory."
+            "Relative paths are resolved from the current working directory. "
+            "Ignored when --mdp_strategy onnx is selected."
         ),
     )
 
     return parser.parse_args()
 
 
+def _run_onnx_flow(qeff_model, shared_kwargs: dict, mdp_num_partitions: int) -> str:
+    """Run a single-pass ONNX-strategy MDP compile. Returns QPC path."""
+    print(f"[ONNX] Compiling with mdp_num_partitions={mdp_num_partitions}, mdp_strategy='onnx'")
+    qpc_path = qeff_model.compile(
+        **shared_kwargs,
+        mdp_num_partitions=mdp_num_partitions,
+        mdp_strategy="onnx",
+    )
+    print(f"[ONNX] QPC path: {qpc_path}")
+    return qpc_path
+
+
+def _run_intersection_flow(
+    qeff_model,
+    shared_kwargs: dict,
+    mdp_num_partitions: int,
+    mdp_compiler_dump_path: str,
+) -> str:
+    """Run two-pass intersection MDP compile.
+
+    Pass 1 dumps the compiler node list; Pass 2 compiles with the compact intersected config.
+    Returns QPC path from Pass 2.
+    """
+    print(f"[Intersection Pass 1] Dumping compiler MDP partition config to: {mdp_compiler_dump_path}")
+    qeff_model.compile(
+        **shared_kwargs,
+        mdp_dump_partition_config=mdp_compiler_dump_path,
+    )
+    print(f"[Intersection Pass 1] Compiler dump written to: {mdp_compiler_dump_path}")
+
+    print(
+        f"[Intersection Pass 2] Compiling final QPC with mdp_num_partitions={mdp_num_partitions}, "
+        f"mdp_strategy='intersection', mdp_compiler_dump_path={mdp_compiler_dump_path}"
+    )
+    qpc_path = qeff_model.compile(
+        **shared_kwargs,
+        mdp_num_partitions=mdp_num_partitions,
+        mdp_strategy="intersection",
+        mdp_compiler_dump_path=mdp_compiler_dump_path,
+    )
+    print(f"[Intersection Pass 2] QPC path: {qpc_path}")
+    return qpc_path
+
+
 def main() -> None:
-    """Run two-pass intersection compile for Qwen3-VL language-prefill.
+    """Run ONNX and/or intersection MDP compile for Qwen3-VL language-prefill.
 
-    Pass 1: dump compiler MDP node list to a JSON file (no mdp_num_partitions).
-    Pass 2: compile final QPC with mdp_num_partitions, mdp_strategy='intersection',
-            and mdp_compiler_dump_path pointing at the Pass-1 dump.
-
-    No ``QAICInferenceSession`` is created and no runtime inference is performed.
+    Strategy is governed by --mdp_strategy: 'onnx', 'intersection', or 'both'.
+    No QAICInferenceSession is created; no runtime inference is performed.
     """
     args = parse_args()
-
-    warnings.warn(
-        "MDP with use_onnx_subfunctions=False and without the intersection strategy can "
-        "produce a very large node list (~19 MB JSON) of ONNX names that do not match "
-        "Glow IR, making compilation extremely slow. This script uses the two-pass "
-        "intersection flow (use_onnx_subfunctions=False + Pass 1 dump + Pass 2 intersection) "
-        "to avoid that problem.",
-        stacklevel=1,
-    )
 
     config = AutoConfig.from_pretrained(args.model_id)
     config.dtype = "float16"
@@ -151,7 +160,7 @@ def main() -> None:
         layerwise=False,
     )
 
-    _shared_compile_kwargs = dict(
+    shared_compile_kwargs = dict(
         batch_size=args.batch_size,
         prefill_seq_len=args.prefill_seq_len,
         ctx_len=args.ctx_len,
@@ -172,24 +181,19 @@ def main() -> None:
         layerwise=False,
     )
 
-    print(f"[Pass 1] Dumping compiler MDP partition config to: {args.mdp_compiler_dump_path}")
-    qeff_model.compile(
-        **_shared_compile_kwargs,
-        mdp_dump_partition_config=args.mdp_compiler_dump_path,
-    )
-    print(f"[Pass 1] Compiler dump written to: {args.mdp_compiler_dump_path}")
+    run_onnx = args.mdp_strategy in ("onnx", "both")
+    run_intersection = args.mdp_strategy in ("intersection", "both")
 
-    print(
-        f"[Pass 2] Compiling final QPC with mdp_num_partitions={args.mdp_num_partitions}, "
-        f"mdp_strategy='intersection', mdp_compiler_dump_path={args.mdp_compiler_dump_path}"
-    )
-    prefill_qpc_path = qeff_model.compile(
-        **_shared_compile_kwargs,
-        mdp_num_partitions=args.mdp_num_partitions,
-        mdp_strategy="intersection",
-        mdp_compiler_dump_path=args.mdp_compiler_dump_path,
-    )
-    print(f"[Pass 2] Prefill QPC path: {prefill_qpc_path}")
+    if run_onnx:
+        _run_onnx_flow(qeff_model, shared_compile_kwargs, args.mdp_num_partitions)
+
+    if run_intersection:
+        _run_intersection_flow(
+            qeff_model,
+            shared_compile_kwargs,
+            args.mdp_num_partitions,
+            args.mdp_compiler_dump_path,
+        )
 
 
 if __name__ == "__main__":

--- a/examples/disagg_serving/qwen3_vl_mdp_compile.py
+++ b/examples/disagg_serving/qwen3_vl_mdp_compile.py
@@ -23,9 +23,6 @@ import argparse
 import logging
 import sys
 
-import torch
-from transformers import AutoConfig
-
 from QEfficient import QEFFAutoModelForImageTextToText
 
 _DEFAULT_COMPILER_DUMP_JSON = "qwen3_vl_mdp_compiler_dump.json"
@@ -68,7 +65,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--mdp_num_partitions",
         type=int,
-        default=2,
+        default=4,
         help="Number of pipeline-parallel partitions for disaggregated prefill.",
     )
     parser.add_argument(
@@ -157,15 +154,10 @@ def main() -> None:
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 
-    config = AutoConfig.from_pretrained(args.model_id)
-    config.dtype = "float16"
-
     qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
         args.model_id,
         attn_implementation="eager",
         kv_offload=True,
-        config=config,
-        dtype=torch.float16,
         layerwise=False,
     )
 

--- a/examples/disagg_serving/qwen3_vl_mdp_compile.py
+++ b/examples/disagg_serving/qwen3_vl_mdp_compile.py
@@ -20,6 +20,7 @@ Set HF_HUB_CACHE to control model download location; QEFF_HOME for QPC artifact 
 """
 
 import argparse
+import logging
 import sys
 
 import torch
@@ -92,6 +93,12 @@ def parse_args() -> argparse.Namespace:
             "Ignored when --mdp_strategy onnx is selected."
         ),
     )
+    parser.add_argument(
+        "--use_onnx_subfunctions",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Enable ONNX subfunction splitting during compile (--no-use_onnx_subfunctions to disable).",
+    )
 
     return parser.parse_args()
 
@@ -148,6 +155,8 @@ def main() -> None:
     """
     args = parse_args()
 
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
     config = AutoConfig.from_pretrained(args.model_id)
     config.dtype = "float16"
 
@@ -177,7 +186,7 @@ def main() -> None:
         prefill_only=True,
         enable_chunking=True,
         skip_vision=True,
-        use_onnx_subfunctions=False,
+        use_onnx_subfunctions=args.use_onnx_subfunctions,
         layerwise=False,
     )
 

--- a/examples/disagg_serving/qwen3_vl_mdp_compile.py
+++ b/examples/disagg_serving/qwen3_vl_mdp_compile.py
@@ -5,31 +5,41 @@
 #
 # -----------------------------------------------------------------------------
 
-"""Compile-only validation: Qwen3-VL-30B language-prefill QPC with MDP.
+"""Compile-only validation: Qwen3-VL-30B language-prefill QPC with MDP (intersection flow).
 
 **Purpose — compile validation only.**
 This script is intended *solely* to verify that the Qwen3-VL language-prefill
-compile succeeds with Multi-Device Partitioning (MDP) options.  It does **not**
-run inference, create a ``QAICInferenceSession``, or execute any generated QPCs.
-Use it to confirm that the export + compile pipeline works end-to-end on your
-hardware configuration before integrating the QPC into a serving stack.
+compile succeeds with Multi-Device Partitioning (MDP) using the two-pass
+intersection strategy.  It does **not** run inference, create a
+``QAICInferenceSession``, or execute any generated QPCs.  Use it to confirm
+that the export + compile pipeline works end-to-end on your hardware
+configuration before integrating the QPC into a serving stack.
 
-The script exports and compiles the language-prefill partition of
-Qwen/Qwen3-VL-30B-A3B-Instruct for disaggregated serving.  It uses:
+**Two-pass intersection flow**
 
-  - ``mdp_ts_num_devices``  -- total number of AIC-100 devices across all
-                               pipeline stages (default: 4).
-  - ``mdp_num_partitions``  -- number of pipeline-parallel stages the model is
-                               split into for prefill (default: 2).
-  - ``mdp_strategy``        -- MDP partition-config generation strategy:
-                               ``onnx`` (default) enumerates every ONNX node;
-                               ``intersection`` requires a prior
-                               ``qaic-compile -mdp-dump-partition-config`` run
-                               and produces a compact JSON.
-  - ``mdp_compiler_dump_path`` -- path to the compiler-dump directory produced
-                               by the prior ``intersection`` run.  Required when
-                               ``--mdp_strategy intersection`` is chosen; the
-                               argparse validator below enforces this.
+The script performs two sequential compile calls against the same loaded model:
+
+Pass 1 — compiler dump
+    Calls ``compile()`` *without* ``mdp_num_partitions`` (defaults to 1) but
+    with ``mdp_dump_partition_config=<json_path>``.  This instructs the QAIC
+    compiler to write the exact Glow IR node names it sees into the JSON file
+    while still producing a (single-partition) QPC that is discarded.
+
+Pass 2 — intersection compile
+    Calls ``compile()`` with ``mdp_num_partitions``, ``mdp_strategy="intersection"``,
+    and ``mdp_compiler_dump_path=<json_path>`` pointing at the file written in
+    Pass 1.  The MDP generator intersects the ONNX-derived node superset with
+    the compiler dump, producing a compact partition config (~1-2 MB vs ~19 MB
+    for the ONNX-only strategy) that maps cleanly to hardware Glow IR names.
+
+.. warning::
+    MDP with ``use_onnx_subfunctions=False`` and **without** the intersection
+    strategy enumerates every node in the ONNX graph (~19 MB JSON).  Many of
+    those names do not match the Glow IR names the compiler actually uses,
+    which can produce a very large node list that makes compilation extremely
+    slow or causes it to stall.  This script always uses the two-pass
+    intersection flow (Pass 1 dump + Pass 2 intersection compile) to avoid
+    that problem.
 
 Running this script will **load / download the HF model weights** and invoke
 the QEfficient export + compile pipeline.  Make sure:
@@ -46,17 +56,24 @@ No secrets or absolute environment-specific paths are embedded here.
 
 import argparse
 import sys
+import warnings
 
 import torch
 from transformers import AutoConfig
 
 from QEfficient import QEFFAutoModelForImageTextToText
 
+_DEFAULT_COMPILER_DUMP_JSON = "qwen3_vl_mdp_compiler_dump.json"
+
 
 def parse_args() -> argparse.Namespace:
     """Return parsed command-line arguments."""
     parser = argparse.ArgumentParser(
-        description="Compile Qwen3-VL-30B language-prefill QPC with MDP for disaggregated serving.",
+        description=(
+            "Two-pass intersection compile for Qwen3-VL-30B language-prefill QPC with MDP. "
+            "Pass 1 dumps the compiler MDP node list; Pass 2 compiles the final QPC using "
+            "intersection to produce a compact partition config."
+        ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
@@ -87,49 +104,40 @@ def parse_args() -> argparse.Namespace:
         "--mdp_num_partitions",
         type=int,
         default=2,
-        help="Number of pipeline-parallel partitions for disaggregated prefill.",
-    )
-    parser.add_argument(
-        "--mdp_strategy",
-        choices=["onnx", "intersection"],
-        default="onnx",
-        help=(
-            "MDP partition-config generation strategy. "
-            "'onnx' enumerates every ONNX graph node (~19 MB JSON). "
-            "'intersection' filters to exact Glow IR names and requires "
-            "--mdp_compiler_dump_path."
-        ),
+        help="Number of pipeline-parallel partitions for disaggregated prefill (used in Pass 2).",
     )
     parser.add_argument(
         "--mdp_compiler_dump_path",
-        default=None,
+        default=_DEFAULT_COMPILER_DUMP_JSON,
         help=(
-            "Path to the directory produced by a prior "
-            "'qaic-compile -mdp-dump-partition-config' run. "
-            "Required when --mdp_strategy intersection is chosen."
+            "Path for the compiler MDP dump JSON file. "
+            "Pass 1 writes this file; Pass 2 reads it. "
+            "Relative paths are resolved from the current working directory."
         ),
     )
 
-    args = parser.parse_args()
-
-    if args.mdp_strategy == "intersection" and not args.mdp_compiler_dump_path:
-        parser.error(
-            "--mdp_compiler_dump_path is required when --mdp_strategy intersection is used. "
-            "Run 'qaic-compile -mdp-dump-partition-config' first to produce the dump directory, "
-            "then pass that path with --mdp_compiler_dump_path."
-        )
-
-    return args
+    return parser.parse_args()
 
 
 def main() -> None:
-    """Load model and compile language-prefill QPC with MDP options.
+    """Run two-pass intersection compile for Qwen3-VL language-prefill.
 
-    This function validates that the prefill compile step succeeds.  It
-    intentionally stops after ``compile()`` returns and prints the QPC path.
+    Pass 1: dump compiler MDP node list to a JSON file (no mdp_num_partitions).
+    Pass 2: compile final QPC with mdp_num_partitions, mdp_strategy='intersection',
+            and mdp_compiler_dump_path pointing at the Pass-1 dump.
+
     No ``QAICInferenceSession`` is created and no runtime inference is performed.
     """
     args = parse_args()
+
+    warnings.warn(
+        "MDP with use_onnx_subfunctions=False and without the intersection strategy can "
+        "produce a very large node list (~19 MB JSON) of ONNX names that do not match "
+        "Glow IR, making compilation extremely slow. This script uses the two-pass "
+        "intersection flow (use_onnx_subfunctions=False + Pass 1 dump + Pass 2 intersection) "
+        "to avoid that problem.",
+        stacklevel=1,
+    )
 
     config = AutoConfig.from_pretrained(args.model_id)
     config.dtype = "float16"
@@ -143,7 +151,7 @@ def main() -> None:
         layerwise=False,
     )
 
-    prefill_qpc_path = qeff_model.compile(
+    _shared_compile_kwargs = dict(
         batch_size=args.batch_size,
         prefill_seq_len=args.prefill_seq_len,
         ctx_len=args.ctx_len,
@@ -151,10 +159,7 @@ def main() -> None:
         width=args.width,
         num_cores=args.num_cores,
         mos=args.mos,
-        num_devices=args.num_devices,  # total devices spread across all pipeline stages
-        mdp_num_partitions=args.mdp_num_partitions,  # number of pipeline-parallel stages (partitions)
-        mdp_strategy=args.mdp_strategy,  # "onnx" (default) or "intersection" (needs compiler dump)
-        mdp_compiler_dump_path=args.mdp_compiler_dump_path,  # required only for intersection strategy
+        num_devices=args.num_devices,
         mxfp6_matmul=True,
         mxint8_kv_cache=True,
         retain_full_kv=True,
@@ -163,11 +168,28 @@ def main() -> None:
         prefill_only=True,
         enable_chunking=True,
         skip_vision=True,
-        use_onnx_subfunctions=True,
+        use_onnx_subfunctions=False,
         layerwise=False,
     )
 
-    print(f"Prefill QPC path: {prefill_qpc_path}")
+    print(f"[Pass 1] Dumping compiler MDP partition config to: {args.mdp_compiler_dump_path}")
+    qeff_model.compile(
+        **_shared_compile_kwargs,
+        mdp_dump_partition_config=args.mdp_compiler_dump_path,
+    )
+    print(f"[Pass 1] Compiler dump written to: {args.mdp_compiler_dump_path}")
+
+    print(
+        f"[Pass 2] Compiling final QPC with mdp_num_partitions={args.mdp_num_partitions}, "
+        f"mdp_strategy='intersection', mdp_compiler_dump_path={args.mdp_compiler_dump_path}"
+    )
+    prefill_qpc_path = qeff_model.compile(
+        **_shared_compile_kwargs,
+        mdp_num_partitions=args.mdp_num_partitions,
+        mdp_strategy="intersection",
+        mdp_compiler_dump_path=args.mdp_compiler_dump_path,
+    )
+    print(f"[Pass 2] Prefill QPC path: {prefill_qpc_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add compact MDP flow and option tables.
- Link docs to the Qwen3-VL MDP example.
- Update the example to show onnx, intersection, and both flows.
- Warn in core compile when no-subfunction onnx MDP can compile slowly.

## Validation
- ruff check/format on changed Python files