### PR TITLE
Remove deprecated compile_only compiler flag

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -878,6 +878,11 @@ class QEFFBaseModel(ABC):
         layerwise_cache_probe = compiler_options.pop("_layerwise_cache_probe", False)
         moe_prefill_packed_chunk_size = compiler_options.pop("moe_prefill_packed_chunk_size", None)
 
+        for removed_option in ("compile_only", "compile-only"):
+            if removed_option in compiler_options:
+                logger.warning(f"'{removed_option}' is deprecated and is ignored; removing it from compiler options.")
+                compiler_options.pop(removed_option, None)
+
         mdp_ts_json_path = compiler_options.pop("mdp_load_partition_config", None)
         mdp_strategy = MdpStrategy(compiler_options.pop("mdp_strategy", MdpStrategy.ONNX))
         mdp_compiler_dump_path = compiler_options.pop("mdp_compiler_dump_path", None)

--- a/QEfficient/diffusers/pipelines/configs/wan_non_unified_config.json
+++ b/QEfficient/diffusers/pipelines/configs/wan_non_unified_config.json
@@ -14,7 +14,6 @@
         "mdp_ts_num_devices": 16,
         "mxfp6_matmul": true,
         "convert_to_fp16": true,
-        "compile_only": true,
         "aic_num_cores": 16,
         "mos": 1,
         "mdts_mos": 1
@@ -37,7 +36,6 @@
         "mdp_ts_num_devices": 16,
         "mxfp6_matmul": true,
         "convert_to_fp16": true,
-        "compile_only": true,
         "aic_num_cores": 16,
         "mos": 1,
         "mdts_mos": 1
@@ -60,7 +58,6 @@
         "convert_to_fp16": true,
         "aic_num_cores": 16,
         "aic-enable-depth-first": true,
-        "compile_only": true,
         "mos": 1,
         "mdts_mos": 1
       },

--- a/examples/diffusers/wan/wan_non_unified_config.json
+++ b/examples/diffusers/wan/wan_non_unified_config.json
@@ -14,7 +14,6 @@
         "mdp_ts_num_devices": 16,
         "mxfp6_matmul": true,
         "convert_to_fp16": true,
-        "compile_only": true,
         "aic_num_cores": 16,
         "mos": 1,
         "mdts_mos": 1
@@ -37,7 +36,6 @@
         "mdp_ts_num_devices": 16,
         "mxfp6_matmul": true,
         "convert_to_fp16": true,
-        "compile_only": true,
         "aic_num_cores": 16,
         "mos": 1,
         "mdts_mos": 1
@@ -60,7 +58,6 @@
         "convert_to_fp16": true,
         "aic_num_cores": 16,
         "aic-enable-depth-first": true,
-        "compile_only": true,
         "mos": 1,
         "mdts_mos": 1
       },

--- a/scripts/debug/gemma4_dense_ort_qaic_parity.py
+++ b/scripts/debug/gemma4_dense_ort_qaic_parity.py
@@ -132,7 +132,6 @@ def main():
             qeff_model._compile(
                 onnx_path=str(onnx_path),
                 compile_dir=compile_dir,
-                compile_only=True,
                 retained_state=True,
                 specializations=specializations,
                 convert_to_fp16=True,

--- a/tests/diffusers/wan_test_non_unified_config.json
+++ b/tests/diffusers/wan_test_non_unified_config.json
@@ -43,7 +43,6 @@
                                 "mdp_ts_num_devices": 1,
                                 "mxfp6_matmul": true,
                                 "convert_to_fp16": true,
-                                "compile_only":true,
                                 "aic_num_cores": 16,
                                 "mos": 1,
                                 "mdts_mos": 1
@@ -66,7 +65,6 @@
                                 "mdp_ts_num_devices": 1,
                                 "mxfp6_matmul": true,
                                 "convert_to_fp16": true,
-                                "compile_only":true,
                                 "aic_num_cores": 16,
                                 "mos": 1,
                                 "mdts_mos": 1
@@ -87,7 +85,6 @@
                 "mdp_ts_num_devices": 1,
                 "mxfp6_matmul": false,
                 "convert_to_fp16": true,
-                "compile_only": true,
                 "aic_num_cores": 16,
                 "mos": 1,
                 "mdts_mos": 1


### PR DESCRIPTION
The \`compile_only\` flag is deprecated from the compiler and no longer supported.

- Dropped \`compile_only\` from the wan diffuser configs and the gemma debug script.
- Added a deprecation shim in \`_compile()\` that warns and ignores the flag if passed via \`compiler_options\`.

**Testing:** Static validation only (ruff lint + format via pre-commit, grep sweep for remaining references). The affected pytest paths are \`on_qaic\`-marked and require QAIC hardware; not run on this CPU host.
