### PR TITLE
Prefill speedup and subfunction support

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -533,12 +533,13 @@ class QEFFBaseModel(ABC):
             kwargs.update(
                 {
                     "prefill_only": prefill_only,
-                    "prefill_seq_len": specializations[0].get("seq_len"),
+                    "prefill_seq_len": constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN,
                     "enable_chunking": enable_chunking,
                     "num_cores": compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES),
                     "moe_prefill_packed_chunk_size": constants.MOE_PREFILL_PACKED_CHUNK_SIZE
                     if moe_prefill_packed_chunk_size is None
                     else moe_prefill_packed_chunk_size,
+                    "moe_prefill_target_seq_len": specializations[0].get("seq_len"),
                 }
             )
 

--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -18,15 +18,15 @@ from onnx import ModelProto, TensorProto, external_data_helper, numpy_helper
 from QEfficient.customop.ctx_scatter_gather import (
     CtxChunkScatterBatch,
     CtxChunkScatterBatchFunc,
-    CtxGatherBlockedKVBatch,
-    CtxGatherFuncBlockedKVBatch,
     CtxGather,
     CtxGather3D,
     CtxGatherBlockedKV,
+    CtxGatherBlockedKVBatch,
     CtxGatherFunc,
     CtxGatherFunc3D,
     CtxGatherFunc3DGeneralized,
     CtxGatherFuncBlockedKV,
+    CtxGatherFuncBlockedKVBatch,
     CtxScatter,
     CtxScatter3D,
     CtxScatter3DInt,
@@ -114,7 +114,7 @@ class CustomOpTransform(BaseOnnxTransform):
         "CtxScatterFuncCB": (CtxScatterFuncCB, CtxScatterCB),
         "CtxGatherFuncCB": (CtxGatherFuncCB, CtxGatherCB),
         "CtxChunkScatterBatchFunc": (CtxChunkScatterBatchFunc, CtxChunkScatterBatch),
-        "CtxGatherFuncBlockedKVBatch": (CtxGatherFuncBlockedKVBatch, CtxGatherBlockedKVBatch)
+        "CtxGatherFuncBlockedKVBatch": (CtxGatherFuncBlockedKVBatch, CtxGatherBlockedKVBatch),
         # "CastToUInt4": (CastToUInt4Func, CastToUInt4),
     }
 

