### PR TITLE
Add CCL support to Gemma4, Qwen3.5 (moe), and qwn3_vl models

### DIFF
--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -415,6 +415,7 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
         position_ids: Optional[torch.LongTensor] = None,
         mm_token_type_ids: Optional[torch.Tensor] = None,
         batch_index: Optional[torch.LongTensor] = None,
+        comp_ctx_lengths: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         input_shape = hidden_states.shape[:-1]
@@ -451,6 +452,9 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
             token_key_states, token_value_states = key_states, value_states
 
         if past_key_values is not None:
+            if comp_ctx_lengths is not None and attention_mask is not None:
+                attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
+                cache_kwargs["CCL"] = attention_mask.shape[-1]
             if self.is_kv_shared_layer:
                 if token_key_states is not None and token_value_states is not None:
                     key_states, value_states = past_key_values.update(
@@ -514,6 +518,7 @@ class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
         past_key_values: Cache | None = None,
+        comp_ctx_lengths: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         hidden_states = _clamp_to_fp16_range(hidden_states)
@@ -526,6 +531,7 @@ class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
             attention_mask=attention_mask,
             position_ids=position_ids,
             past_key_values=past_key_values,
+            comp_ctx_lengths=comp_ctx_lengths,
             **kwargs,
         )
         hidden_states = self.post_attention_layernorm(hidden_states)
@@ -571,6 +577,7 @@ class QEffGemma4TextModel(Gemma4TextModel):
         past_key_values: Optional[Cache] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         per_layer_inputs: Optional[torch.Tensor] = None,
+        comp_ctx_lengths: Optional[torch.Tensor] = None,
         use_cache: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         **kwargs,
@@ -645,6 +652,7 @@ class QEffGemma4TextModel(Gemma4TextModel):
                 attention_mask=layer_attention_mask,
                 position_ids=position_ids,
                 past_key_values=past_key_values,
+                comp_ctx_lengths=comp_ctx_lengths,
                 **kwargs,
             )
 
@@ -868,9 +876,9 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
                 spec["batch_size"] = kv_cache_batch_size
             return spec
 
-        if comp_ctx_lengths_prefill and comp_ctx_lengths_decode:
-            specializations = [build_prefill_spec(length) for length in comp_ctx_lengths_prefill]
-            specializations.extend(build_decode_spec(length) for length in comp_ctx_lengths_decode)
+        if comp_ctx_lengths_prefill or comp_ctx_lengths_decode:
+            specializations = [build_prefill_spec(length) for length in (comp_ctx_lengths_prefill or [])]
+            specializations.extend(build_decode_spec(length) for length in (comp_ctx_lengths_decode or []))
             return specializations
 
         return [build_prefill_spec(), build_decode_spec()]
@@ -1244,9 +1252,9 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
                 spec["batch_size"] = kv_cache_batch_size or batch_size
             return spec
 
-        if comp_ctx_lengths_prefill and comp_ctx_lengths_decode:
-            lang = [build_lang_prefill_spec(length) for length in comp_ctx_lengths_prefill]
-            lang.extend(build_lang_decode_spec(length) for length in comp_ctx_lengths_decode)
+        if comp_ctx_lengths_prefill or comp_ctx_lengths_decode:
+            lang = [build_lang_prefill_spec(length) for length in (comp_ctx_lengths_prefill or [])]
+            lang.extend(build_lang_decode_spec(length) for length in (comp_ctx_lengths_decode or []))
         else:
             lang = [build_lang_prefill_spec(), build_lang_decode_spec()]
         if kv_offload:
@@ -1374,7 +1382,7 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         if continuous_batching:
             lang_inputs["batch_index"] = torch.arange(bs).view(bs, 1)
         if comp_ctx_lengths is not None:
-            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int8)
+            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int64)
         if kv_offload:
             return {"vision": vision_inputs, "lang": lang_inputs}
         return {**vision_inputs, **lang_inputs}

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -2086,14 +2086,26 @@ class _QEffAutoModelForImageTextToTextDualQPC:
 
             custom_io_lang = _filter_custom_io_for_onnx(custom_io_lang, self.lang_model.onnx_path)
 
