### PR TITLE
nit (0720): fix bunch of things in modeling file, faster prefill export and subf fixes for qwen3-vl-moe

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -533,12 +533,13 @@ class QEFFBaseModel(ABC):
             kwargs.update(
                 {
                     "prefill_only": prefill_only,
-                    "prefill_seq_len": specializations[0].get("seq_len"),
+                    "prefill_seq_len": constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN,
                     "enable_chunking": enable_chunking,
                     "num_cores": compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES),
                     "moe_prefill_packed_chunk_size": constants.MOE_PREFILL_PACKED_CHUNK_SIZE
                     if moe_prefill_packed_chunk_size is None
                     else moe_prefill_packed_chunk_size,
+                    "moe_prefill_target_seq_len": specializations[0].get("seq_len"),
                 }
             )
 

--- a/QEfficient/blocking/blocked_attention_forwards.py
+++ b/QEfficient/blocking/blocked_attention_forwards.py
@@ -96,6 +96,7 @@ def update_running_softmax(
         output = output_updated
     return current_max, current_denominator, output
 
+
 def update_running_softmax_prefill(
     current_max: torch.Tensor,
     attn_weights_block: torch.Tensor,
@@ -110,19 +111,19 @@ def update_running_softmax_prefill(
     delta_max = prev_max - current_max_updated
     current_exp = torch.exp(attn_weights_block - current_max_updated.unsqueeze(-1))
     prev_denominator = current_denominator
-    curr_exp_sum = current_exp.sum(dim=-1)
+    curr_exp_sum = torch.einsum("bhqk->bhq", current_exp)
     current_denominator_updated = prev_denominator * torch.exp(delta_max) + curr_exp_sum
     prev_output = output
     output_updated = prev_output * torch.exp(delta_max.unsqueeze(-1)) + torch.matmul(current_exp, v_block)
     if skip_kv and (torch.onnx.is_in_onnx_export() or torch.jit.is_tracing()):
         assert skip_future is not None
-        current_max         = torch.where(skip_future, prev_max, current_max_updated)
+        current_max = torch.where(skip_future, prev_max, current_max_updated)
         current_denominator = torch.where(skip_future, prev_denominator, current_denominator_updated)
-        output              = torch.where(skip_future.unsqueeze(-1), prev_output, output_updated)
+        output = torch.where(skip_future.unsqueeze(-1), prev_output, output_updated)
     else:
-        current_max         = current_max_updated
+        current_max = current_max_updated
         current_denominator = current_denominator_updated
-        output              = output_updated
+        output = output_updated
     return current_max, current_denominator, output
 
 
@@ -320,13 +321,15 @@ def blocked_kv_attention_forward_decode_headpar_batch(
         )
         # [1, BH, seq_len, T_block] -> [1, BH, num_kv_groups*seq_len, T_block]
         # (tile, not interleave — query_flat's m-axis is rep-major/seq-minor: m = r*seq_len + q_pos)
-        causal_mask =  (
+        causal_mask = (
             causal_mask.unsqueeze(3)
             .expand(1, BH, seq_len, num_kv_groups, kv_len_block)
             .reshape(1, BH, seq_len * num_kv_groups, kv_len_block)
         )
-        attn_weights_block = torch.where(causal_mask, torch.full_like(attn_weights_block, float(MIN_MASKED_ATTENTION_VALUE)), attn_weights_block)
-        
+        attn_weights_block = torch.where(
+            causal_mask, torch.full_like(attn_weights_block, float(MIN_MASKED_ATTENTION_VALUE)), attn_weights_block
+        )
+
         # causal_mask = causal_mask.repeat(1, 1, num_kv_groups, 1)
         # attn_weights_block = attn_weights_block.masked_fill(causal_mask, float(MIN_MASKED_ATTENTION_VALUE))
 

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -3844,11 +3844,12 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         enable_chunking=False,
         num_cores: int = constants.DEFAULT_AIC_NUM_CORES,
         moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
+        moe_prefill_target_seq_len: Optional[int] = None,
     ) -> int:
         self.hash_params["prefill_only"] = True
         if enable_chunking:
             self.hash_params["chunking"] = True
-            compile_seq_len = prefill_seq_len or constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
+            compile_seq_len = moe_prefill_target_seq_len or prefill_seq_len or constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
             num_packed_chunks = max(1, -(-compile_seq_len // moe_prefill_packed_chunk_size))
             for module in self.model.modules():
                 if getattr(module, "supports_moe_prefill_blocking", False):
@@ -3941,6 +3942,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         prefill_seq_len: Optional[int] = None,
         num_cores: int = constants.DEFAULT_AIC_NUM_CORES,
         moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
+        moe_prefill_target_seq_len: Optional[int] = None,
         layerwise: bool = False,
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
@@ -3980,6 +3982,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                 prefill_seq_len=prefill_seq_len,
                 num_cores=num_cores,
                 moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
+                moe_prefill_target_seq_len=moe_prefill_target_seq_len or prefill_seq_len,
                 kv_cache_prefix=kv_cache_prefix,
                 **kwargs,
             )
@@ -4030,6 +4033,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                         enable_chunking=enable_chunking,
                         num_cores=num_cores,
                         moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
+                        moe_prefill_target_seq_len=moe_prefill_target_seq_len or prefill_seq_len,
                     )
                     sliding_window = getattr(self.model.config, "sliding_window", None)
                     kv_cache_shape[2] = (

--- a/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -45,6 +45,28 @@ from QEfficient.transformers.models._layerwise import is_last_layer_window, is_l
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
 
 
+class _TraceOnlyMatMul(torch.autograd.Function):
+    """Emit ONNX MatMul while skipping expensive CPU matmul during export tracing."""
+
+    @staticmethod
+    def forward(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+        return lhs.new_zeros((*lhs.shape[:-1], rhs.shape[-1]))
+
+    @staticmethod
+    def setup_context(ctx, inputs, outputs):
+        pass
+
+    @staticmethod
+    def symbolic(g: torch.Graph, lhs: torch.Value, rhs: torch.Value) -> torch.Value:
+        return g.op("MatMul", lhs, rhs)
+
+
+def _matmul_for_export(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+        return _TraceOnlyMatMul.apply(lhs, rhs)
+    return lhs @ rhs
+
+
 class QEffQwen3MoeRotaryEmbedding(Qwen3MoeRotaryEmbedding):
     def __init__(self, config: Qwen3MoeConfig, device=None):
         super().__init__(config=config)
@@ -136,29 +158,40 @@ def _cumsum_scatter_gather_update_expert_blocked(
     expert_out: torch.Tensor,
     act_fn,
     packed_chunk_size: int,
+    num_packed_chunks: Optional[int] = None,
 ) -> torch.Tensor:
     """Cumsum-scatter-gather-update expert helper for NSP-blocked dispatch.
 
-    Accumulates one local expert's contribution in-place onto ``expert_out``.
-    Uses a packed/cumsum layout so the MLP runs only over active rows, then
-    scatters the weighted output back to original token positions.
+    ``num_packed_chunks`` decouples export tensor length from target prefill
+    length, so a small dummy export can still emit the target packed loop count.
     """
     batch_size, seq_len = T2Ei.shape
-    packed_chunk_size = max(1, min(packed_chunk_size, seq_len))
+    packed_chunk_size = max(1, int(packed_chunk_size))
+    if num_packed_chunks is None:
+        packed_chunk_size = min(packed_chunk_size, seq_len)
+        num_packed_chunks = max(1, -(-seq_len // packed_chunk_size))
+    else:
+        num_packed_chunks = max(1, int(num_packed_chunks))
 
     matched_idx = _build_matched_idx_from_cumsum(T2Ei)
+    total_packed_rows = packed_chunk_size * num_packed_chunks
+    if total_packed_rows > seq_len:
+        int32_max = torch.iinfo(torch.int32).max
+        pad = matched_idx.new_full((batch_size, total_packed_rows - seq_len), int32_max)
+        matched_idx = torch.cat((matched_idx, pad), dim=1)
     valid_rows = torch.einsum("ij->i", T2Ei.to(torch.int32)).unsqueeze(1)
     row_range = torch.arange(packed_chunk_size, dtype=torch.int32, device=x.device).unsqueeze(0)
     x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
-    for packed_start in range(0, seq_len, packed_chunk_size):
+    for packed_idx in range(num_packed_chunks):
+        packed_start = packed_idx * packed_chunk_size
         packed_stop = packed_start + packed_chunk_size
         chunk_matched_idx = matched_idx[:, packed_start:packed_stop]
 
         x_chunk = CtxGatherFunc3DGeneralized.apply(x_expanded, chunk_matched_idx)
 
-        gate_prime = x_chunk @ W_g
-        up_prime = x_chunk @ W_u
-        down_chunk = (up_prime * act_fn(gate_prime)) @ W_d
+        gate_prime = _matmul_for_export(x_chunk, W_g)
+        up_prime = _matmul_for_export(x_chunk, W_u)
+        down_chunk = _matmul_for_export(up_prime * act_fn(gate_prime), W_d)
 
         rw_chunk = CtxGatherFunc3DGeneralized.apply(routing_weight, chunk_matched_idx)
         down_chunk = down_chunk * rw_chunk
@@ -239,6 +272,7 @@ class QEffPrefillChunkedQwen3MoeSparseMoeBlock(Qwen3MoeSparseMoeBlock):
 
         num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
         packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+        num_packed_chunks = getattr(self, "expert_blocking_num_packed_chunks", None)
         if self.num_experts % num_nsp != 0:
             raise ValueError(
                 f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
@@ -264,6 +298,7 @@ class QEffPrefillChunkedQwen3MoeSparseMoeBlock(Qwen3MoeSparseMoeBlock):
                 expert_out=expert_out,
                 act_fn=act_fn,
                 packed_chunk_size=packed_chunk_size,
+                num_packed_chunks=num_packed_chunks,
             )
         expert_out_sum = torch.einsum("nth->th", expert_out)
         return expert_out_sum.view(B, S, H), router_logits


### PR DESCRIPTION
Compiled with `-sub-functions` and ran on QAIC with inputs.

 Verified simplified API:
  - Tested:
      - tiny subfunction compile passed.
      - 2L 235B prefill subfunction compile passed.
      - 2L 235B prefill QPC runtime passed.