### PR TITLE
Make dataPathTimeoutMs configurable, default 120s

### DIFF
--- a/QEfficient/generation/cloud_infer.py
+++ b/QEfficient/generation/cloud_infer.py
@@ -67,7 +67,7 @@ class QAICInferenceSession:
         device_ids: Optional[List[int]] = None,
         activate: bool = True,
         enable_debug_logs: bool = False,
-        data_path_timeout_ms: int = 120_000,
+        data_path_timeout_ms: int = 60_000,
     ):
         """
         Initialise for QAIC inference Session

--- a/QEfficient/generation/cloud_infer.py
+++ b/QEfficient/generation/cloud_infer.py
@@ -67,6 +67,7 @@ class QAICInferenceSession:
         device_ids: Optional[List[int]] = None,
         activate: bool = True,
         enable_debug_logs: bool = False,
+        data_path_timeout_ms: int = 120_000,
     ):
         """
         Initialise for QAIC inference Session
@@ -76,6 +77,7 @@ class QAICInferenceSession:
         :device_ids: List[int]. Device Ids to be used for compilation. if devices > 1, it enables multiple card setup.
         :activate: bool. If false, activation will be disabled. Default=True.
         :enable_debug_logs: bool. If True, It will enable debug logs. Default=False.
+        :data_path_timeout_ms: int. Host wait timeout (in ms) for a data-path response from the device. Default=120000 (120s).
         """
         if not (is_qaicrt_imported and is_aicapi_imported):
             raise ImportError(
@@ -124,7 +126,7 @@ class QAICInferenceSession:
         _add_basename_binding_aliases(self.binding_index_map, self.bindings)
         # Create and load Program
         prog_properties = qaicrt.QAicProgramProperties()
-        prog_properties.dataPathTimeoutMs = 60_000
+        prog_properties.dataPathTimeoutMs = data_path_timeout_ms
         dev_id_non_mq = None
         if device_ids:
             if len(device_ids) == 1:

--- a/QEfficient/generation/cloud_infer.py
+++ b/QEfficient/generation/cloud_infer.py
@@ -77,7 +77,7 @@ class QAICInferenceSession:
         :device_ids: List[int]. Device Ids to be used for compilation. if devices > 1, it enables multiple card setup.
         :activate: bool. If false, activation will be disabled. Default=True.
         :enable_debug_logs: bool. If True, It will enable debug logs. Default=False.
-        :data_path_timeout_ms: int. Host wait timeout (in ms) for a data-path response from the device. Default=120000 (120s).
+        :data_path_timeout_ms: int. Host wait timeout (in ms) for a data-path response from the device. Default=60000 (60s).
         """
         if not (is_qaicrt_imported and is_aicapi_imported):
             raise ImportError(


### PR DESCRIPTION
On long-context, long-generation runs the 60s data-path timeout is too tight. With Llama-3.3-70B at ctx-len 32768 / generation-len 16000 using hqkv blocking, a single decode iteration can take longer than 60s, and the host aborts mid-generation across all devices with "failed to receive response from NW: Connection timed out"

The timeout was hardcoded at 60s with no way to change it short of editing the source. This exposes `data_path_timeout_ms` on `QAICInferenceSession` and bumps the default to 120s. Existing callers are unaffected since it's a keyword arg with a default, and anyone who needs more can pass a larger value per session.

Tested locally with the blocked_attention_inference example on the reported config; the run now completes instead of timing out at 60s.