+            # get_specializations lays the language specs out as
+            # [prefill specs..., decode specs...], with one spec per CCL value when
+            # CCL is enabled. The disagg prefill/decode QPCs must therefore keep the
+            # whole prefill/decode slice (not just the first/last spec), otherwise all
+            # but one CCL value is silently dropped.
+            lang_specs = specializations["lang"]
             if prefill_only:
-                specializations = specializations["lang"][:1]
+                if self.comp_ctx_lengths_prefill is not None:
+                    specializations = lang_specs[: len(self.comp_ctx_lengths_prefill)]
+                else:
+                    specializations = lang_specs[:1]
                 qpc_key = "lang_prefill_qpc_path"
             elif prefill_seq_len == 1:
-                specializations = specializations["lang"][-1:]
+                if self.comp_ctx_lengths_decode is not None:
+                    specializations = lang_specs[-len(self.comp_ctx_lengths_decode) :]
+                else:
+                    specializations = lang_specs[-1:]
                 qpc_key = "lang_decode_qpc_path"
             else:
-                specializations = specializations["lang"]
+                specializations = lang_specs
                 qpc_key = "lang_qpc_path"
 
             lang_qpc_path = self.lang_model._compile(

--- a/QEfficient/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/QEfficient/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -1714,8 +1714,8 @@ class QEffQwen3_5ForConditionalGeneration(Qwen3_5ForConditionalGeneration):
             return spec
 
         lang = []
-        if comp_ctx_lengths_prefill is not None:
-            for comp_ctx in comp_ctx_lengths_prefill:
+        if comp_ctx_lengths_prefill is not None or comp_ctx_lengths_decode is not None:
+            for comp_ctx in comp_ctx_lengths_prefill or []:
                 lang.append(_build_lang_spec(prefill_seq_len, comp_ctx_len=comp_ctx))
             for comp_ctx in comp_ctx_lengths_decode or []:
                 lang.append(_build_lang_spec(1, comp_ctx_len=comp_ctx))
@@ -1849,7 +1849,7 @@ class QEffQwen3_5ForConditionalGeneration(Qwen3_5ForConditionalGeneration):
             lang_inputs["batch_index"] = torch.arange(bs).view(bs, 1)
 
         if comp_ctx_lengths is not None:
-            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int8)
+            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int64)
 
         inputs = {}
         if kv_offload:

--- a/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -1270,6 +1270,8 @@ class QEffQwen3_5MoeModel(Qwen3_5MoeModel):
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
         past_key_values: Cache | None = None,
+        comp_ctx_lengths: torch.LongTensor | None = None,
+        batch_index: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         pixel_values: torch.Tensor | None = None,
         pixel_values_videos: torch.FloatTensor | None = None,
@@ -1318,6 +1320,8 @@ class QEffQwen3_5MoeModel(Qwen3_5MoeModel):
             position_ids=position_ids,
             attention_mask=attention_mask,
             past_key_values=past_key_values,
+            comp_ctx_lengths=comp_ctx_lengths,
+            batch_index=batch_index,
             inputs_embeds=inputs_embeds,
             cache_position=cache_position,
             **kwargs,
@@ -1679,6 +1683,8 @@ class QEffQwen3_5MoeForConditionalGeneration(Qwen3_5MoeForConditionalGeneration)
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
         past_key_values: Cache | None = None,
+        comp_ctx_lengths: torch.LongTensor | None = None,
+        batch_index: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
         pixel_values: torch.Tensor | None = None,
@@ -1748,6 +1754,8 @@ class QEffQwen3_5MoeForConditionalGeneration(Qwen3_5MoeForConditionalGeneration)
             position_ids=position_ids,
             attention_mask=attention_mask,
             past_key_values=past_key_values,
+            comp_ctx_lengths=comp_ctx_lengths,
+            batch_index=batch_index,
             inputs_embeds=inputs_embeds,
             cache_position=cache_position,
             mm_token_type_ids=mm_token_type_ids,
@@ -1878,8 +1886,8 @@ class QEffQwen3_5MoeForConditionalGeneration(Qwen3_5MoeForConditionalGeneration)
             return spec
 
         lang = []
-        if comp_ctx_lengths_prefill is not None:
-            for comp_ctx in comp_ctx_lengths_prefill:
+        if comp_ctx_lengths_prefill is not None or comp_ctx_lengths_decode is not None:
+            for comp_ctx in comp_ctx_lengths_prefill or []:
                 lang.append(_build_lang_spec(prefill_seq_len, comp_ctx_len=comp_ctx))
             for comp_ctx in comp_ctx_lengths_decode or []:
                 lang.append(_build_lang_spec(1, comp_ctx_len=comp_ctx))
