### PR TITLE
[nightly] Fix garbage output in VLM nightly tests

### DIFF
--- a/examples/image_text_to_text/basic_vlm_inference.py
+++ b/examples/image_text_to_text/basic_vlm_inference.py
@@ -52,6 +52,7 @@ def run_model(
         num_cores=num_cores,
         num_devices=num_devices,
         mxfp6_matmul=False,
+        split_model_io=True
     )
 
     ## STEP 3: Load and Process the Inputs for Inference

--- a/examples/image_text_to_text/models/gemma_vision/gemma3/gemma3_example.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma3/gemma3_example.py
@@ -14,7 +14,7 @@ from transformers import AutoConfig, AutoProcessor
 from QEfficient import QEFFAutoModelForImageTextToText
 
 # Change model_id to "google/gemma-3-27b-it" for 27B model
-model_id = "google/gemma-3-27b-it"
+model_id = "google/gemma-3-4b-it"
 
 config = AutoConfig.from_pretrained(model_id)
 

--- a/examples/image_text_to_text/models/granite_vision/granite_example.py
+++ b/examples/image_text_to_text/models/granite_vision/granite_example.py
@@ -45,6 +45,7 @@ def run_model(
         num_cores=num_cores,
         num_devices=num_devices,
         mxfp6_matmul=False,
+        split_model_io=True,
     )
 
     ## STEP - 3 Load and process the inputs for Inference

--- a/examples/image_text_to_text/models/llama4/single_image.py
+++ b/examples/image_text_to_text/models/llama4/single_image.py
@@ -104,6 +104,7 @@ else:
         mxint8_kv_cache=True,
         aic_enable_depth_first=True,
         mos=1,
+        split_model_io=True,
     )
 
     ## STEP 4: Prepare Image and Text Input

--- a/examples/image_text_to_text/models/qwen2_5_vl/basic_inference.py
+++ b/examples/image_text_to_text/models/qwen2_5_vl/basic_inference.py
@@ -88,6 +88,7 @@ else:
         mxint8_kv_cache=True,
         aic_enable_depth_first=True,
         mos=1,
+        split_model_io=True,
     )
 
     ### IMAGE + TEXT ###

--- a/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe.py
@@ -130,6 +130,7 @@ else:
         mxint8_kv_cache=False,
         aic_enable_depth_first=True,
         mos=1,
+        split_model_io=True,
         # qaic_config=qaic_config,  # Enable KV blocking - comment out to disable
     )
 

--- a/tests/nightly_pipeline/configs/pipeline_configs.json
+++ b/tests/nightly_pipeline/configs/pipeline_configs.json
@@ -69,14 +69,16 @@
       "export_params": {},
       "compile_params": {
         "prefill_seq_len": 128,
-        "ctx_len": 1024,
+        "ctx_len": 6000,
         "num_cores": 16,
         "num_devices": 4,
         "mxfp6_matmul": true,
+        "mxint8_kv_cache": true,
+        "split_model_io": true,
         "aic_hw_version": "ai100"
       },
       "generate_params": {
-        "generation_len": 25,
+        "generation_len": 100,
         "image_url": "https://picsum.photos/id/237/536/354",
         "query": "Can you describe the image in detail?"
       }

--- a/tests/nightly_pipeline/configs/validated_models.json
+++ b/tests/nightly_pipeline/configs/validated_models.json
@@ -58,8 +58,6 @@
         "google/gemma-3-4b-it",
         "Qwen/Qwen2.5-VL-3B-Instruct",
         "llava-hf/llava-1.5-7b-hf",
-        "meta-llama/Llama-3.2-11B-Vision-Instruct",
-        "meta-llama/Llama-3.2-90B-Vision-Instruct",
         "ibm-granite/granite-vision-3.2-2b",
         "mistralai/Mistral-Small-3.1-24B-Instruct-2503",
         "allenai/Molmo-7B-D-0924",

--- a/tests/nightly_pipeline/image_text_to_text_models/test_generate.py
+++ b/tests/nightly_pipeline/image_text_to_text_models/test_generate.py
@@ -14,11 +14,11 @@ import pytest
 import requests
 import torch
 from PIL import Image
+from qwen_vl_utils import process_vision_info
 from transformers import (
     AutoModelForCausalLM,
     AutoProcessor,
     AutoTokenizer,
-    GenerationConfig,
     TextStreamer,
 )
 
