### PR TITLE
Added test script for qwen3 vl moe blocking modes

### DIFF
--- a/QEfficient/blocking/blocked_attention_forwards.py
+++ b/QEfficient/blocking/blocked_attention_forwards.py
@@ -29,7 +29,7 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
-def _get_kv_states(module: nn.Module, key: torch.Tensor, value: torch.Tensor, num_repeat: Optional[int]) -> Tuple[torch.Tensor, torch.Tensor]:
+def _get_kv_states(module: nn.Module, key: torch.Tensor, value: torch.Tensor, num_repeat: Optional[int] = None) -> Tuple[torch.Tensor, torch.Tensor]:
     num_kv_groups = getattr(module, "num_key_value_groups", None) if not num_repeat else num_repeat
     if num_kv_groups is None:
         return key, value

--- a/QEfficient/blocking/blocked_attention_forwards.py
+++ b/QEfficient/blocking/blocked_attention_forwards.py
@@ -29,7 +29,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
-def _get_kv_states(module: nn.Module, key: torch.Tensor, value: torch.Tensor, num_repeat: Optional[int] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+def _get_kv_states(
+    module: nn.Module, key: torch.Tensor, value: torch.Tensor, num_repeat: Optional[int] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
     num_kv_groups = getattr(module, "num_key_value_groups", None) if not num_repeat else num_repeat
     if num_kv_groups is None:
         return key, value
@@ -211,6 +213,7 @@ def blocked_kv_attention_forward(
 
     return attn_output, attn_weights
 
+
 def blocked_kv_attention_forward_headpar_offline(
     module: nn.Module,
     query: torch.Tensor,
@@ -375,6 +378,7 @@ def blocked_kv_attention_forward_headpar_offline(
     )
     return attn_output.transpose(1, 2).contiguous(), None
 
+
 def blocked_qkv_attention_forward_prefill_headpar_offline(
     module: nn.Module,
     query: torch.Tensor,
@@ -422,11 +426,12 @@ def blocked_qkv_attention_forward_prefill_headpar_offline(
     for t_start in range(0, seq_len, ql_chunk):
         t_end = min(t_start + ql_chunk, seq_len)
         tc = t_end - t_start
-        pos_sub          = position_ids[:, t_start:t_end]
+        pos_sub = position_ids[:, t_start:t_end]
         current_position = pos_sub.max(dim=-1).values
 
-        r_ranges = [(r_start, min(r_start + n_rep_chunk, num_kv_groups))
-                    for r_start in range(0, num_kv_groups, n_rep_chunk)]
+        r_ranges = [
+            (r_start, min(r_start + n_rep_chunk, num_kv_groups)) for r_start in range(0, num_kv_groups, n_rep_chunk)
+        ]
 
         assert kv_block_size % split == 0, f"kv_block_size ({kv_block_size}) must be divisible by split ({split})"
         T_h_nom = kv_block_size // split
@@ -440,21 +445,31 @@ def blocked_qkv_attention_forward_prefill_headpar_offline(
         accs = []
         for r_start, r_end in r_ranges:
             rc = r_end - r_start
-            accs.append({
-                "rc":    rc,
-                "query": query_folded[:, :, r_start:r_end, t_start:t_end, :]
-                            .reshape(batch_size, num_kv_heads, rc * tc, head_dim)
-                            .repeat_interleave(split, dim=1),  # [B, num_kv_heads*split, rc*tc, head_dim]
-                "m_acc": torch.full((batch_size, num_kv_heads * split, rc * tc), float(MIN_MASKED_ATTENTION_VALUE),
-                                    device=query.device, dtype=query.dtype),
-                "s_acc": torch.zeros(batch_size, num_kv_heads * split, rc * tc, device=query.device, dtype=query.dtype),
-                "o_acc": torch.zeros(batch_size, num_kv_heads * split, rc * tc, head_dim, device=query.device, dtype=query.dtype),
-            })
+            accs.append(
+                {
+                    "rc": rc,
+                    "query": query_folded[:, :, r_start:r_end, t_start:t_end, :]
+                    .reshape(batch_size, num_kv_heads, rc * tc, head_dim)
+                    .repeat_interleave(split, dim=1),  # [B, num_kv_heads*split, rc*tc, head_dim]
+                    "m_acc": torch.full(
+                        (batch_size, num_kv_heads * split, rc * tc),
+                        float(MIN_MASKED_ATTENTION_VALUE),
+                        device=query.device,
+                        dtype=query.dtype,
+                    ),
+                    "s_acc": torch.zeros(
+                        batch_size, num_kv_heads * split, rc * tc, device=query.device, dtype=query.dtype
+                    ),
+                    "o_acc": torch.zeros(
+                        batch_size, num_kv_heads * split, rc * tc, head_dim, device=query.device, dtype=query.dtype
+                    ),
+                }
+            )
 
         for j in range(num_kv_blocks):
-            start_index  = j * kv_block_size
+            start_index = j * kv_block_size
             kv_len_block = (ctx_len - start_index) if j == num_kv_blocks - 1 else kv_block_size
-            end_index    = start_index + kv_len_block
+            end_index = start_index + kv_len_block
             split_block_len = kv_len_block // split
 
             skip_future = None
@@ -470,19 +485,24 @@ def blocked_qkv_attention_forward_prefill_headpar_offline(
             K_4d = key_5d.reshape(batch_size, num_kv_heads * split, split_block_len, head_dim)
             V_4d = value_5d.reshape(batch_size, num_kv_heads * split, split_block_len, head_dim)
 
-            off               = kv_offsets if split_block_len == T_h_nom else kv_offsets[:, :split_block_len]
+            off = kv_offsets if split_block_len == T_h_nom else kv_offsets[:, :split_block_len]
             causal_mask_block = off[None, :, None, :] > (pos_sub - start_index)[:, None, :, None]
-            skip_split        = (kv_offsets[:, 0] > (pos_sub.min() - start_index)).view(1, num_kv_heads * split)
+            skip_split = (kv_offsets[:, 0] > (pos_sub.min() - start_index)).view(1, num_kv_heads * split)
 
             for acc in accs:
                 rc = acc["rc"]
                 # causal_mask_block: [B, num_kv_heads*split, tc, split_block_len] → expand to [B, num_kv_heads*split, rc*tc, split_block_len]
-                causal_rc          = causal_mask_block.repeat(1, 1, rc, 1) if rc > 1 else causal_mask_block
+                causal_rc = causal_mask_block.repeat(1, 1, rc, 1) if rc > 1 else causal_mask_block
                 attn_weights_block = torch.matmul(acc["query"], K_4d.transpose(-1, -2)) * scaling
                 attn_weights_block = torch.where(causal_rc, masked_tensor, attn_weights_block)
                 acc["m_acc"], acc["s_acc"], acc["o_acc"] = update_running_softmax(
-                    acc["m_acc"], attn_weights_block, acc["s_acc"], acc["o_acc"], V_4d,
-                    skip_kv=True, skip_future=skip_split.unsqueeze(-1),
+                    acc["m_acc"],
+                    attn_weights_block,
+                    acc["s_acc"],
+                    acc["o_acc"],
+                    V_4d,
+                    skip_kv=True,
+                    skip_future=skip_split.unsqueeze(-1),
                 )
 
         r_chunks = []
@@ -491,10 +511,10 @@ def blocked_qkv_attention_forward_prefill_headpar_offline(
             m = acc["m_acc"].view(batch_size, num_kv_heads, split, rc * tc)
             s = acc["s_acc"].view(batch_size, num_kv_heads, split, rc * tc)
             o = acc["o_acc"].view(batch_size, num_kv_heads, split, rc * tc, head_dim)
-            split_max    = m.max(dim=2).values
+            split_max = m.max(dim=2).values
             split_weight = torch.exp(m - split_max.unsqueeze(2))
-            split_sum    = (split_weight * s).sum(dim=2)
-            split_out    = (split_weight.unsqueeze(-1) * o).sum(dim=2)
+            split_sum = (split_weight * s).sum(dim=2)
+            split_out = (split_weight.unsqueeze(-1) * o).sum(dim=2)
             r_chunks.append((split_out / split_sum.unsqueeze(-1)).view(batch_size, num_kv_heads, rc, tc, head_dim))
 
         t_chunks.append(torch.cat(r_chunks, dim=2))
@@ -502,6 +522,7 @@ def blocked_qkv_attention_forward_prefill_headpar_offline(
     output = torch.cat(t_chunks, dim=3)
     attn_output = output.reshape(batch_size, num_heads, seq_len, head_dim)
     return attn_output.transpose(1, 2).contiguous(), None
+
 
 def blocked_qkv_attention_forward_prefill_online(
     module: nn.Module,
@@ -543,29 +564,35 @@ def blocked_qkv_attention_forward_prefill_online(
     for t_start in range(0, QL, ql_chunk):
         t_end = min(t_start + ql_chunk, QL)
         tc = t_end - t_start
-        pos_sub          = position_ids[:, t_start:t_end]
+        pos_sub = position_ids[:, t_start:t_end]
         current_position = pos_sub.max(dim=-1).values
 
-        r_ranges = [(r_start, min(r_start + n_rep_chunk, n_rep_per_core))
-                    for r_start in range(0, n_rep_per_core, n_rep_chunk)]
+        r_ranges = [
+            (r_start, min(r_start + n_rep_chunk, n_rep_per_core)) for r_start in range(0, n_rep_per_core, n_rep_chunk)
+        ]
 
         accs = []
         for r_start, r_end in r_ranges:
             rc = r_end - r_start
-            accs.append({
-                "rc":    rc,
-                "Q":     q_fold[:, :, r_start:r_end, t_start:t_end, :]
-                            .reshape(B, num_cores, rc * tc, D),
-                "m_acc": torch.full((B, num_cores, rc * tc), float(MIN_MASKED_ATTENTION_VALUE),
-                                    device=query.device, dtype=query.dtype),
-                "s_acc": torch.zeros(B, num_cores, rc * tc, device=query.device, dtype=query.dtype),
-                "o_acc": torch.zeros(B, num_cores, rc * tc, D, device=query.device, dtype=query.dtype),
-            })
+            accs.append(
+                {
+                    "rc": rc,
+                    "Q": q_fold[:, :, r_start:r_end, t_start:t_end, :].reshape(B, num_cores, rc * tc, D),
+                    "m_acc": torch.full(
+                        (B, num_cores, rc * tc),
+                        float(MIN_MASKED_ATTENTION_VALUE),
+                        device=query.device,
+                        dtype=query.dtype,
+                    ),
+                    "s_acc": torch.zeros(B, num_cores, rc * tc, device=query.device, dtype=query.dtype),
+                    "o_acc": torch.zeros(B, num_cores, rc * tc, D, device=query.device, dtype=query.dtype),
+                }
+            )
 
         for j in range(num_kv_blocks):
-            start_index  = j * kv_block_size
+            start_index = j * kv_block_size
             kv_len_block = (ctx_len - start_index) if j == num_kv_blocks - 1 else kv_block_size
-            end_index    = start_index + kv_len_block
+            end_index = start_index + kv_len_block
 
             skip_future = None
             if skip_kv:
@@ -577,20 +604,30 @@ def blocked_qkv_attention_forward_prefill_online(
             v_block = past_key_value.read_only_blocked_V(start_index, end_index, layer_idx, cache_kwargs)
             k_block, v_block = _get_kv_states(module, k_block, v_block, num_repeat=kv_repeat)
 
-            k_abs  = torch.arange(start_index, end_index, device=query.device)
+            k_abs = torch.arange(start_index, end_index, device=query.device)
             causal = k_abs[None, None, None, :] > pos_sub[:, None, :, None]
 
             for acc in accs:
-                rc     = acc["rc"]
-                attn   = torch.matmul(acc["Q"], k_block.transpose(2, 3)) * scaling
-                attn_m = attn.view(B, num_cores, rc, tc, -1).masked_fill(causal.unsqueeze(2), float(MIN_MASKED_ATTENTION_VALUE)).view(B, num_cores, rc * tc, -1)
+                rc = acc["rc"]
+                attn = torch.matmul(acc["Q"], k_block.transpose(2, 3)) * scaling
+                attn_m = (
+                    attn.view(B, num_cores, rc, tc, -1)
+                    .masked_fill(causal.unsqueeze(2), float(MIN_MASKED_ATTENTION_VALUE))
+                    .view(B, num_cores, rc * tc, -1)
+                )
                 acc["m_acc"], acc["s_acc"], acc["o_acc"] = update_running_softmax(
-                    acc["m_acc"], attn_m, acc["s_acc"], acc["o_acc"], v_block, skip_kv, skip_future,
+                    acc["m_acc"],
+                    attn_m,
+                    acc["s_acc"],
+                    acc["o_acc"],
+                    v_block,
+                    skip_kv,
+                    skip_future,
                 )
 
         r_chunks = []
         for acc in accs:
-            rc  = acc["rc"]
+            rc = acc["rc"]
             out = acc["o_acc"] / acc["s_acc"].unsqueeze(-1)
             r_chunks.append(out.view(B, num_cores, rc, tc, D))
         t_chunks.append(torch.cat(r_chunks, dim=2))

--- a/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -175,17 +175,16 @@ class QEffPrefillOnlyChunkedGptOssMLP(GptOssMLP):
         #     routing_weights.transpose(0, 1).contiguous().view(local_experts, num_nsp, T).transpose(0, 1).contiguous()
         # )
 
-        expert_ids = (
-            torch.arange(local_experts, device=hidden.device, dtype=top_i.dtype).unsqueeze(0) * num_nsp
-            + torch.arange(num_nsp, device=hidden.device, dtype=top_i.dtype).unsqueeze(1)
-        )  # [N, L]
+        expert_ids = torch.arange(local_experts, device=hidden.device, dtype=top_i.dtype).unsqueeze(
+            0
+        ) * num_nsp + torch.arange(num_nsp, device=hidden.device, dtype=top_i.dtype).unsqueeze(1)  # [N, L]
 
         # Cast→ReduceSum→Greater rather than .any() because the AOT compiler
         # currently rejects ReduceMax over the rank-4 bool tensor here.
         eq = top_i.unsqueeze(0).unsqueeze(0) == expert_ids.unsqueeze(-1).unsqueeze(-1)
         local_T2E = eq.to(top_i.dtype).sum(dim=-1) > 0  # [N, L, T]
         local_rw = (eq.to(top_w.dtype) * top_w.unsqueeze(0).unsqueeze(0)).sum(dim=-1)
-        
+
         W_g = self.experts.gate_proj.view(local_experts, num_nsp, H, expert_dim).transpose(0, 1).contiguous()
         W_u = self.experts.up_proj.view(local_experts, num_nsp, H, expert_dim).transpose(0, 1).contiguous()
         W_d = self.experts.down_proj.view(local_experts, num_nsp, expert_dim, H).transpose(0, 1).contiguous()

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -405,7 +405,7 @@ class QEffQwen3VLMoeTextAttention(Qwen3VLMoeTextAttention):
         blocking_config = getattr(self, "attn_blocking_config", AttentionBlockingConfig())
         use_blocking = blocking_config is not None and (blocking_config.mode != BlockingMode.NONE)
         if use_blocking:
-            use_prefill = blocking_config.prefill_blocking_mode != None
+            use_prefill = blocking_config.prefill_blocking_mode is not None
             if not use_prefill:
                 attn_output, attn_weights = generic_blocked_attention_interface(
                     module=self,

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -406,7 +406,7 @@ class QEffQwen3VLMoeTextAttention(Qwen3VLMoeTextAttention):
         use_blocking = blocking_config is not None and (blocking_config.mode != BlockingMode.NONE)
         if use_blocking:
             use_prefill = blocking_config.prefill_blocking_mode != None
-            if use_prefill:
+            if not use_prefill:
                 attn_output, attn_weights = generic_blocked_attention_interface(
                     module=self,
                     query=query_states,
@@ -426,8 +426,8 @@ class QEffQwen3VLMoeTextAttention(Qwen3VLMoeTextAttention):
                 attn_output, attn_weights = prefill_blocked_attention_interface(
                     module=self,
                     query=query_states,
-                    key=key_states,
-                    value=value_states,
+                    k_cache=key_states,
+                    v_cache=value_states,
                     attention_mask=attention_mask,
                     scaling=self.scaling,
                     layer_idx=self.layer_idx,

--- a/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe_blocking_headpar_example.py
+++ b/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe_blocking_headpar_example.py
@@ -1,0 +1,405 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+"""Qwen3-VL-MoE blocked attention example with head-parallel support.
+
+Tests three blocking configurations for the Qwen3-VL-MoE text (language
+decoder) path, comparing AIC output against a vanilla HuggingFace PyTorch
+reference. A dummy 1-layer model (random weights, reduced config) is used
+for fast execution.
+
+Blocking modes (selected via --blocking-mode):
+
+  decode          HQKV blocking with kv_blocking_headpar_split=0 (auto-set
+                  to num_cores). Single prefill+decode QPC, uses the
+                  high-level generate() API.
+
+  prefill_par     Separate prefill QPC (prefill_blocking_mode="qkv") plus
+                  a decode QPC (HQKV). Manual chunked-prefill + decode loop
+                  via QAICInferenceSession.
+
+  prefill_online  Same structure as prefill_par but uses
+                  prefill_blocking_mode="online".
+
+  all             Run all three modes back-to-back against the same PyTorch
+                  reference.
+"""
+
+import argparse
+import copy
+import time
+
+import numpy as np
+import torch
+from transformers import AutoConfig, AutoModelForImageTextToText, AutoProcessor
+
+from QEfficient import QEFFAutoModelForImageTextToText
+from QEfficient.generation.cloud_infer import QAICInferenceSession
+
+MODEL_ID = "Qwen/Qwen3-VL-30B-A3B-Instruct"
+
+# ── Compile / inference defaults ──────────────────────────────────────────────
+PREFILL_SEQ_LEN = 256
+CTX_LEN = 8192
+GEN_LEN = 2048
+DEFAULT_NUM_CORES = 16
+DEFAULT_NUM_DEVICES = 4
+NUM_KV_BLOCKS = 2
+NUM_Q_BLOCKS = 2
+HEAD_BLOCK_SIZE = 8
+PREFILL_BLOCK_CHUNKS = 2
+
+PROMPT = "Tell me about yourself."
+
+
+# ── Config builders ────────────────────────────────────────────────────────────
+
+
+def _decode_qaic_config() -> dict:
+    return {
+        "blocking_mode": "hqkv",
+        "num_kv_blocks": NUM_KV_BLOCKS,
+        "num_q_blocks": NUM_Q_BLOCKS,
+        "head_block_size": HEAD_BLOCK_SIZE,
+        "kv_blocking_headpar_split": 0,  # 0 → resolved to num_cores at compile time
+    }
+
+
+def _prefill_qaic_config(prefill_mode: str) -> dict:
+    cfg = _decode_qaic_config()
+    cfg["prefill_block_chunks"] = PREFILL_BLOCK_CHUNKS
+    cfg["prefill_blocking_mode"] = prefill_mode
+    cfg["ctx_len"] = CTX_LEN
+    return cfg
+
+
+# ── Dummy model builder ────────────────────────────────────────────────────────
+
+
+def build_dummy_config() -> AutoConfig:
+    """Shrink the Qwen3-VL-MoE config to 1 text layer for fast testing."""
+    config = AutoConfig.from_pretrained(MODEL_ID, trust_remote_code=True)
+    config.vision_config.depth = 9
+    config.text_config.num_hidden_layers = 1
+    config.vision_config.deepstack_visual_indexes = [8]
+    return config
+
+
+def build_hf_model(config: AutoConfig):
+    torch.manual_seed(42)
+    model_hf = AutoModelForImageTextToText.from_config(
+        config,
+        attn_implementation="eager",
+        trust_remote_code=True,
+    )
+    if getattr(model_hf.config, "torch_dtype", None) in (torch.bfloat16, torch.float16):
+        model_hf = model_hf.to(torch.float32)
+    model_hf.eval()
+    return model_hf
+
+
+# ── Shared compile kwargs ─────────────────────────────────────────────────────
+
+
+def _base_compile_kwargs(num_cores: int, num_devices: int) -> dict:
+    return dict(
+        batch_size=1,
+        ctx_len=CTX_LEN,
+        num_cores=num_cores,
+        num_devices=num_devices,
+        mxfp6_matmul=False,
+        mxint8_kv_cache=True,
+        retain_full_kv=True,
+        split_model_io=True,  # required for disagg KV transfer via VLLM
+        user_tiled=True,
+        skip_vision=True,
+        use_onnx_subfunctions=True,
+        layerwise=False,
+    )
+
+
+# ── Input helpers ─────────────────────────────────────────────────────────────
+
+
+def build_processor_inputs(processor, prompt: str):
+    messages = [[{"role": "user", "content": [{"type": "text", "text": prompt}]}]]
+    return processor.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_dict=True,
+        return_tensors="pt",
+    )
+
+
+# ── PyTorch reference ─────────────────────────────────────────────────────────
+
+
+@torch.no_grad()
+def run_pytorch_reference(model_hf, raw_inputs, gen_len: int, tokenizer=None) -> np.ndarray:
+    output = model_hf.generate(**raw_inputs, max_new_tokens=gen_len, do_sample=False)
+    generated = output[0, raw_inputs["input_ids"].shape[1] :]
+    text = tokenizer.decode(generated, skip_special_tokens=True) if tokenizer is not None else str(generated.tolist())
+    print(f"  [pytorch] {text}")
+    return generated.numpy()
+
+
+# ── Config 1: decode (single QPC, high-level generate()) ──────────────────────
+
+
+def run_decode_config(
+    model_hf, config, processor, raw_inputs, gen_len: int, num_cores: int, num_devices: int
+) -> np.ndarray:
+    print("\n=== Config: decode (HQKV, kv_blocking_headpar_split=0) ===")
+
+    qeff_model = QEFFAutoModelForImageTextToText(
+        copy.deepcopy(model_hf),
+        kv_offload=True,
+        config=config,
+    )
+
+    ckwargs = _base_compile_kwargs(num_cores, num_devices)
+    ckwargs["qaic_config"] = _decode_qaic_config()
+    ckwargs["prefill_seq_len"] = PREFILL_SEQ_LEN
+    ckwargs["offload_pt_weights"] = False
+    print("  Exporting + compiling...")
+    qpc_paths = qeff_model.compile(**ckwargs)
+    print(f"  QPC path: {qpc_paths}")
+
+    qeff_inputs = qeff_model.model.prepare_inputs_for_generation(
+        inputs=copy.deepcopy(raw_inputs),
+        prefill_seq_len=PREFILL_SEQ_LEN,
+        batch_size=1,
+    )
+
+    print(f"  Running {gen_len} tokens on AIC...")
+    t0 = time.time()
+    output = qeff_model.generate(inputs=qeff_inputs, generation_len=gen_len)
+    elapsed = time.time() - t0
+
+    aic_tokens = output.generated_ids[0, : gen_len + 1]
+    text = processor.tokenizer.decode(aic_tokens, skip_special_tokens=True)
+    print(f"  [aic/decode] {text} ({elapsed:.2f}s)")
+    return aic_tokens
+
+
+# ── Configs 2 & 3: prefill_par / prefill_online (two QPCs) ───────────────────
+
+
+def run_prefill_config(
+    model_hf,
+    config,
+    processor,
+    raw_inputs,
+    gen_len: int,
+    prefill_mode: str,
+    num_cores: int,
+    num_devices: int,
+) -> np.ndarray:
+    label = f"prefill_{prefill_mode}"
+    num_layers = config.text_config.num_hidden_layers
+    print(f"\n=== Config: {label} (HQKV decode + {prefill_mode} prefill) ===")
+
+    ckwargs = _base_compile_kwargs(num_cores, num_devices)
+
+    # ── Compile decode model (prefill_seq_len=1) ──────────────────────────────
+    print("  Compiling decode model (prefill_seq_len=1)...")
+    decode_model = QEFFAutoModelForImageTextToText(
+        copy.deepcopy(model_hf),
+        kv_offload=True,
+        config=config,
+    )
+    decode_qpc_paths = decode_model.compile(
+        prefill_seq_len=1,
+        qaic_config=_decode_qaic_config(),
+        offload_pt_weights=False,
+        **ckwargs,
+    )
+    decode_qpc = decode_qpc_paths.get("lang_decode_qpc_path")
+    print(f"  Decode QPC: {decode_qpc}")
+
+    # ── Compile prefill model ─────────────────────────────────────────────────
+    print(f"  Compiling prefill model (prefill_blocking_mode={prefill_mode})...")
+    prefill_model = QEFFAutoModelForImageTextToText(
+        copy.deepcopy(model_hf),
+        kv_offload=True,
+        config=config,
+    )
+    prefill_qpc_paths = prefill_model.compile(
+        prefill_seq_len=PREFILL_SEQ_LEN,
+        prefill_only=True,
+        enable_chunking=True,
+        qaic_config=_prefill_qaic_config(prefill_mode),
+        offload_pt_weights=True,
+        **ckwargs,
+    )
+    prefill_qpc = prefill_qpc_paths.get("lang_prefill_qpc_path")
+    print(f"  Prefill QPC: {prefill_qpc}")
+
+    # ── Prepare padded inputs ─────────────────────────────────────────────────
+    qeff_inputs = decode_model.model.prepare_inputs_for_generation(
+        inputs=copy.deepcopy(raw_inputs),
+        prefill_seq_len=PREFILL_SEQ_LEN,
+        batch_size=1,
+    )
+    for k, v in qeff_inputs.items():
+        qeff_inputs[k] = np.array(v)
+
+    input_ids = qeff_inputs["input_ids"]
+    position_ids = qeff_inputs["position_ids"]
+    seq_len = input_ids.shape[1]
+    num_chunks = -(seq_len // -PREFILL_SEQ_LEN)
+    padded_len = num_chunks * PREFILL_SEQ_LEN
+
+    if padded_len > seq_len:
+        pad = padded_len - seq_len
+        input_ids = np.pad(input_ids, ((0, 0), (0, pad)), constant_values=0)
+        # position_ids shape is [4, batch, seq_len]; pad the last dim
+        position_ids = np.pad(position_ids, [(0, 0)] * (position_ids.ndim - 1) + [(0, pad)], constant_values=-1)
+
+    # ── Run chunked prefill ───────────────────────────────────────────────────
+    prefill_session = QAICInferenceSession(prefill_qpc)
+    decode_session = QAICInferenceSession(decode_qpc)
+
+    chunk_inputs = {"image_idx": np.array([[0]])}
+    prefill_out = None
+    t0 = time.time()
+    for i in range(num_chunks):
+        chunk_inputs["input_ids"] = input_ids[:, i * PREFILL_SEQ_LEN : (i + 1) * PREFILL_SEQ_LEN]
+        chunk_inputs["position_ids"] = position_ids[..., i * PREFILL_SEQ_LEN : (i + 1) * PREFILL_SEQ_LEN]
+        prefill_out = prefill_session.run(chunk_inputs)
+        for layer in range(num_layers):
+            chunk_inputs[f"past_key.{layer}"] = prefill_out[f"past_key.{layer}_RetainedState"]
+            chunk_inputs[f"past_value.{layer}"] = prefill_out[f"past_value.{layer}_RetainedState"]
+        chunk_inputs["image_idx"] = prefill_out["image_idx_output"]
+    t_prefill = time.time() - t0
+    print(f"  Prefill done: {num_chunks} chunk(s) in {t_prefill:.3f}s")
+
+    # # ── Build decode seed inputs from last prefill output ─────────────────────
+    # # position_ids max over last dim for the decode start position
+    # decode_pos = np.max(position_ids, axis=-1, keepdims=True) + 1  # [..., 1]
+    # decode_inputs = {
+    #     "input_ids": np.argmax(prefill_out["logits"]).reshape(1, 1),
+    #     "position_ids": decode_pos,
+    #     "image_idx": prefill_out["image_idx_output"],
+    # }
+    # for layer in range(num_layers):
+    #     decode_inputs[f"past_key.{layer}"] = prefill_out[f"past_key.{layer}_RetainedState"]
+    #     decode_inputs[f"past_value.{layer}"] = prefill_out[f"past_value.{layer}_RetainedState"]
+
+    # # ── Decode loop ───────────────────────────────────────────────────────────
+    # all_tokens = [decode_inputs["input_ids"].flatten()]
+    # t0 = time.time()
+    # for _ in range(gen_len - 1):
+    #     out = decode_session.run(decode_inputs)
+    #     next_tok = np.argmax(out["logits"], axis=-1).reshape(1, 1)
+    #     all_tokens.append(next_tok.flatten())
+    #     decode_inputs["input_ids"] = next_tok
+    #     decode_inputs["position_ids"] = decode_inputs["position_ids"] + 1
+    #     decode_inputs["image_idx"] = out["image_idx_output"]
+    #     for layer in range(num_layers):
+    #         decode_inputs[f"past_key.{layer}"] = out[f"past_key.{layer}_RetainedState"]
+    #         decode_inputs[f"past_value.{layer}"] = out[f"past_value.{layer}_RetainedState"]
+    # t_decode = time.time() - t0
+    # print(f"  Decode {gen_len} tokens in {t_decode:.2f}s ({gen_len / t_decode:.1f} tok/s)")
+
+    # aic_tokens = np.concatenate(all_tokens)
+    # text = processor.tokenizer.decode(aic_tokens, skip_special_tokens=True)
+    # print(f"  [aic/{label}] {text}")
+    # return aic_tokens
+
+
+# ── Comparison helper ─────────────────────────────────────────────────────────
+
+
+def compare_tokens(pt_tokens: np.ndarray, aic_tokens: np.ndarray, label: str):
+    n = min(len(pt_tokens), len(aic_tokens))
+    match = np.array_equal(pt_tokens[:n], aic_tokens[:n])
+    status = "PASS" if match else "FAIL"
+    print(f"\n[{status}] {label}: PyTorch vs AIC token match ({n} tokens)")
+    if not match:
+        mismatches = np.where(pt_tokens[:n] != aic_tokens[:n])[0]
+        print(
+            f"  First mismatch at position {mismatches[0]}: "
+            f"PyTorch={pt_tokens[mismatches[0]]} AIC={aic_tokens[mismatches[0]]}"
+        )
+    return match
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Qwen3-VL-MoE blocking attention example")
+    parser.add_argument(
+        "--blocking-mode",
+        choices=["decode", "prefill_par", "prefill_online", "all"],
+        default="all",
+        help="Blocking configuration to test (default: all)",
+    )
+    parser.add_argument("--gen-len", type=int, default=GEN_LEN, help="Number of tokens to generate")
+    parser.add_argument("--num-cores", type=int, default=DEFAULT_NUM_CORES, help="Number of AIC cores")
+    parser.add_argument("--num-devices", type=int, default=DEFAULT_NUM_DEVICES, help="Number of AIC devices")
+    parser.add_argument("--prompt", type=str, default=PROMPT, help="Text prompt for inference")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    num_cores = args.num_cores
+    num_devices = args.num_devices
+
+    modes_to_run = ["decode", "prefill_par", "prefill_online"] if args.blocking_mode == "all" else [args.blocking_mode]
+
+    print(f"\nModel ID : {MODEL_ID}")
+    print(f"Modes    : {modes_to_run}")
+    print(f"Gen len  : {args.gen_len}")
+    print(f"Devices  : {num_devices} x {num_cores} cores\n")
+
+    # ── Build shared dummy model + processor ──────────────────────────────────
+    print("Building dummy 1-layer model (from_config, random weights)...")
+    config = build_dummy_config()
+    model_hf = build_hf_model(config)
+    processor = AutoProcessor.from_pretrained(MODEL_ID, trust_remote_code=True)
+
+    raw_inputs = build_processor_inputs(processor, args.prompt)
+
+    # # ── PyTorch reference ─────────────────────────────────────────────────────
+    # print("\n--- PyTorch reference (vanilla HF model) ---")
+    # pt_tokens = run_pytorch_reference(model_hf, raw_inputs, args.gen_len, tokenizer=processor.tokenizer)
+
+    # ── Run selected blocking config(s) ──────────────────────────────────────
+    results = {}
+    for mode in modes_to_run:
+        if mode == "decode":
+            aic_tokens = run_decode_config(
+                model_hf, config, processor, raw_inputs, args.gen_len, num_cores=num_cores, num_devices=num_devices
+            )
+        else:
+            prefill_mode = "qkv" if mode == "prefill_par" else "online"
+            aic_tokens = run_prefill_config(
+                model_hf, config, processor, raw_inputs, args.gen_len, prefill_mode, num_cores, num_devices
+            )
+        results[mode] = aic_tokens
+
+    # ── Summary ───────────────────────────────────────────────────────────────
+    # print("\n" + "=" * 60)
+    # print("RESULTS")
+    # print("=" * 60)
+    # all_pass = True
+    # for mode, aic_tokens in results.items():
+    #     passed = compare_tokens(pt_tokens, aic_tokens, mode)
+    #     all_pass = all_pass and passed
+
+    # print("=" * 60)
+    # print(f"Overall: {'ALL PASS' if all_pass else 'FAILURES DETECTED'}")
+    # print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe_blocking_headpar_example.py
+++ b/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe_blocking_headpar_example.py
@@ -263,7 +263,7 @@ def run_prefill_config(
 
     # ── Run chunked prefill ───────────────────────────────────────────────────
     prefill_session = QAICInferenceSession(prefill_qpc)
-    decode_session = QAICInferenceSession(decode_qpc)
+    # decode_session = QAICInferenceSession(decode_qpc)
 
     chunk_inputs = {"image_idx": np.array([[0]])}
     prefill_out = None


### PR DESCRIPTION
## Summary of Changes
- Adds examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe_blocking_headpar_example.py, a self-contained
  end-to-end script that exercises three blocked-attention configurations for the Qwen3-VL-MoE 
- Added support in Qwen3VL-MOE forward to use prefill_blocked_interface if requested by user. 
  
## Blocking modes covered in example script 
-  --blocking-mode decode
  Decode QPC: HQKV +  kv_blocking_headpar_split=0
-  --blocking-mode prefill_par
  Decode QPC: HQKV
  Prefill QPC: prefill_blocking_mode="qkv"
  Description: Separate QPCs;
    chunked-prefill + manual decode loop
-  --blocking-mode prefill_online
  Decode QPC: HQKV
  Prefill QPC:
  prefill_blocking_mode="online"
  Description: Same as above with
    online-softmax prefill
 - --blocking-mode all
  Decode QPC: —
  Prefill QPC: —
  Description: Runs all three back-to-back

## Usage
python examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe_blocking_headpar_example.py --blocking-mode all