@@ -2023,7 +2031,7 @@ class QEffQwen3_5MoeForConditionalGeneration(Qwen3_5MoeForConditionalGeneration)
             lang_inputs["batch_index"] = torch.arange(bs).view(bs, 1)
 
         if comp_ctx_lengths is not None:
-            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int8)
+            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int64)
 
         inputs = {}
         if kv_offload:

--- a/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -1024,10 +1024,10 @@ class QEffQwen3VLForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 }
             )
 
-        if comp_ctx_lengths_prefill is not None:
+        if comp_ctx_lengths_prefill is not None or comp_ctx_lengths_decode is not None:
             lang = []
 
-            for i in range(0, len(comp_ctx_lengths_prefill)):
+            for i in range(0, len(comp_ctx_lengths_prefill or [])):
                 lang_prefill = {
                     "batch_size": 1 if continuous_batching else batch_size,
                     "seq_len": prefill_seq_len,
@@ -1047,7 +1047,7 @@ class QEffQwen3VLForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
                 lang.append(lang_prefill)
 
-            for i in range(0, len(comp_ctx_lengths_decode)):
+            for i in range(0, len(comp_ctx_lengths_decode or [])):
                 lang_decode = {
                     "batch_size": full_batch_size if continuous_batching else batch_size,
                     "seq_len": "1",

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -1171,10 +1171,10 @@ class QEffQwen3VLMoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration)
                 }
             )
 
-        if comp_ctx_lengths_prefill is not None:
+        if comp_ctx_lengths_prefill is not None or comp_ctx_lengths_decode is not None:
             lang = []
 
-            for i in range(0, len(comp_ctx_lengths_prefill)):
+            for i in range(0, len(comp_ctx_lengths_prefill or [])):
                 lang_prefill = {
                     "batch_size": 1 if continuous_batching else batch_size,
                     "seq_len": prefill_seq_len,
@@ -1194,7 +1194,7 @@ class QEffQwen3VLMoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration)
 
                 lang.append(lang_prefill)
 
-            for i in range(0, len(comp_ctx_lengths_decode)):
+            for i in range(0, len(comp_ctx_lengths_decode or [])):
                 lang_decode = {
                     "batch_size": full_batch_size if continuous_batching else batch_size,
                     "seq_len": "1",

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
@@ -31,7 +31,9 @@ CTX_LEN = 2048
 GENERATION_LEN = 1920
 NUM_LANG_HIDDEN_LAYER = 2
 NUM_VISION_HIDDEN_LAYER = 2
-
+# For CCL activation
+# comp_ctx_lengths_prefill=[1024,2048]
+# comp_ctx_lengths_decode=[1024,2048]
 # NODE_PRECISION_INFO:Optional argument
 # If set to True, the NPI file will be generated automatically.
 # If a file path is provided, that file will be used for compilation.
@@ -53,6 +55,9 @@ compiler_kwargs = {
     "split_model_io": True,
     "BATCH_SIZE": BS,
     "node_precision_info": NODE_PRECISION_INFO,
+    ## For CCL activation
+    # "comp_ctx_lengths_prefill": comp_ctx_lengths_prefill,
+    # "comp_ctx_lengths_decode": comp_ctx_lengths_decode,
 }
 
 
@@ -92,6 +97,10 @@ def main():
         dtype="float32",
         kv_offload=True,
         ignore_mismatched_sizes=True,
+        ## For CCL activation
+        # qaic_config={
+        #     "ccl_enabled": True,
+        # },
     )
     remove_fp16clip_transform_if_disabled(qeff_model, True)
 

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
@@ -32,8 +32,8 @@ GENERATION_LEN = 1920
 NUM_LANG_HIDDEN_LAYER = 2
 NUM_VISION_HIDDEN_LAYER = 2
 # For CCL activation
-# comp_ctx_lengths_prefill=[1024,2048]
-# comp_ctx_lengths_decode=[1024,2048]
+# comp_ctx_lengths_prefill=[65536]
+# comp_ctx_lengths_decode=[4096]
 # NODE_PRECISION_INFO:Optional argument
 # If set to True, the NPI file will be generated automatically.
 # If a file path is provided, that file will be used for compilation.