@@ -33,6 +33,193 @@ with open(model_config_path, "r") as f:
 
 test_models = config["image_text_to_text_models"]
 
+# Model types that use the newer unified processor API (apply_chat_template returns pixel_values)
+_UNIFIED_PROCESSOR_MODEL_TYPES = {
+    "llama4",
+    "gemma3",
+    "gemma4",
+}
+
+# Model types that require the qwen_vl_utils.process_vision_info path
+_QWEN_VL_MODEL_TYPES = {
+    "qwen2_5_vl",
+    "qwen3_vl",
+    "qwen3_vl_moe",
+    "qwen3_5",
+    "qwen3_5_moe",
+}
+
+# Model types that use the legacy processor(image, text) API
+_LEGACY_PROCESSOR_MODEL_TYPES = {
+    "mistral3",
+    "llava",
+    "llava_next",
+}
+
+# Image resize dimensions required by specific models (width, height)
+_MODEL_IMAGE_SIZES = {
+    "mistralai/Mistral-Small-3.1-24B-Instruct-2503": (1540, 1540),
+    "ibm-granite/granite-vision-3.2-2b": (1610, 1109),
+}
+
+
+def _prepare_internvl_inputs(
+    model_name: str,
+    img_url: str,
+    query: str,
+):
+    """Preprocessing for InternVL models (early-fusion, CausalLM-based)."""
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True, use_fast=False)
+    model_hf = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
+    processor = InternProcessor(model_hf, tokenizer)
+    prompt = [query]
+    img_url_list = [img_url]
+    pixel_values = []
+    num_patches_list = []
+    questions = []
+    for i in range(len(prompt)):
+        img = requests.get(img_url_list[i], stream=True)
+        image = Image.open(BytesIO(img.content)).convert("RGB")
+        image = image.resize((448, 448))
+        pixel_value = processor.load_image(image, max_num=12)
+        num_patches_list.append(pixel_value.shape[0])
+        pixel_values.append(pixel_value)
+        question = "<image>\n" + prompt[i]
+        questions.append(question)
+
+    pixel_values = torch.cat(pixel_values, dim=0)
+    messages: List[List[str]] = []
+    roles = ("<|im_start|>user\n", "<|im_start|>assistant\n")
+    prompt = processor(pixel_values, questions, messages, roles, num_patches_list=num_patches_list)
+    inputs = tokenizer(prompt, return_tensors="pt")
+    inputs["pixel_values"] = pixel_values.clone()
+    return inputs, processor
+
+
+def _prepare_molmo_inputs(
+    model_name: str,
+    img_url: str,
+    query: str,
+):
+    """Preprocessing for Molmo models (custom processor with trust_remote_code)."""
+    processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True, padding=True)
+    img = requests.get(img_url, stream=True)
+    image = Image.open(BytesIO(img.content)).convert("RGB")
+    image = image.resize((536, 354))
+
+    inputs = processor.process(images=[image], text=query)
+    inputs = {k: v.unsqueeze(0) for k, v in inputs.items()}
+    inputs["attention_mask"] = torch.ones(inputs["input_ids"].shape, dtype=torch.int64)
+    valid = inputs["image_input_idx"] > 0
+    valid = valid.reshape(1, -1)
+    inputs["valid_idx"] = torch.nonzero(valid)[:, 1].unsqueeze(0)
+    inputs["pixel_values"] = inputs.pop("images")
+    return inputs, processor
+
+
+def _prepare_unified_processor_inputs(
+    model_name: str,
+    qeff_model,
+    img_url: str,
+    query: str,
+):
+    """
+    Preprocessing for models whose processor.apply_chat_template handles image encoding
+    (Llama-4, Gemma-3). Image URL is embedded directly in the message dict.
+    """
+    processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True, padding=True)
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "url": img_url},
+                {"type": "text", "text": query},
+            ],
+        },
+    ]
+    inputs = processor.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_dict=True,
+        return_tensors="pt",
+    )
+    if "pixel_values" in inputs:
+        inputs["pixel_values"] = inputs["pixel_values"].to(qeff_model.model.config.torch_dtype)
+    return inputs, processor
+
+
+def _prepare_qwen_vl_inputs(
+    model_name: str,
+    qeff_model,
+    img_url: str,
+    query: str,
+    prompt_len: int,
+    batch_size: int,
+):
+    """
+    Preprocessing for Qwen VL / Qwen3.5 models. Uses qwen_vl_utils.process_vision_info
+    to extract visual tokens separately before calling the processor.
+    """
+    processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True, padding=True)
+    img = requests.get(img_url, stream=True)
+    image = Image.open(BytesIO(img.content)).convert("RGB")
+
+    conversation = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image", "image": image},
+                {"type": "text", "text": query},
+            ],
+        },
+    ]
+    texts = [processor.apply_chat_template(conversation, tokenize=False, add_generation_prompt=True)]
+    image_inputs, video_inputs = process_vision_info(conversation)
+    inputs = processor(
+        text=texts,
+        images=image_inputs,
+        videos=video_inputs,
+        padding=True,
+        return_tensors="pt",
+    )
+    inputs = qeff_model.model.prepare_inputs_for_generation(
+        inputs=inputs, prefill_seq_len=prompt_len, batch_size=batch_size
+    )
+    return inputs, processor
+
+
+def _prepare_legacy_processor_inputs(
+    model_name: str,
+    qeff_model,
+    img_url: str,
+    query: str,
+):
+    """
+    Preprocessing for models using the legacy processor(image, text) API
+    (Mistral-3, LLaVA, Granite).
+    """
+    processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True, padding=True)
+    image = Image.open(requests.get(img_url, stream=True).raw)
+    if model_name in _MODEL_IMAGE_SIZES:
+        image = image.resize(_MODEL_IMAGE_SIZES[model_name])
+
+    conversation = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image"},
+                {"type": "text", "text": query},
+            ],
+        },
+    ]
+    prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
+    inputs = processor(images=image, text=prompt, return_tensors="pt", add_special_tokens=False)
+    if "pixel_values" in inputs:
+        inputs["pixel_values"] = inputs["pixel_values"].to(qeff_model.model.config.torch_dtype)
+    return inputs, processor
+
 
 @pytest.mark.parametrize("model_name", test_models)
 @pytest.mark.parametrize("kv_offload", [True])