--- a/QEfficient/blocking/blocked_attention_forwards.py
+++ b/QEfficient/blocking/blocked_attention_forwards.py
@@ -96,6 +96,7 @@ def update_running_softmax(
         output = output_updated
     return current_max, current_denominator, output
 
+
 def update_running_softmax_prefill(
     current_max: torch.Tensor,
     attn_weights_block: torch.Tensor,
@@ -110,19 +111,19 @@ def update_running_softmax_prefill(
     delta_max = prev_max - current_max_updated
     current_exp = torch.exp(attn_weights_block - current_max_updated.unsqueeze(-1))
     prev_denominator = current_denominator
-    curr_exp_sum = current_exp.sum(dim=-1)
+    curr_exp_sum = torch.einsum("bhqk->bhq", current_exp)
     current_denominator_updated = prev_denominator * torch.exp(delta_max) + curr_exp_sum
     prev_output = output
     output_updated = prev_output * torch.exp(delta_max.unsqueeze(-1)) + torch.matmul(current_exp, v_block)
     if skip_kv and (torch.onnx.is_in_onnx_export() or torch.jit.is_tracing()):
         assert skip_future is not None
-        current_max         = torch.where(skip_future, prev_max, current_max_updated)
+        current_max = torch.where(skip_future, prev_max, current_max_updated)
         current_denominator = torch.where(skip_future, prev_denominator, current_denominator_updated)
-        output              = torch.where(skip_future.unsqueeze(-1), prev_output, output_updated)
+        output = torch.where(skip_future.unsqueeze(-1), prev_output, output_updated)
     else:
-        current_max         = current_max_updated
+        current_max = current_max_updated
         current_denominator = current_denominator_updated
-        output              = output_updated
+        output = output_updated
     return current_max, current_denominator, output
 
 
@@ -320,13 +321,15 @@ def blocked_kv_attention_forward_decode_headpar_batch(
         )
         # [1, BH, seq_len, T_block] -> [1, BH, num_kv_groups*seq_len, T_block]
         # (tile, not interleave — query_flat's m-axis is rep-major/seq-minor: m = r*seq_len + q_pos)
-        causal_mask =  (
+        causal_mask = (
             causal_mask.unsqueeze(3)
             .expand(1, BH, seq_len, num_kv_groups, kv_len_block)
             .reshape(1, BH, seq_len * num_kv_groups, kv_len_block)
         )
-        attn_weights_block = torch.where(causal_mask, torch.full_like(attn_weights_block, float(MIN_MASKED_ATTENTION_VALUE)), attn_weights_block)
-        
+        attn_weights_block = torch.where(
+            causal_mask, torch.full_like(attn_weights_block, float(MIN_MASKED_ATTENTION_VALUE)), attn_weights_block
+        )
+
         # causal_mask = causal_mask.repeat(1, 1, num_kv_groups, 1)
         # attn_weights_block = attn_weights_block.masked_fill(causal_mask, float(MIN_MASKED_ATTENTION_VALUE))
 

--- a/QEfficient/blocking/blocking_configurator.py
+++ b/QEfficient/blocking/blocking_configurator.py
@@ -367,7 +367,14 @@ def build_transformer_blocking_config_for_transform(
     else:
         blocking_config.mode = BlockingMode(mode_from_config)
 
-    for param in ("skip_kv", "prefill_block_chunks", "prefill_blocking_mode", "ctx_len", "batch_fold", "prefill_n_rep_chunk"):
+    for param in (
+        "skip_kv",
+        "prefill_block_chunks",
+        "prefill_blocking_mode",
+        "ctx_len",
+        "batch_fold",
+        "prefill_n_rep_chunk",
+    ):
         if qaic_config.get(param) is not None:
             setattr(blocking_config, param, qaic_config.get(param))
 

--- a/QEfficient/transformers/cache_utils.py
+++ b/QEfficient/transformers/cache_utils.py
@@ -478,13 +478,21 @@ class QEffDynamicLayer(CacheLayerMixin):
         """
         # Update the cache
         if self.keys is None:
-            self.keys = key_states.reshape(key_states.shape[0] * key_states.shape[1], key_states.shape[2], key_states.shape[3]).unsqueeze(0)
-            self.values = value_states.reshape(value_states.shape[0] * value_states.shape[1], value_states.shape[2], value_states.shape[3]).unsqueeze(0)
+            self.keys = key_states.reshape(
+                key_states.shape[0] * key_states.shape[1], key_states.shape[2], key_states.shape[3]
+            ).unsqueeze(0)
+            self.values = value_states.reshape(
+                value_states.shape[0] * value_states.shape[1], value_states.shape[2], value_states.shape[3]
+            ).unsqueeze(0)
             self._mark_initialized(self.keys)
         else:
             if self.keys.shape[0] != 1:
-                self.keys = self.keys.reshape(self.keys.shape[0] * self.keys.shape[1], self.keys.shape[2], self.keys.shape[3]).unsqueeze(0)
-                self.values = self.values.reshape(self.values.shape[0] * self.values.shape[1], self.values.shape[2], self.values.shape[3]).unsqueeze(0)
+                self.keys = self.keys.reshape(
+                    self.keys.shape[0] * self.keys.shape[1], self.keys.shape[2], self.keys.shape[3]
+                ).unsqueeze(0)
+                self.values = self.values.reshape(
+                    self.values.shape[0] * self.values.shape[1], self.values.shape[2], self.values.shape[3]
+                ).unsqueeze(0)
             self._mark_initialized(self.keys)
             position_ids = cache_kwargs.get("position_ids")
 

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -3844,11 +3844,12 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         enable_chunking=False,
         num_cores: int = constants.DEFAULT_AIC_NUM_CORES,
         moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
+        moe_prefill_target_seq_len: Optional[int] = None,
     ) -> int:
         self.hash_params["prefill_only"] = True
         if enable_chunking:
             self.hash_params["chunking"] = True
-            compile_seq_len = prefill_seq_len or constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
+            compile_seq_len = moe_prefill_target_seq_len or prefill_seq_len or constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
             num_packed_chunks = max(1, -(-compile_seq_len // moe_prefill_packed_chunk_size))
             for module in self.model.modules():
                 if getattr(module, "supports_moe_prefill_blocking", False):
@@ -3941,6 +3942,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
         prefill_seq_len: Optional[int] = None,
         num_cores: int = constants.DEFAULT_AIC_NUM_CORES,
         moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
+        moe_prefill_target_seq_len: Optional[int] = None,
         layerwise: bool = False,
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
@@ -3980,6 +3982,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                 prefill_seq_len=prefill_seq_len,
                 num_cores=num_cores,
                 moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
+                moe_prefill_target_seq_len=moe_prefill_target_seq_len or prefill_seq_len,
                 kv_cache_prefix=kv_cache_prefix,
                 **kwargs,
             )
@@ -4030,6 +4033,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                         enable_chunking=enable_chunking,
                         num_cores=num_cores,
                         moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
+                        moe_prefill_target_seq_len=moe_prefill_target_seq_len or prefill_seq_len,
                     )
                     sliding_window = getattr(self.model.config, "sliding_window", None)
                     kv_cache_shape[2] = (

--- a/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -45,6 +45,28 @@ from QEfficient.transformers.models._layerwise import is_last_layer_window, is_l
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
 
 
+class _TraceOnlyMatMul(torch.autograd.Function):
+    """Emit ONNX MatMul while skipping expensive CPU matmul during export tracing."""
+
+    @staticmethod
+    def forward(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+        return lhs.new_zeros((*lhs.shape[:-1], rhs.shape[-1]))
+
+    @staticmethod
+    def setup_context(ctx, inputs, outputs):
+        pass
+
+    @staticmethod
+    def symbolic(g: torch.Graph, lhs: torch.Value, rhs: torch.Value) -> torch.Value:
+        return g.op("MatMul", lhs, rhs)
+
+
+def _matmul_for_export(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+        return _TraceOnlyMatMul.apply(lhs, rhs)
+    return lhs @ rhs
+
+
 class QEffQwen3MoeRotaryEmbedding(Qwen3MoeRotaryEmbedding):
     def __init__(self, config: Qwen3MoeConfig, device=None):
         super().__init__(config=config)
@@ -136,29 +158,40 @@ def _cumsum_scatter_gather_update_expert_blocked(
     expert_out: torch.Tensor,
     act_fn,
     packed_chunk_size: int,
+    num_packed_chunks: Optional[int] = None,
 ) -> torch.Tensor:
     """Cumsum-scatter-gather-update expert helper for NSP-blocked dispatch.
 
-    Accumulates one local expert's contribution in-place onto ``expert_out``.
-    Uses a packed/cumsum layout so the MLP runs only over active rows, then
-    scatters the weighted output back to original token positions.
+    ``num_packed_chunks`` decouples export tensor length from target prefill
+    length, so a small dummy export can still emit the target packed loop count.
     """
     batch_size, seq_len = T2Ei.shape
-    packed_chunk_size = max(1, min(packed_chunk_size, seq_len))
+    packed_chunk_size = max(1, int(packed_chunk_size))
+    if num_packed_chunks is None:
+        packed_chunk_size = min(packed_chunk_size, seq_len)
+        num_packed_chunks = max(1, -(-seq_len // packed_chunk_size))
+    else:
+        num_packed_chunks = max(1, int(num_packed_chunks))
 
     matched_idx = _build_matched_idx_from_cumsum(T2Ei)
+    total_packed_rows = packed_chunk_size * num_packed_chunks
+    if total_packed_rows > seq_len:
+        int32_max = torch.iinfo(torch.int32).max
+        pad = matched_idx.new_full((batch_size, total_packed_rows - seq_len), int32_max)
+        matched_idx = torch.cat((matched_idx, pad), dim=1)
     valid_rows = torch.einsum("ij->i", T2Ei.to(torch.int32)).unsqueeze(1)
     row_range = torch.arange(packed_chunk_size, dtype=torch.int32, device=x.device).unsqueeze(0)
     x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
-    for packed_start in range(0, seq_len, packed_chunk_size):
+    for packed_idx in range(num_packed_chunks):
+        packed_start = packed_idx * packed_chunk_size
         packed_stop = packed_start + packed_chunk_size
         chunk_matched_idx = matched_idx[:, packed_start:packed_stop]
 
         x_chunk = CtxGatherFunc3DGeneralized.apply(x_expanded, chunk_matched_idx)
 
-        gate_prime = x_chunk @ W_g
-        up_prime = x_chunk @ W_u
-        down_chunk = (up_prime * act_fn(gate_prime)) @ W_d
+        gate_prime = _matmul_for_export(x_chunk, W_g)
+        up_prime = _matmul_for_export(x_chunk, W_u)
+        down_chunk = _matmul_for_export(up_prime * act_fn(gate_prime), W_d)
 
         rw_chunk = CtxGatherFunc3DGeneralized.apply(routing_weight, chunk_matched_idx)
         down_chunk = down_chunk * rw_chunk
@@ -239,6 +272,7 @@ class QEffPrefillChunkedQwen3MoeSparseMoeBlock(Qwen3MoeSparseMoeBlock):
 
         num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
         packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+        num_packed_chunks = getattr(self, "expert_blocking_num_packed_chunks", None)
         if self.num_experts % num_nsp != 0:
             raise ValueError(
                 f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
@@ -264,6 +298,7 @@ class QEffPrefillChunkedQwen3MoeSparseMoeBlock(Qwen3MoeSparseMoeBlock):
                 expert_out=expert_out,
                 act_fn=act_fn,
                 packed_chunk_size=packed_chunk_size,
+                num_packed_chunks=num_packed_chunks,
             )
         expert_out_sum = torch.einsum("nth->th", expert_out)
         return expert_out_sum.view(B, S, H), router_logits

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -58,6 +58,29 @@ from QEfficient.utils._utils import IOInfo, get_padding_shape_from_config
 from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE
 from QEfficient.utils.logging_utils import logger
 
+
+class _TraceOnlyMatMul(torch.autograd.Function):
+    """Emit ONNX MatMul while skipping expensive CPU matmul during export tracing."""
+
+    @staticmethod
+    def forward(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+        return lhs.new_zeros((*lhs.shape[:-1], rhs.shape[-1]))
+
+    @staticmethod
+    def setup_context(ctx, inputs, outputs):
+        pass
+
+    @staticmethod
+    def symbolic(g: torch.Graph, lhs: torch.Value, rhs: torch.Value) -> torch.Value:
+        return g.op("MatMul", lhs, rhs)
+
+
+def _matmul_for_export(lhs: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    if torch.onnx.is_in_onnx_export() or torch.jit.is_tracing():
+        return _TraceOnlyMatMul.apply(lhs, rhs)
+    return lhs @ rhs
+
+
 QWEN3_VL_ROPE_CACHE_EXPORT_CAP = 76800
 
 
@@ -977,24 +1000,41 @@ def cumsum_scatter_gather_update_one_local_expert(
     packed_chunk_size: int,
     router_weights=None,
     act_fn=F.silu,
+    num_packed_chunks: Optional[int] = None,
     **_unused_kwargs,
 ) -> torch.Tensor:
+    """Cumsum-scatter-gather-update expert helper for NSP-blocked dispatch.
+
+    ``num_packed_chunks`` decouples export tensor length from target prefill
+    length, so a small dummy export can still emit the target packed loop count.
+    """
     batch_size, seq_len = T2Ei.shape
-    packed_chunk_size = max(1, min(packed_chunk_size, seq_len))
+    packed_chunk_size = max(1, int(packed_chunk_size))
+    if num_packed_chunks is None:
+        packed_chunk_size = min(packed_chunk_size, seq_len)
+        num_packed_chunks = max(1, -(-seq_len // packed_chunk_size))
+    else:
+        num_packed_chunks = max(1, int(num_packed_chunks))
 
     matched_idx = build_matched_idx_from_cumsum(T2Ei)
+    total_packed_rows = packed_chunk_size * num_packed_chunks
+    if total_packed_rows > seq_len:
+        int32_max = torch.iinfo(torch.int32).max
+        pad = matched_idx.new_full((batch_size, total_packed_rows - seq_len), int32_max)
+        matched_idx = torch.cat((matched_idx, pad), dim=1)
     valid_rows = torch.einsum("ij->i", T2Ei.to(torch.int32)).unsqueeze(1)
     row_range = torch.arange(packed_chunk_size, dtype=torch.int32, device=x.device).unsqueeze(0)
     x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
 
-    for packed_start in range(0, seq_len, packed_chunk_size):
+    for packed_idx in range(num_packed_chunks):
+        packed_start = packed_idx * packed_chunk_size
         packed_stop = packed_start + packed_chunk_size
         chunk_matched_idx = matched_idx[:, packed_start:packed_stop]
 
         x_chunk = CtxGatherFunc3DGeneralized.apply(x_expanded, chunk_matched_idx)
-        gate_prime = x_chunk @ W_g
-        up_prime = x_chunk @ W_u
-        down_chunk = (up_prime * act_fn(gate_prime)) @ W_d
+        gate_prime = _matmul_for_export(x_chunk, W_g)
+        up_prime = _matmul_for_export(x_chunk, W_u)
+        down_chunk = _matmul_for_export(up_prime * act_fn(gate_prime), W_d)
 
         expert_out_chunk = CtxGatherFunc3DGeneralized.apply(expert_out, chunk_matched_idx)
         rw_chunk = CtxGatherFunc3DGeneralized.apply(router_weights, chunk_matched_idx)
@@ -1107,6 +1147,7 @@ class QEffQwen3VLMoeTextSparseMoeBlock(Qwen3VLMoeTextSparseMoeBlock):
         expert_out = torch.zeros(N, T, H, dtype=x_flat.dtype, device=x_flat.device)
 
         packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+        num_packed_chunks = getattr(self, "expert_blocking_num_packed_chunks", None)
         W_g = (
             self.experts.gate_proj.view(num_pipeline_stages, num_parallelized_experts, H, -1)
             .transpose(0, 1)
@@ -1133,6 +1174,7 @@ class QEffQwen3VLMoeTextSparseMoeBlock(Qwen3VLMoeTextSparseMoeBlock):
                 packed_chunk_size=packed_chunk_size,
                 router_weights=rw,
                 act_fn=self.experts.act_fn,
+                num_packed_chunks=num_packed_chunks,
             )
 
         def reduce_nsp_tree(values: torch.Tensor, num_lanes: int) -> torch.Tensor:
@@ -1188,6 +1230,8 @@ class QEffQwen3VLMoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration)
         **kwargs,
     ):
         bs = kwargs.get("batch_size", constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE)
+        if bs > 1:
+            bs = 2
 
         prefill_seq_len = kwargs.get("prefill_seq_len")
         if prefill_seq_len is None:
@@ -1229,11 +1273,7 @@ class QEffQwen3VLMoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration)
             (inputs_shapes["vision_embeds"]), dtype=self.model.config.torch_dtype
         )
         lang_inputs["position_ids"] = (
-            (
-                torch.arange(prefill_seq_len, dtype=torch.int64)
-                .view(1, prefill_seq_len)
-                .repeat(bs, 1)
-            )
+            (torch.arange(prefill_seq_len, dtype=torch.int64).view(1, prefill_seq_len).repeat(bs, 1))
             .unsqueeze(0)
             .repeat(4, 1, 1)
         )
@@ -1457,7 +1497,11 @@ class QEffQwen3VLMoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration)
             return lang, compiler_options
 
     def get_onnx_dynamic_axes(
-        self, comp_ctx_lengths: Optional[List[int]] = None, kv_offload: bool = False, continuous_batching: bool = False, batch_fold: bool = False,
+        self,
+        comp_ctx_lengths: Optional[List[int]] = None,
+        kv_offload: bool = False,
+        continuous_batching: bool = False,
+        batch_fold: bool = False,
     ):
         # Define dynamic axes
         num_layers = self.config.text_config.num_hidden_layers
@@ -1474,7 +1518,7 @@ class QEffQwen3VLMoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration)
             "deepstack_features": {0: "num_feature_layers", 1: "vision_batch_size", 2: "vision_size"},
         }
 
-        if batch_fold: # Cache layout is 1 x BH x ctx_len x head_dim
+        if batch_fold:  # Cache layout is 1 x BH x ctx_len x head_dim
             for i in range(num_layers):
                 lang_dynamic_axes[f"past_key.{i}"] = {
                     1: "BH",
@@ -1484,7 +1528,7 @@ class QEffQwen3VLMoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration)
                     1: "BH",
                     2: "ctx_len",
                 }
-        else: 
+        else:
             for i in range(num_layers):
                 lang_dynamic_axes[f"past_key.{i}"] = {
                     0: "full_batch_size" if continuous_batching else "batch_size",

--- a/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_disagg_mode.py
+++ b/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_disagg_mode.py
@@ -36,7 +36,7 @@ tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
 processor = AutoProcessor.from_pretrained(model_id)
 
 PREFILL_SEQ_LEN = 1024
-CTX_LEN = 2048 * 8
+CTX_LEN = 2048 * 2
 BS = 256
 
 NUM_KV_BLOCKS = 4
@@ -94,6 +94,7 @@ if not skip_vision:
     )
 decode_qaic_config = _qaic_config()
 print("decode", decode_qaic_config)
+decode_start_time = perf_counter()
 decode_qpc_path = qeff_model.compile(
     batch_size=BS,
     prefill_seq_len=1,
@@ -117,6 +118,9 @@ decode_qpc_path = qeff_model.compile(
     offload_pt_weights=False,
     qaic_config=decode_qaic_config,
 )
+print(f"Decode export + compile time is {(perf_counter() - decode_start_time):.3f}s")
+
+# exit(0)
 
 ################
 # Prefill modes:
@@ -131,7 +135,7 @@ MOE_PREFILL_PACKED_CHUNK_SIZE = 256
 prefill_qaic_config = _qaic_config()
 print("prefill", prefill_qaic_config)
 
-
+prefill_start_time = perf_counter()
 prefill_qpc_path = qeff_model.compile(
     batch_size=1,
     prefill_seq_len=PREFILL_SEQ_LEN,
@@ -155,6 +159,7 @@ prefill_qpc_path = qeff_model.compile(
     offload_pt_weights=True,
     qaic_config=prefill_qaic_config,
 )
+print(f"Prefill export + compile time is {(perf_counter() - prefill_start_time):.3f}s")
 
 print(f"Prefill qpc path {prefill_qpc_path}")
 print(f"Decode qpc path {decode_qpc_path}")
@@ -208,7 +213,7 @@ input_len = inputs["attention_mask"].sum(1, keepdims=True)
 input_ids_length = inputs["input_ids"].shape[1]
 num_chunks = -(input_ids_length // -PREFILL_SEQ_LEN)  # ceil divide without float
 padded_len = num_chunks * PREFILL_SEQ_LEN  # Convert to a multiple of prompt_len
-generation_len = CTX_LEN - input_len.max()
+generation_len = 30  # CTX_LEN - input_len.max()
 print(f"generation_len : {generation_len}")
 generated_ids = np.full((BS, generation_len + 1), pad_token_id)
 
@@ -299,7 +304,7 @@ st = perf_counter()
 decode_out = lang_decode_session.run(decode_inputs)
 print(f"time for first run of decode with KV as input = {perf_counter() - st} sec\n")
 
-exit(0)
+# exit(0)
 
 all_outputs.append(np.argmax(decode_out["logits"][0]))  # track batch 0
 pos_id = decode_inputs["position_ids"] + 1  # [BS, 1]
@@ -308,9 +313,9 @@ loop_decode_inputs = {
     "position_ids": pos_id,
 }
 
-for i in range(config.text_config.num_hidden_layers):
-    loop_decode_inputs[f"past_key.{i}"] = decode_out[f"past_key.{i}_RetainedState"]
-    loop_decode_inputs[f"past_value.{i}"] = decode_out[f"past_value.{i}_RetainedState"]
+# for i in range(config.text_config.num_hidden_layers):
+#     loop_decode_inputs[f"past_key.{i}"] = decode_out[f"past_key.{i}_RetainedState"]
+#     loop_decode_inputs[f"past_value.{i}"] = decode_out[f"past_value.{i}_RetainedState"]
 
 
 st = perf_counter()
@@ -318,9 +323,9 @@ for i in range(generation_len - 2):
     decode_out = lang_decode_session.run(loop_decode_inputs)
     all_outputs.append(np.argmax(decode_out["logits"][0]))
     pos_id += 1
-    for j in range(config.text_config.num_hidden_layers):
-        loop_decode_inputs[f"past_key.{j}"] = decode_out[f"past_key.{j}_RetainedState"]
-        loop_decode_inputs[f"past_value.{j}"] = decode_out[f"past_value.{j}_RetainedState"]
+    # for j in range(config.text_config.num_hidden_layers):
+    #     loop_decode_inputs[f"past_key.{j}"] = decode_out[f"past_key.{j}_RetainedState"]
+    #     loop_decode_inputs[f"past_value.{j}"] = decode_out[f"past_value.{j}_RetainedState"]
     loop_decode_inputs.update(
         {
             "input_ids": np.argmax(decode_out["logits"]).reshape(1, 1),

--- a/tests/unit_test/transforms/test_blocking_transform.py
+++ b/tests/unit_test/transforms/test_blocking_transform.py
@@ -266,7 +266,7 @@ class TestBlockingModes:
 
         model = make_tiny_llama()
         model, _ = KVCacheTransform.apply(model)
-        config = AttentionBlockingConfig(mode=mode, head_block_size=8, num_kv_blocks=2, num_q_blocks=2)
+        config = AttentionBlockingConfig(mode=mode, head_block_size=8, num_kv_blocks=2, num_q_blocks=2, ctx_len=128)
         model, transformed = BlockingAttentionTransform.apply(model, config)
 
         assert transformed
@@ -285,6 +285,7 @@ class TestBlockingModes:
             head_block_size=8,
             skip_kv=False,
             num_batch_blocks=1,
+            ctx_len=128,
         )
         model, transformed = BlockingAttentionTransform.apply(model, config)
 
@@ -314,7 +315,7 @@ class TestBlockingTransformIdempotent:
         model = make_tiny_llama()
         model, _ = KVCacheTransform.apply(model)
 
-        config1 = AttentionBlockingConfig(mode=BlockingMode.KV, num_kv_blocks=2)
+        config1 = AttentionBlockingConfig(mode=BlockingMode.KV, num_kv_blocks=2, ctx_len=1024)
         config2 = AttentionBlockingConfig(mode=BlockingMode.Q, num_q_blocks=4)
 
         model, _ = BlockingAttentionTransform.apply(model, config1)
@@ -358,7 +359,7 @@ class TestBlockingWrapperFallbackAndParity:
             def forward(self, *args, **kwargs):
                 return self.model(*args, **kwargs)
 
-        cfg = AttentionBlockingConfig(mode=BlockingMode.KV, num_kv_blocks=2)
+        cfg = AttentionBlockingConfig(mode=BlockingMode.KV, num_kv_blocks=2, ctx_len=128)
         wrapped = _WrapperWithoutConfig(_DeepseekContainer())
         wrapped, transformed = BlockingAttentionTransform.apply(wrapped, cfg)
 
@@ -369,7 +370,7 @@ class TestBlockingWrapperFallbackAndParity:
         "blocking_cfg",
         [
             AttentionBlockingConfig(mode=BlockingMode.NONE),
-            AttentionBlockingConfig(mode=BlockingMode.KV, num_kv_blocks=2),
+            AttentionBlockingConfig(mode=BlockingMode.KV, num_kv_blocks=2, ctx_len=128),
         ],
         ids=["mode_none", "mode_kv"],
     )


### PR DESCRIPTION
Added qwen3 moe optimizations to qwen3vl moe, and changed export BS to 2 if >1.

Checked e2e run, able to run generation with the example script:
`python examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_disagg_mode.py`