@@ -130,6 +130,7 @@ def main():
             skip_vision=SKIP_VISION,
             **compiler_kwargs,
         )
+        # print("compile_kwargs:", compile_kwargs)
         qeff_model.compile(**compile_kwargs)
 
         output = qeff_model.generate(inputs=text_inputs, generation_len=GENERATION_LEN)
@@ -169,6 +170,7 @@ def main():
         skip_model_io=True,
         **compiler_kwargs,
     )
+    # print("compile_kwargs:", compile_kwargs)
 
     qeff_model.compile(**compile_kwargs)
 

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
@@ -32,8 +32,8 @@ GENERATION_LEN = 1920
 NUM_LANG_HIDDEN_LAYER = 2
 NUM_VISION_HIDDEN_LAYER = 2
 # For CCL activation
-# comp_ctx_lengths_prefill=[65536]
-# comp_ctx_lengths_decode=[4096]
+# comp_ctx_lengths_prefill=[2048]
+# comp_ctx_lengths_decode=[4096,65536]
 # NODE_PRECISION_INFO:Optional argument
 # If set to True, the NPI file will be generated automatically.
 # If a file path is provided, that file will be used for compilation.

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_utils.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_utils.py
@@ -66,7 +66,7 @@ def build_messages(system_prompt: str, user_prompt: str, use_image: bool):
 
 
 def build_compile_kwargs(*, effective_prefill_seq_len: int, effective_ctx_len: int, skip_vision: bool, **kwargs):
-    kwargs = {
+    compile_kwargs = {
         "prefill_seq_len": effective_prefill_seq_len,
         "ctx_len": effective_ctx_len,
         "num_cores": kwargs["NUM_CORES"],
@@ -80,13 +80,15 @@ def build_compile_kwargs(*, effective_prefill_seq_len: int, effective_ctx_len: i
         "batch_size": kwargs.get("BATCH_SIZE", 1),
         "node_precision_info": kwargs.get("node_precision_info", None),
     }
+    # Carry the Compute-Context-Length lists through to compile() when provided.
+    for key in ("comp_ctx_lengths_prefill", "comp_ctx_lengths_decode"):
+        if kwargs.get(key) is not None:
+            compile_kwargs[key] = kwargs[key]
     if skip_vision:
-        kwargs["skip_vision"] = True
-    if kwargs["node_precision_info"] is None:
-        kwargs["node_precision_info"] = False
-    return kwargs
-
-    return kwargs
+        compile_kwargs["skip_vision"] = True
+    if compile_kwargs["node_precision_info"] is None:
+        compile_kwargs["node_precision_info"] = False
+    return compile_kwargs
 
 
 def remove_fp16clip_transform_if_disabled(model, effective_fp16clip: bool):

--- a/examples/image_text_to_text/models/qwen3_5/qwen3_5.py
+++ b/examples/image_text_to_text/models/qwen3_5/qwen3_5.py
@@ -50,8 +50,8 @@ CTX_LEN = 4096
 
 # Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
 # ccl_enabled=True, they are auto-generated from CTX_LEN.
-# comp_ctx_lengths_prefill = [65536]
-# comp_ctx_lengths_decode = [4096, 16384, 32768, 65536]
+# comp_ctx_lengths_prefill = [2048]
+# comp_ctx_lengths_decode = [4096, 65536]
 
 if skip_vision:
     ## Only Text ##

--- a/examples/image_text_to_text/models/qwen3_5/qwen3_5.py
+++ b/examples/image_text_to_text/models/qwen3_5/qwen3_5.py
@@ -22,7 +22,14 @@ config = AutoConfig.from_pretrained(model_id)
 config.torch_dtype = "float32"
 
 qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
-    model_id, attn_implementation="eager", kv_offload=True, config=config
+    model_id,
+    attn_implementation="eager",
+    kv_offload=True,
+    config=config,
+    # # For CCL activation
+    # qaic_config={
+    #     "ccl_enabled": True,
+    # },
 )
 
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
@@ -41,6 +48,11 @@ BS = 1
 PREFILL_SEQ_LEN = 64
 CTX_LEN = 4096
 
+# Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
+# ccl_enabled=True, they are auto-generated from CTX_LEN.
+# comp_ctx_lengths_prefill = [65536]
+# comp_ctx_lengths_decode = [4096, 16384, 32768, 65536]
+
 if skip_vision:
     ## Only Text ##
 
@@ -49,7 +61,7 @@ if skip_vision:
         prefill_seq_len=PREFILL_SEQ_LEN,
         ctx_len=CTX_LEN,
         num_cores=16,
-        num_devices=1,
+        num_devices=4,
         mxfp6_matmul=True,
         mxint8_kv_cache=True,
         aic_enable_depth_first=False,
@@ -57,6 +69,8 @@ if skip_vision:
         mos=1,
         split_model_io=True,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
         # qaic_config=qaic_config,  # Enable KV blocking - comment out to disable
     )
 