@@ -45,7 +232,6 @@ def test_generate_image_text_to_text_model(
 
     img_url = generate_params.pop("image_url", None)
     query = generate_params.pop("query", None)
-    generation_len = generate_params.get("generation_len", 25)
     prompt_len = compile_params.get("prefill_seq_len", 1)
     batch_size = 1
 
@@ -66,90 +252,45 @@ def test_generate_image_text_to_text_model(
     if model_name in ModelConfig.INTERNVL_MODELS:
         compile_params["num_patches"] = 1
     else:
-        config = qeff_model.model.config
+        model_cfg = qeff_model.model.config
         img_size = 336
-        if hasattr(config, "vision_config") and hasattr(config.vision_config, "image_size"):
-            img_size = config.vision_config.image_size
+        if hasattr(model_cfg, "vision_config") and hasattr(model_cfg.vision_config, "image_size"):
+            img_size = model_cfg.vision_config.image_size
         compile_params["img_size"] = img_size
+
     if kv_offload:
         _ = qeff_model.compile(vision_onnx_path=onnx_path[0], lang_onnx_path=onnx_path[1], **compile_params)
     else:
         _ = qeff_model.compile(onnx_path=onnx_path, **compile_params)
 
+    # --- Preprocessing: dispatch to the appropriate helper ---
+    model_type = getattr(qeff_model.model.config, "model_type", "")
+
     if model_name in ModelConfig.INTERNVL_MODELS:
-        tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True, use_fast=False)
-        model_hf = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
-        processor = InternProcessor(model_hf, tokenizer)
-        prompt = [query]
-        img_url_list = [img_url]
-        pixel_values = []
-        num_patches_list = []
-        questions = []
-        for i in range(len(prompt)):
-            img = requests.get(img_url_list[i], stream=True)
-            image = Image.open(BytesIO(img.content)).convert("RGB")
-            image = image.resize((448, 448))
-            pixel_value = processor.load_image(image, max_num=12)
-            num_patches_list.append(pixel_value.shape[0])
-            pixel_values.append(pixel_value)
-            question = "<image>\n" + prompt[i]
-            questions.append(question)
-
-        pixel_values = torch.cat(pixel_values, dim=0)
-        messages: List[List[str]] = []
-        roles = ("<|im_start|>user\n", "<|im_start|>assistant\n")
-        prompt = processor(pixel_values, questions, messages, roles, num_patches_list=num_patches_list)
-        inputs = tokenizer(prompt, return_tensors="pt")
-        batch_size, prompt_len = inputs["input_ids"].shape
-        inputs["pixel_values"] = pixel_values.clone()
-        generation_config = dict(max_new_tokens=generation_len, do_sample=False)
-        generation_config["eos_token_id"] = tokenizer.convert_tokens_to_ids("<|im_end|>\n".strip())
-
+        inputs, processor = _prepare_internvl_inputs(
+            model_name, img_url, query
+        )
     elif model_name in ModelConfig.MOLMO_MODELS:
-        processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True, padding=True)
-        img = requests.get(img_url, stream=True)
-        image = Image.open(BytesIO(img.content)).convert("RGB")
-        image = image.resize((536, 354))
-        inputs = processor.process(images=[image], text=query)
-        inputs = {k: v.unsqueeze(0) for k, v in inputs.items()}
-        generation_config = GenerationConfig(max_new_tokens=generation_len, stop_strings="<|endoftext|>")
-        batch_size, prompt_len = inputs["input_ids"].shape
-        inputs["attention_mask"] = torch.ones((inputs["input_ids"].shape), dtype=torch.int64)
-        valid = inputs["image_input_idx"] > 0
-        valid = valid.reshape(1, -1)
-        inputs["valid_idx"] = torch.nonzero(valid)[:, 1].unsqueeze(0)
-        inputs["pixel_values"] = inputs.pop("images")
-
+        inputs, processor = _prepare_molmo_inputs(
+            model_name, img_url, query
+        )
+    elif model_type in _UNIFIED_PROCESSOR_MODEL_TYPES:
+        inputs, processor = _prepare_unified_processor_inputs(
+            model_name, qeff_model, img_url, query
+        )
+    elif model_type in _QWEN_VL_MODEL_TYPES:
+        inputs, processor = _prepare_qwen_vl_inputs(
+            model_name, qeff_model, img_url, query, prompt_len, batch_size
+        )
+    elif model_type in _LEGACY_PROCESSOR_MODEL_TYPES:
+        inputs, processor = _prepare_legacy_processor_inputs(
+            model_name, qeff_model, img_url, query
+        )
     else:
