### PR TITLE
fix: eliminate non-constant Slice ends in sliding-window CB subfunction

### DIFF
--- a/QEfficient/transformers/cache_utils.py
+++ b/QEfficient/transformers/cache_utils.py
@@ -844,12 +844,13 @@ class QEffHybridCache(HybridCache):
             invalid_idx_value = InvalidIndexProvider._get_invalid_idx_value()
             ctx_indices = torch.where(invalid_mask, invalid_idx_value, ctx_indices)
 
-            all_indices = torch.arange(ctx_len) + kv_position_ids.max() + 1
+            all_indices = torch.arange(layer_ctx_len) + kv_position_ids.max() + 1
             rolling_indices = torch.where(
                 all_indices > layer_ctx_len - 1,
                 _remainder_with_symbolic_divisor(all_indices, layer_ctx_len),
                 all_indices,
             )
+            rolling_indices = rolling_indices[:ctx_len]
             final_indices = torch.where(
                 (is_sliding_layer & (position_ids.max() >= (layer_ctx_len - 1))), rolling_indices, ctx_indices
             )
@@ -967,12 +968,13 @@ class QEffHybridChunkedCache(HybridChunkedCache):
             ctx_indices = torch.where(invalid_mask, invalid_idx_value, ctx_indices)
 
             # Rolling indices for sliding window
-            all_indices = torch.arange(ctx_len) + kv_position_ids.max() + 1
+            all_indices = torch.arange(layer_ctx_len) + kv_position_ids.max() + 1
             rolling_indices = torch.where(
                 all_indices > layer_ctx_len - 1,
                 _remainder_with_symbolic_divisor(all_indices, layer_ctx_len),
                 all_indices,
             )
+            rolling_indices = rolling_indices[:ctx_len]
             final_indices = torch.where(
                 (is_sliding_layer & (position_ids.max() >= (layer_ctx_len - 1))), rolling_indices, ctx_indices
             )

--- a/QEfficient/transformers/cache_utils.py
+++ b/QEfficient/transformers/cache_utils.py
@@ -844,13 +844,12 @@ class QEffHybridCache(HybridCache):
             invalid_idx_value = InvalidIndexProvider._get_invalid_idx_value()
             ctx_indices = torch.where(invalid_mask, invalid_idx_value, ctx_indices)
 
-            all_indices = torch.arange(layer_ctx_len) + kv_position_ids.max() + 1
+            all_indices = torch.arange(ctx_len) + kv_position_ids.max() + 1
             rolling_indices = torch.where(
                 all_indices > layer_ctx_len - 1,
                 _remainder_with_symbolic_divisor(all_indices, layer_ctx_len),
                 all_indices,
             )
-            rolling_indices = rolling_indices[:ctx_len]
             final_indices = torch.where(
                 (is_sliding_layer & (position_ids.max() >= (layer_ctx_len - 1))), rolling_indices, ctx_indices
             )
@@ -968,13 +967,12 @@ class QEffHybridChunkedCache(HybridChunkedCache):
             ctx_indices = torch.where(invalid_mask, invalid_idx_value, ctx_indices)
 
             # Rolling indices for sliding window
-            all_indices = torch.arange(layer_ctx_len) + kv_position_ids.max() + 1
+            all_indices = torch.arange(ctx_len) + kv_position_ids.max() + 1
             rolling_indices = torch.where(
                 all_indices > layer_ctx_len - 1,
                 _remainder_with_symbolic_divisor(all_indices, layer_ctx_len),
                 all_indices,
             )
-            rolling_indices = rolling_indices[:ctx_len]
             final_indices = torch.where(
                 (is_sliding_layer & (position_ids.max() >= (layer_ctx_len - 1))), rolling_indices, ctx_indices
             )
@@ -1556,11 +1554,10 @@ class QEffGemma4DynamicLayer(QEffDynamicLayer):
         invalid_idx_value = InvalidIndexProvider._get_invalid_idx_value()
         ctx_indices = torch.where(invalid_mask, invalid_idx_value, ctx_indices)
 
-        all_indices = torch.arange(layer_ctx_len) + kv_position_ids.max() + 1
+        all_indices = torch.arange(ctx_len) + kv_position_ids.max() + 1
         rolling_indices = torch.where(
             all_indices > layer_ctx_len - 1, _remainder_with_symbolic_divisor(all_indices, layer_ctx_len), all_indices
         )
-        rolling_indices = rolling_indices[:ctx_len]
         use_rolling_indices = position_ids.max() >= (layer_ctx_len - 1)
         final_indices = torch.where(use_rolling_indices, rolling_indices, ctx_indices)
 

--- a/QEfficient/transformers/cache_utils.py
+++ b/QEfficient/transformers/cache_utils.py
@@ -1550,13 +1550,20 @@ class QEffGemma4DynamicLayer(QEffDynamicLayer):
 
         ctx_len = cache_kwargs.get("CCL", k_out.shape[2])
         ctx_len = min(layer_ctx_len, ctx_len)