@@ -128,6 +142,8 @@ else:
         mos=1,
         split_model_io=True,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
         # qaic_config=qaic_config,  # Enable KV blocking - comment out to disable
     )
 

--- a/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe.py
@@ -50,8 +50,8 @@ CTX_LEN = 4096
 
 # Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
 # ccl_enabled=True, they are auto-generated from CTX_LEN.
-# comp_ctx_lengths_prefill = [2048, 4096]
-# comp_ctx_lengths_decode = [2048, 4096]
+# comp_ctx_lengths_prefill = [2048]
+# comp_ctx_lengths_decode = [4096,65536]
 
 if skip_vision:
     ## Only Text ##

--- a/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe.py
@@ -13,7 +13,7 @@ from transformers import AutoConfig, AutoProcessor, TextStreamer
 
 from QEfficient import QEFFAutoModelForImageTextToText
 
-model_id = "Qwen/Qwen3.6-35B-A3B"
+model_id = "Qwen/Qwen3.5-35B-A3B"
 config = AutoConfig.from_pretrained(model_id)
 
 # For faster execution user can run with lesser layers, For Testing Purpose Only
@@ -22,7 +22,14 @@ config.text_config.num_hidden_layers = 4
 config.torch_dtype = "float32"
 
 qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
-    model_id, attn_implementation="eager", kv_offload=True, config=config
+    model_id,
+    attn_implementation="eager",
+    kv_offload=True,
+    config=config,
+    # # For CCL activation
+    # qaic_config={
+    #     "ccl_enabled": True,
+    # },
 )
 
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
@@ -41,6 +48,11 @@ BS = 1
 PREFILL_SEQ_LEN = 64
 CTX_LEN = 4096
 
+# Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
+# ccl_enabled=True, they are auto-generated from CTX_LEN.
+# comp_ctx_lengths_prefill = [2048, 4096]
+# comp_ctx_lengths_decode = [2048, 4096]
+
 if skip_vision:
     ## Only Text ##
 
@@ -58,6 +70,8 @@ if skip_vision:
         skip_vision=True,
         mos=1,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
         # qaic_config=qaic_config,  # Enable KV blocking - comment out to disable
     )
 
@@ -130,6 +144,8 @@ else:
         mxint8_kv_cache=False,
         aic_enable_depth_first=True,
         mos=1,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
         # qaic_config=qaic_config,  # Enable KV blocking - comment out to disable
     )
 

--- a/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -39,8 +39,8 @@ skip_vision = False
 
 # Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
 # ccl_enabled=True, they are auto-generated from ctx_len.
-# comp_ctx_lengths_prefill = [2048, 4096]
-# comp_ctx_lengths_decode = [2048, 4096]
+# comp_ctx_lengths_prefill = [2048]
+# comp_ctx_lengths_decode = [4096,65536]
 
 if skip_vision:
     ## Only Text ##

--- a/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -22,13 +22,25 @@ config = AutoConfig.from_pretrained(model_id)
 # config.vision_config.deepstack_visual_indexes = [8]
 
 qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
-    model_id, attn_implementation="eager", kv_offload=True, config=config
+    model_id,
+    attn_implementation="eager",
+    kv_offload=True,
+    config=config,
+    # For CCL activation
+    # qaic_config={
+    #     "ccl_enabled": True,
+    # },
 )
 
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
 processor = AutoProcessor.from_pretrained(model_id)
 ### use skip_vision=Ture, if want to run only text, or false ###
 skip_vision = False