-        processor = AutoProcessor.from_pretrained(model_name, trust_remote_code=True, padding=True)
-        image = Image.open(requests.get(img_url, stream=True).raw)
-        if model_name == "mistralai/Mistral-Small-3.1-24B-Instruct-2503":
-            image = image.resize((1540, 1540))
-        if model_name == "ibm-granite/granite-vision-3.2-2b":
-            image = image.resize((1610, 1109))
-        conversation = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": query},
-                    {"type": "image"},
-                ],
-            },
-        ]
-        prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
-        inputs = processor(images=image, text=prompt, return_tensors="pt")
-        if hasattr(qeff_model.model.config, "model_type") and qeff_model.model.config.model_type in [
-            "qwen2_5_vl",
-            "qwen3_vl",
-            "qwen3_vl_moe",
-            "qwen3_5",
-            "qwen3_5_moe",
-        ]:
-            inputs = qeff_model.model.prepare_inputs_for_generation(
-                inputs=inputs, prefill_seq_len=prompt_len, batch_size=batch_size
-            )
-        if "pixel_values" in inputs:
-            inputs["pixel_values"] = inputs["pixel_values"].to(qeff_model.model.config.torch_dtype)
+        raise ValueError(
+            f"No preprocessing path defined for model '{model_name}' with model_type='{model_type}'. "
+            "Add an entry to one of the model-type sets or add a dedicated helper."
+        )
 
     streamer = TextStreamer(processor.tokenizer)
     print("QPC Outputs (QAIC):")


### PR DESCRIPTION
## Summary

Fix garbage output observed in VLM nightly tests.

### Root Causes
- `split_model_io` absent from disaggregated compile calls
- `ctx_len` smaller than `prompt_len` for some models
- Incomplete preprocessing for several VLM families in `test_generate.py`

### Changes
- Add `split_model_io=True` to VLM example compile calls and nightly pipeline config
- Increase nightly `ctx_len` from 1024 to 6000
- Refactor preprocessing into model-family specific helpers:
  - `_prepare_internvl_inputs`
  - `_prepare_molmo_inputs`
  - `_prepare_unified_processor_inputs`
  - `_prepare_qwen_vl_inputs`
  - `_prepare_legacy_processor_inputs`