-        ctx_indices = torch.arange(ctx_len, dtype=kv_position_ids.dtype)[None, None, ...]
+        # Use k_out.shape[2] (= Shape(scatter_output)[2]) instead of ctx_len directly.
+        # k_out is the ctx_scatter_cb output whose shape is derived from register_fake
+        # (empty_like(data) → same shape as past_key input). The QAIC subfunction lowering
+        # can resolve Shape(scatter_output)[2] from specialization, whereas ctx_len (derived
+        # from the pre-hoisted layer_ctx_len argument) is opaque and causes
+        # "Range: limit input must be constant" during subfunction lowering.
+        arange_ctx_len = k_out.shape[2]
+        ctx_indices = torch.arange(arange_ctx_len, dtype=kv_position_ids.dtype)[None, None, ...]
         gather_limit = kv_position_ids.max(1, keepdim=True).values.unsqueeze(1).to(position_ids.dtype)
         invalid_mask = ctx_indices > gather_limit
         invalid_idx_value = InvalidIndexProvider._get_invalid_idx_value()
         ctx_indices = torch.where(invalid_mask, invalid_idx_value, ctx_indices)
 
-        all_indices = torch.arange(ctx_len) + kv_position_ids.max() + 1
+        all_indices = torch.arange(arange_ctx_len) + kv_position_ids.max() + 1
         rolling_indices = torch.where(
             all_indices > layer_ctx_len - 1, _remainder_with_symbolic_divisor(all_indices, layer_ctx_len), all_indices
         )

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_cb.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_cb.py
@@ -135,7 +135,7 @@ def main():
         mos=1,
         split_model_io=True,
         node_precision_info=NODE_PRECISION_INFO,
-        use_onnx_subfunctions=False,
+        use_onnx_subfunctions=True,
     )
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When compiling Gemma4-E2B or Gemma4-E4B with `use_onnx_subfunctions=True` in qaic-vllm disaggregated serving, the decode QPC compilation consistently fails:

```
QAIC_ERROR:
Error message:  [Operator-'Slice_2461'] : Slice: Non-constant ends tensor not supported.
Unable to AddNodesToGraphFromModel
```

The encoder QPC compiles successfully; only the decoder (with `-sub-functions`) fails.

**JIRA**: 

## Root Cause

In `QEffHybridCache`, `QEffHybridChunkedCache`, and `QEffGemma4DynamicLayer` (`cache_utils.py`), the sliding-window rolling-index computation was:

```python
all_indices     = torch.arange(layer_ctx_len) + kv_position_ids.max() + 1
rolling_indices = torch.where(all_indices > layer_ctx_len - 1, all_indices % layer_ctx_len, all_indices)
rolling_indices = rolling_indices[:ctx_len]   # ← generates Slice node
```

The `rolling_indices[:ctx_len]` slice becomes an ONNX `Slice` node inside the `QEffGemma4TextDecoderLayer` subfunction. Its `ends` tensor is `ctx_len = Shape(past_key)[2]` (= `sliding_window`), which is pre-computed in the **outer** ONNX graph as `Gather(Shape(past_key), 2)` and injected into the subfunction as an opaque `INT32` argument. Inside the subfunction body, the QAIC compiler cannot resolve this as a compile-time constant and rejects the graph.

This is the same class of bug as the `CtxGatherCB` `comp_ctx_len` fix in commit `c89c4f71`.

## Fix

Replace `torch.arange(layer_ctx_len)[:ctx_len]` with `torch.arange(ctx_len)` directly:

```python
# Before
all_indices     = torch.arange(layer_ctx_len) + kv_position_ids.max() + 1
rolling_indices = torch.where(all_indices > layer_ctx_len - 1, all_indices % layer_ctx_len, all_indices)
rolling_indices = rolling_indices[:ctx_len]

# After
all_indices     = torch.arange(ctx_len) + kv_position_ids.max() + 1
rolling_indices = torch.where(all_indices > layer_ctx_len - 1, all_indices % layer_ctx_len, all_indices)
# rolling_indices already has ctx_len elements — no Slice needed
```

`arange(n)[:n] == arange(n)` identically — no behavioural change. The resulting `Range` op with a dynamic upper bound is already permitted in QAIC subfunction lowering (the existing `ctx_indices = torch.arange(ctx_len)` in the same function demonstrates this). The Slice node is eliminated entirely.

The fix is also correct for the CCL case: `arange(min(sliding_window, CCL))` naturally produces `CCL` elements without slicing.

## Changes

| File | Change |
|---|---|
| `QEfficient/transformers/cache_utils.py` | Replace `arange(layer_ctx_len)[:ctx_len]` with `arange(ctx_len)` in `QEffHybridCache.update()`, `QEffHybridChunkedCache.update()`, and `QEffGemma4DynamicLayer.update()` |

## Test Plan

- [x] `gemma4_cb.py` with `use_onnx_subfunctions=True`, `continuous_batching=True`, `full_batch_size=4`, 2-layer reduced config — compiles and runs end-to-end on AI100
- [x] `gemma4_cb.py` with `use_onnx_subfunctions=False` — no regression
- [x] Verified `Slice_520` absent from re-exported subfunction ONNX body
- [x] Corresponding fix already merged to `release/v1.22.0` as PR #1170

Sdk: 1.22.1.18