+
+# Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
+# ccl_enabled=True, they are auto-generated from ctx_len.
+# comp_ctx_lengths_prefill = [2048, 4096]
+# comp_ctx_lengths_decode = [2048, 4096]
 
 if skip_vision:
     ## Only Text ##
@@ -47,6 +59,8 @@ if skip_vision:
         skip_vision=True,
         mos=1,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
 
     messages = [
@@ -91,6 +105,8 @@ else:
         aic_enable_depth_first=True,
         mos=1,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
 
     ### IMAGE + TEXT ###

--- a/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
+++ b/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
@@ -21,12 +21,24 @@ config = AutoConfig.from_pretrained(model_id)
 # config.vision_config.deepstack_visual_indexes = [8]
 
 qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
-    model_id, attn_implementation="eager", kv_offload=True, config=config
+    model_id,
+    attn_implementation="eager",
+    kv_offload=True,
+    config=config,
+    # # For CCL activation
+    # qaic_config={
+    #     "ccl_enabled": True,
+    # },
 )
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
 processor = AutoProcessor.from_pretrained(model_id)
 ### use skip_vision=Ture, if want to run only text, else false ###
-skip_vision = False
+skip_vision = True
+
+# Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
+# ccl_enabled=True, they are auto-generated from ctx_len.
+# comp_ctx_lengths_prefill = [2048, 4096]
+# comp_ctx_lengths_decode = [2048, 4096]
 
 if skip_vision:
     ## Only Text ##
@@ -46,6 +58,8 @@ if skip_vision:
         skip_vision=True,
         mos=1,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
 
     messages = [
@@ -90,6 +104,8 @@ else:
         aic_enable_depth_first=True,
         mos=1,
         use_onnx_subfunctions=False,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
 
     ### IMAGE + TEXT ###

--- a/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
+++ b/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
@@ -37,8 +37,8 @@ skip_vision = True
 
 # Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
 # ccl_enabled=True, they are auto-generated from ctx_len.
-# comp_ctx_lengths_prefill = [2048, 4096]
-# comp_ctx_lengths_decode = [2048, 4096]
+# comp_ctx_lengths_prefill = [2048]
+# comp_ctx_lengths_decode = [65536]
 
 if skip_vision:
     ## Only Text ##


### PR DESCRIPTION
Enable the compute-context-length (CCL) feature for the Gemma4 and Qwen3.5 image-text-to-text model families and fix CCL specialization gating so it also works for disaggregated (separate prefill/decode) serving.

Gemma4 (modeling_gemma4.py):
- Thread comp_ctx_lengths through the text model, decoder layer, and attention so the exported ONNX actually consumes it: slice the attention mask to the CCL width and pass "CCL" into cache_kwargs (mirrors Gemma3).
- Fix the dummy comp_ctx_lengths input dtype (int8 -> int64) so the traced ONNX input matches the int64 runtime buffer.
- Split the "prefill and decode" specialization gate into an OR so CCL is honored when only one of the prefill/decode lists is provided.

Qwen3.5 (modeling_qwen3_5.py, modeling_qwen3_5_moe.py):
- Fix the dummy comp_ctx_lengths input dtype (int8 -> int64).
- Add the missing comp_ctx_lengths pass-through on the MoE full-model forwards (QEffQwen3_5MoeModel, QEffQwen3_5MoeForConditionalGeneration) to match the non-MoE variant.
- Allow decode-only CCL specialization (gate -> OR, guard prefill loop).

Qwen3.5-VL (modeling_qwen3_vl.py, modeling_qwen3_vl_moe.py):
- Allow decode-only CCL specialization and guard both prefill/decode loops with `or []` to avoid a TypeError when one list is None (disaggregated serving).

Examples (gemma4_example.py, gemma4_utils.py):
- Carry comp_ctx_lengths_prefill/decode through build_compile_kwargs and document CCL activation in the example.

Important points to consider:
- In this support, for gemma4 and qwen3_5 models the use_onnx_subfunctions should be False to have CCL feature actually work for these models otherwise it will be compiled but CCL won't be effective. Related ongoing work is in progress to solve the source of this issue.
- I've already raised the following Jira ticket for this issue. Please track the changes there:
https://jira-dc.qualcomm.com/jira/browse/QRANIUMSW-63142
