### PR TITLE
Gpt_oss prefill: avoid packed expert-axis slicing in chunked MoE to restore MXFP6 constant compression for release1.22

### DIFF
--- a/QEfficient/generation/vlm_generation.py
+++ b/QEfficient/generation/vlm_generation.py
@@ -737,6 +737,7 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
         generation_len: int = None,
         stream: List[str] = None,
     ):
+
         exec_batch_size = self.batch_size
         max_gen_length = self._ctx_len if not generation_len else max(self._ctx_len, generation_len)
         self.initialize_decode_inputs(

--- a/QEfficient/generation/vlm_generation.py
+++ b/QEfficient/generation/vlm_generation.py
@@ -737,7 +737,6 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
         generation_len: int = None,
         stream: List[str] = None,
     ):
-
         exec_batch_size = self.batch_size
         max_gen_length = self._ctx_len if not generation_len else max(self._ctx_len, generation_len)
         self.initialize_decode_inputs(

--- a/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -150,6 +150,56 @@ def _cumsum_scatter_gather_update_gptoss_expert_blocked(
 class QEffPrefillOnlyChunkedGptOssMLP(GptOssMLP):
     supports_moe_prefill_blocking = True
 
+    def __qeff_init__(self):
+        num_experts = self.experts.num_experts
+        num_nsp = getattr(self, "expert_blocking_num_nsp", num_experts)
+        local_experts = num_experts // num_nsp
+        expert_dim = self.experts.expert_dim
+        hidden_size = self.hidden_size
+
+        self.W_g = nn.Parameter(
+            self.experts.gate_proj.view(local_experts, num_nsp, hidden_size, expert_dim)
+            .transpose(0, 1)
+            .contiguous()
+            .detach()
+            .clone()
+        )
+        self.W_u = nn.Parameter(
+            self.experts.up_proj.view(local_experts, num_nsp, hidden_size, expert_dim)
+            .transpose(0, 1)
+            .contiguous()
+            .detach()
+            .clone()
+        )
+        self.W_d = nn.Parameter(
+            self.experts.down_proj.view(local_experts, num_nsp, expert_dim, hidden_size)
+            .transpose(0, 1)
+            .contiguous()
+            .detach()
+            .clone()
+        )
+        self.b_g = nn.Parameter(
+            self.experts.gate_proj_bias.view(local_experts, num_nsp, expert_dim)
+            .transpose(0, 1)
+            .contiguous()
+            .detach()
+            .clone()
+        )
+        self.b_u = nn.Parameter(
+            self.experts.up_proj_bias.view(local_experts, num_nsp, expert_dim)
+            .transpose(0, 1)
+            .contiguous()
+            .detach()
+            .clone()
+        )
+        self.b_d = nn.Parameter(
+            self.experts.down_proj_bias.view(local_experts, num_nsp, hidden_size)
+            .transpose(0, 1)
+            .contiguous()
+            .detach()
+            .clone()
+        )
+
     def forward(self, hidden: torch.Tensor):
         B, S, H = hidden.shape
         T = B * S
@@ -169,28 +219,24 @@ class QEffPrefillOnlyChunkedGptOssMLP(GptOssMLP):
             raise ValueError(f"num_experts ({num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})")
 
         local_experts = num_experts // num_nsp
-        routing_weights_by_expert = routing_weights.transpose(0, 1).contiguous()
+        routing_weights_by_expert = (
+            routing_weights.transpose(0, 1).contiguous().view(local_experts, num_nsp, T).transpose(0, 1).contiguous()
+        )
 
         expert_out = hidden.new_zeros((num_nsp, T, H))
+        routing_weights_unsqueezed = routing_weights_by_expert.unsqueeze(-1)
         for local_slot in range(local_experts):
-            # Keep each local expert shard as a separate block instead of packing
-            # [num_nsp, local_experts, ...] and slicing on local_experts inside the
-            # decoder-layer subfunction. This avoids packed-then-sliced expert
-            # constants in ONNX subfunction export for prefill.
-            slot_start = local_slot * num_nsp
-            slot_end = slot_start + num_nsp
-            rw_slot = routing_weights_by_expert[slot_start:slot_end]
-            T2Ei = rw_slot > 0
+            T2Ei = routing_weights_by_expert[:, local_slot, :] > 0
             expert_out = _cumsum_scatter_gather_update_gptoss_expert_blocked(
                 x=hidden,
                 T2Ei=T2Ei,
-                W_g=self.experts.gate_proj[slot_start:slot_end],
-                W_u=self.experts.up_proj[slot_start:slot_end],
-                W_d=self.experts.down_proj[slot_start:slot_end],
-                b_g=self.experts.gate_proj_bias[slot_start:slot_end],
-                b_u=self.experts.up_proj_bias[slot_start:slot_end],
-                b_d=self.experts.down_proj_bias[slot_start:slot_end],
-                routing_weight=rw_slot.unsqueeze(-1),
+                W_g=self.W_g[:, local_slot],
+                W_u=self.W_u[:, local_slot],
+                W_d=self.W_d[:, local_slot],
+                b_g=self.b_g[:, local_slot],
+                b_u=self.b_u[:, local_slot],
+                b_d=self.b_d[:, local_slot],
+                routing_weight=routing_weights_unsqueezed[:, local_slot],
                 expert_out=expert_out,
                 limit=self.experts.limit,
                 alpha=self.experts.alpha,

--- a/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -169,31 +169,28 @@ class QEffPrefillOnlyChunkedGptOssMLP(GptOssMLP):
             raise ValueError(f"num_experts ({num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})")
 
         local_experts = num_experts // num_nsp
-        expert_dim = self.experts.expert_dim
-        routing_weights_by_expert = (
-            routing_weights.transpose(0, 1).contiguous().view(local_experts, num_nsp, T).transpose(0, 1).contiguous()
-        )
-        W_g = self.experts.gate_proj.view(local_experts, num_nsp, H, expert_dim).transpose(0, 1).contiguous()
-        W_u = self.experts.up_proj.view(local_experts, num_nsp, H, expert_dim).transpose(0, 1).contiguous()
-        W_d = self.experts.down_proj.view(local_experts, num_nsp, expert_dim, H).transpose(0, 1).contiguous()
-        b_g = self.experts.gate_proj_bias.view(local_experts, num_nsp, expert_dim).transpose(0, 1).contiguous()
-        b_u = self.experts.up_proj_bias.view(local_experts, num_nsp, expert_dim).transpose(0, 1).contiguous()
-        b_d = self.experts.down_proj_bias.view(local_experts, num_nsp, H).transpose(0, 1).contiguous()
+        routing_weights_by_expert = routing_weights.transpose(0, 1).contiguous()
 
         expert_out = hidden.new_zeros((num_nsp, T, H))
-        routing_weights_unsqueezed = routing_weights_by_expert.unsqueeze(-1)
         for local_slot in range(local_experts):
-            T2Ei = routing_weights_by_expert[:, local_slot, :] > 0
+            # Keep each local expert shard as a separate block instead of packing
+            # [num_nsp, local_experts, ...] and slicing on local_experts inside the
+            # decoder-layer subfunction. This avoids packed-then-sliced expert
+            # constants in ONNX subfunction export for prefill.
+            slot_start = local_slot * num_nsp
+            slot_end = slot_start + num_nsp
+            rw_slot = routing_weights_by_expert[slot_start:slot_end]
+            T2Ei = rw_slot > 0
             expert_out = _cumsum_scatter_gather_update_gptoss_expert_blocked(
                 x=hidden,
                 T2Ei=T2Ei,
-                W_g=W_g[:, local_slot],
-                W_u=W_u[:, local_slot],
-                W_d=W_d[:, local_slot],
-                b_g=b_g[:, local_slot],
-                b_u=b_u[:, local_slot],
-                b_d=b_d[:, local_slot],
-                routing_weight=routing_weights_unsqueezed[:, local_slot],
+                W_g=self.experts.gate_proj[slot_start:slot_end],
+                W_u=self.experts.up_proj[slot_start:slot_end],
+                W_d=self.experts.down_proj[slot_start:slot_end],
+                b_g=self.experts.gate_proj_bias[slot_start:slot_end],
+                b_u=self.experts.up_proj_bias[slot_start:slot_end],
+                b_d=self.experts.down_proj_bias[slot_start:slot_end],
+                routing_weight=rw_slot.unsqueeze(-1),
                 expert_out=expert_out,
                 limit=self.experts.limit,
                 alpha=self.experts.alpha,

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -3398,10 +3398,19 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         enable: Optional[bool] = True,
         enable_chunking: Optional[bool] = False,
         retain_full_kv: Optional[bool] = False,
+        num_cores: int = constants.DEFAULT_AIC_NUM_CORES,
+        moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
     ):
         if enable:
             self.model, tf = PrefillOnlyExternalModuleMapperTransform.apply(self.model)
             if enable_chunking:
+                # __qeff_init__ runs during module remapping; seed MoE prefill-blocking attrs
+                # on source modules before remap so strict getattr(...) in __qeff_init__ succeeds.
+                for module in self.model.modules():
+                    if hasattr(module, "experts") and hasattr(module, "router"):
+                        module.expert_blocking_num_nsp = num_cores
+                        module.expert_blocking_packed_chunk_size = moe_prefill_packed_chunk_size
+                        module.hidden_size = self.config.hidden_size
                 self.model, tf = PrefillOnlyChunkedTransform.apply(self.model)
             else:
                 self.model, tf = PrefillOnlyTransform.apply(self.model)
@@ -3805,7 +3814,12 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                     raise NotImplementedError(
                         "Looks like you are trying to run prefix-caching without chunking, this feature is not available yet!"
                     )
-                self.__update_prefill_transform(enable=True, enable_chunking=enable_chunking)
+                self.__update_prefill_transform(
+                    enable=True,
+                    enable_chunking=enable_chunking,
+                    num_cores=num_cores,
+                    moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
+                )
                 self.hash_params.pop("retain_full_kv", None)
                 if "DeepseekV3ForCausalLM" not in (getattr(self.model.config, "architectures", None) or []):
                     seq_len = self.get_seq_len_and_handle_specialized_prefill_model(


### PR DESCRIPTION
### Root cause and fix summary (prefill-only)

  #### Before (problematic pattern)
  In `QEffPrefillOnlyChunkedGptOssMLP.forward`, the prefill path did:

  1. Repacked expert tensors into grouped views:
     - `W_g/W_u/W_d` and biases were reshaped to `[num_nsp, local_experts, ...]`.
  2. Sliced that grouped axis inside the `local_slot` loop:
     - `W_g[:, local_slot]`, `W_u[:, local_slot]`, etc.

  This matches the compiler pattern we observed:
  - input like `float16<16 x 2 x 2880 x 2880>`
  - then two slices on axis-1 (index `0` and `1`)

  So even with logically split gate/up params, this path reintroduced a packed-then-sliced representation during subfunction export.

  #### After (fixed pattern)
  The updated code now:

  1. Keeps routing weights in flat per-expert layout:
     - `routing_weights_by_expert = routing_weights.transpose(0, 1)` → `[num_experts, T]`
  2. Computes explicit contiguous expert ranges per `local_slot`:
     - `slot_start = local_slot * num_nsp`
     - `slot_end = slot_start + num_nsp`
  3. Passes per-slot expert blocks directly:
     - `self.experts.gate_proj[slot_start:slot_end]`
     - `self.experts.up_proj[slot_start:slot_end]`
     - `self.experts.down_proj[slot_start:slot_end]`
     - same pattern for biases and routing weights

  So we no longer materialize `[num_nsp, local_experts, ...]` temporaries and no longer slice that axis inside the subfunction body.