### PR TITLE
Enabling model Qwen3-Embedding-0.6B and Qwen3-Embedding-8B

### DIFF
--- a/QEfficient/blocking/attention_blocking.py
+++ b/QEfficient/blocking/attention_blocking.py
@@ -81,8 +81,8 @@ def past_key_value_update(
     position_ids: Optional[torch.LongTensor] = None,
     sliding_window: Optional[int] = None,
 ):
+    cache_kwargs = {"batch_index": batch_index, "position_ids": position_ids}
     if past_key_value is not None:
-        cache_kwargs = {"batch_index": batch_index, "position_ids": position_ids}
         if sliding_window is not None:
             cache_kwargs.update(
                 {

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -469,7 +469,7 @@ class QEFFAutoModel(QEFFTransformersBase):
     """
 
     _hf_auto_class = AutoModel
-    _pytorch_transforms = [CustomOpsTransform, AwqToMatmulNbitsTransform, GPTQToMatmulNbitsTransform]
+    _pytorch_transforms = [CustomOpsTransform, KVCacheTransform, AwqToMatmulNbitsTransform, GPTQToMatmulNbitsTransform]
     # FP16Clip inlines external weights; without Split the saved protobuf exceeds 2GB for large embedders.
     _onnx_transforms = [FP16ClipTransform, SplitTensorsTransform]
 
@@ -777,7 +777,7 @@ class QEFFAutoModel(QEFFTransformersBase):
             self.qpc_session = QAICInferenceSession(str(self.qpc_path), device_ids)
             self.batch_size = self.qpc_session.bindings[0].dims[0]
 
-        # Dynamic switching to closest seq_Len based on input_ids_len
+        # Dynamic switching to closest seq_len based on input_ids length.
         input_ids_len = inputs["input_ids"].shape[1]
 
         for allowed_shape in self.qpc_session.allowed_shapes:
@@ -793,34 +793,39 @@ class QEFFAutoModel(QEFFTransformersBase):
         input_ids = np.array(
             torch.nn.functional.pad(inputs["input_ids"], (0, self.seq_len - input_ids_len), "constant", 0)
         )
-        attention_mask = np.array(
-            torch.nn.functional.pad(
-                inputs["attention_mask"], (0, self.seq_len - inputs["attention_mask"].size(1)), "constant", 0
+        session_inputs = {"input_ids": input_ids}
+        if "attention_mask" in self.qpc_session.input_names and "attention_mask" in inputs:
+            attention_mask = np.array(
+                torch.nn.functional.pad(
+                    inputs["attention_mask"], (0, self.seq_len - inputs["attention_mask"].size(1)), "constant", 0
+                )
             )
-        )
+            session_inputs["attention_mask"] = attention_mask
 
-        inputs = dict(input_ids=input_ids, attention_mask=attention_mask)
+        output_name = self.qpc_session.output_names[0]
+        output_binding = next((binding for binding in self.qpc_session.bindings if binding.name == output_name), None)
+        if output_binding is None:
+            raise RuntimeError(f"Could not find output binding '{output_name}' in QAIC session bindings.")
 
         # TODO: Remove try and catch after compiler fix
         try:
             outputs = {
-                "output": np.random.randn(*list(self.qpc_session.bindings[2].dims)).astype(
-                    TORCH_TO_NUMPY_DTYPE_MAP[dtype]
-                ),
+                output_name: np.random.randn(*list(output_binding.dims)).astype(TORCH_TO_NUMPY_DTYPE_MAP[dtype]),
             }
             self.qpc_session.set_buffers(outputs)
-            outputs = self.qpc_session.run(inputs)
+            outputs = self.qpc_session.run(session_inputs)
         except Exception:
+            feature_dim = output_binding.dims[-1] if len(output_binding.dims) > 0 else 1
             outputs = {
-                "output": np.random.randn(self.batch_size, self.seq_len, self.qpc_session.bindings[2].dims[1]).astype(
+                output_name: np.random.randn(self.batch_size, self.seq_len, feature_dim).astype(
                     TORCH_TO_NUMPY_DTYPE_MAP[dtype]
                 ),
             }
             self.qpc_session.set_buffers(outputs)
-            outputs = self.qpc_session.run(inputs)
+            outputs = self.qpc_session.run(session_inputs)
 
         if self._write_io_dir is not None:
-            write_io_files(inputs, outputs, self._write_io_dir, "output", "aic_batch_io", True, False)
+            write_io_files(session_inputs, outputs, self._write_io_dir, output_name, "aic_batch_io", True, False)
 
         return outputs
 

--- a/QEfficient/transformers/models/qwen3/modeling_qwen3.py
+++ b/QEfficient/transformers/models/qwen3/modeling_qwen3.py
@@ -161,7 +161,7 @@ class QEffQwen3Attention(Qwen3Attention):
                 layer_idx=self.layer_idx,
                 past_key_value=past_key_values,
                 blocking_config=blocking_config,
-                comp_ctx_length=comp_ctx_lengths,
+                comp_ctx_lengths=comp_ctx_lengths,
                 batch_index=batch_index,
                 position_ids=position_ids,
                 past_seen_tokens=past_seen_tokens,

--- a/tests/unit_test/models/test_modeling_auto_cpu.py
+++ b/tests/unit_test/models/test_modeling_auto_cpu.py
@@ -96,6 +96,23 @@ def make_tiny_bert():
     return BertModel(cfg).eval(), cfg
 
 
+def make_tiny_qwen3():
+    from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+    from transformers.models.qwen3.modeling_qwen3 import Qwen3Model
+
+    cfg = Qwen3Config(
+        hidden_size=64,
+        intermediate_size=128,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        vocab_size=VOCAB_SIZE,
+        max_position_embeddings=CTX_LEN,
+    )
+    cfg.is_decoder = None
+    return Qwen3Model(cfg).eval(), cfg
+
+
 def make_tiny_bert_seq_cls():
     cfg = BertConfig(
         num_hidden_layers=2,
@@ -669,6 +686,64 @@ class TestQEFFAutoModel:
         decoder_model.config.is_decoder = True
         qeff_decoder = QEFFAutoModel(decoder_model)
         assert qeff_decoder.model.base_model.config.use_cache is True
+
+    def test_init_applies_qwen3_kv_cache_transform(self):
+        """Qwen3 models loaded via AutoModel path are transformed to QEff wrappers."""
+        from QEfficient.transformers.models.qwen3.modeling_qwen3 import QEffQwen3Model
+
+        model, cfg = make_tiny_qwen3()
+        qeff = QEFFAutoModel(model)
+        assert isinstance(qeff.model, QEffQwen3Model)
+
+    def test_qwen3_forward_without_past_cache_does_not_fail(self):
+        """Qwen3 embedding-style forwards should work without past_key_values input."""
+        model, cfg = make_tiny_qwen3()
+        qeff = QEFFAutoModel(model)
+        inputs = {
+            "input_ids": torch.zeros((1, SEQ_LEN), dtype=torch.int64),
+            "attention_mask": torch.ones((1, SEQ_LEN), dtype=torch.int64),
+        }
+        with torch.no_grad():
+            out = qeff.model(**inputs)
+        assert out.last_hidden_state.shape == (1, SEQ_LEN, cfg.hidden_size)
+
+    def test_cloud_ai_100_feature_generate_supports_single_input_qpc(self):
+        """AI100 embedding runtime supports QPCs exposing only input_ids input."""
+        model, cfg = make_tiny_bert()
+        qeff = QEFFAutoModel(model)
+        qeff._write_io_dir = None
+
+        class _Binding:
+            def __init__(self, name, dims):
+                self.name = name
+                self.dims = dims
+
+        class _FakeSession:
+            def __init__(self):
+                self.bindings = [_Binding("input_ids", [1, 16]), _Binding("output", [1, 16, 64])]
+                self.allowed_shapes = []
+                self.input_names = ["input_ids"]
+                self.output_names = ["output"]
+                self.last_inputs = None
+                self._outputs = None
+
+            def set_buffers(self, outputs):
+                self._outputs = outputs
+
+            def run(self, inputs):
+                self.last_inputs = inputs
+                return self._outputs
+
+        qeff.qpc_session = _FakeSession()
+        qeff.batch_size = 1
+        inputs = {
+            "input_ids": torch.zeros((1, SEQ_LEN), dtype=torch.int64),
+            "attention_mask": torch.ones((1, SEQ_LEN), dtype=torch.int64),
+        }
+        outputs = qeff.cloud_ai_100_feature_generate(inputs=inputs)
+        assert "output" in outputs
+        assert tuple(outputs["output"].shape) == (1, 16, 64)
+        assert set(qeff.qpc_session.last_inputs.keys()) == {"input_ids"}
 
     def test_get_model_config_returns_dict(self):
         """get_model_config returns the model's config as a dict."""


### PR DESCRIPTION
## Problem
AI100 support for `Qwen/Qwen3-Embedding-0.6B` and `Qwen/Qwen3-Embedding-8B` was failing in the `QEFFAutoModel` embedding flow.

Observed failures:
- ONNX export/runtime path stayed on HF Qwen3 modules in the embedding (`AutoModel`) path.
- No-cache path hit `UnboundLocalError` in `past_key_value_update()`.
- AI100 runtime assumed fixed QPC binding layout and always-required `attention_mask`.
- Script-level compile/inference batch mismatch caused buffer-size errors.

## Root Cause
These checkpoints are embedding variants, but their config is still Qwen3 decoder-family (`model_type=qwen3`, `architectures=Qwen3ForCausalLM`).
In this repo, embedding flow uses `QEFFAutoModel`, so decoder-family Qwen3 still needs QEff module remapping and robust AI100 I/O handling in that path.

## Fixes
1. Enabled Qwen3 remapping in `QEFFAutoModel` by adding `KVCacheTransform`.
2. Initialized `cache_kwargs` in `past_key_value_update()` for no-cache execution paths.
3. Fixed Qwen3 blocked-attention kwarg mismatch (`comp_ctx_lengths`).
4. Updated AI100 embedding runtime to:
   - resolve output binding by declared output name (no hardcoded binding index),
   - pass `attention_mask` only when the compiled QPC declares it.
5. Updated `testing_qwen.py` to compile with actual batch/seq and consume AI100 output tensor correctly.
6. Added focused unit tests for:
   - Qwen3 transform application in `QEFFAutoModel`,
   - no-cache Qwen3 forward path,
   - single-input-QPC runtime handling.

## Compatibility / Risk
- No behavior change for encoder-only embedding models; `KVCacheTransform` remains a no-op when no matching decoder modules exist.
- AI100 embedding runtime now supports both QPC signatures:
  - `input_ids + attention_mask`, and
  - `input_ids`-only.
