### PR TITLE
feat: Replace num_replicate_kv_heads with boolean replicate_kv_heads flag

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -125,15 +125,19 @@ class QEFFBaseModel(ABC):
         if model_config is None or qaic_config is None or "EncoderWrapper" in self.model.__class__.__name__:
             return 1
 
-        num_replicate_kv_heads = qaic_config.get("num_replicate_kv_heads")
-        if num_replicate_kv_heads is None:
-            num_replicate_kv_heads = calculate_num_replicate_kv_heads(
-                num_devices=num_devices,
-                text_model_config=model_config,
-            )
-        if num_replicate_kv_heads is not None:
-            num_replicate_kv_heads = int(num_replicate_kv_heads)
-            qaic_config["num_replicate_kv_heads"] = num_replicate_kv_heads
+        replicate_kv_heads = qaic_config.get("replicate_kv_heads", False)
+
+        if not replicate_kv_heads:
+            return 1
+
+        text_config = getattr(model_config, "text_config", None)
+        effective_config = text_config if text_config is not None else model_config
+
+        num_replicate_kv_heads = calculate_num_replicate_kv_heads(
+            num_devices=num_devices,
+            text_model_config=effective_config,
+        )
+        num_replicate_kv_heads = int(num_replicate_kv_heads)
         if num_replicate_kv_heads is None or num_replicate_kv_heads <= 1:
             return 1
 

--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -137,7 +137,6 @@ class QEFFBaseModel(ABC):
             num_devices=num_devices,
             text_model_config=effective_config,
         )
-        num_replicate_kv_heads = int(num_replicate_kv_heads)
         if num_replicate_kv_heads is None or num_replicate_kv_heads <= 1:
             return 1
 

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1612,10 +1612,11 @@ class _QEffAutoModelForImageTextToTextDualQPC:
 
         # TODO: remove the current pt weight offload capability once CustomLoader is in place
         if offload_pt_weights is None:
-            if prefill_only and prefill_seq_len > 1:
+            if prefill_only and prefill_seq_len is not None and prefill_seq_len > 1:
                 offload_pt_weights = False  # keep weights resident for the decode export
             else:
-                offload_pt_weights = True
+                num_replicate_kv_heads = self.lang_model.hash_params.get("num_replicate_kv_heads", 1)
+                offload_pt_weights = num_replicate_kv_heads <= 1
 
         if not skip_lang:
             self.lang_model.export(

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1615,8 +1615,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             if prefill_only and prefill_seq_len is not None and prefill_seq_len > 1:
                 offload_pt_weights = False  # keep weights resident for the decode export
             else:
-                num_replicate_kv_heads = self.lang_model.hash_params.get("num_replicate_kv_heads", 1)
-                offload_pt_weights = num_replicate_kv_heads <= 1
+                offload_pt_weights = True
 
         if not skip_lang:
             self.lang_model.export(

--- a/QEfficient/utils/config_utils.py
+++ b/QEfficient/utils/config_utils.py
@@ -45,24 +45,25 @@ def calculate_num_replicate_kv_heads(num_devices: int, text_model_config) -> int
     Choose a KV-repeat value from model config and device count.
 
     Primary criteria:
-    1. num_kv_heads * repeat is divisible by num_devices
+    1. num_devices is divisible by num_kv_heads * repeat
     2. num_attention_heads is divisible by (num_kv_heads * repeat)
 
-    Fallback:
-    repeat = num_attention_heads / num_kv_heads (integer-truncated if needed).
+    Returns 1 if no valid repeat exists (replication not applicable or not achievable).
     """
     num_attention_heads = resolve_attention_heads(text_model_config)
     num_kv_heads = resolve_kv_heads(text_model_config)
 
     if num_attention_heads is None or num_kv_heads is None or num_attention_heads < 1 or num_kv_heads < 1:
-        return 1
+        return None
 
     num_devices = max(1, int(num_devices))
-    max_repeat = max(1, int(num_attention_heads / num_kv_heads))
-
-    for repeat in range(max_repeat, 0, -1):
-        repeated_kv_heads = num_kv_heads * repeat
-        if (repeated_kv_heads % num_devices == 0) and (num_attention_heads % repeated_kv_heads == 0):
+    max_repeat = max(1, num_attention_heads // num_kv_heads)
+    if num_devices <= num_kv_heads or num_devices % num_kv_heads != 0:
+        # Replication not possible with current configuration
+        return None
+    for repeat in range(2, max_repeat + 1):
+        new_kv_heads = num_kv_heads * repeat
+        if (num_devices % new_kv_heads == 0) and (num_attention_heads % new_kv_heads == 0):
             return repeat
 
     return 1

--- a/examples/kimi_k2/README.md
+++ b/examples/kimi_k2/README.md
@@ -20,9 +20,9 @@ mla_absorption has 3 keys:
 # Blocking
 We have also implemented KV head replication, HEAD Blocking and KV Blocking which can be enable like this : 
 - For No Blocking : qaic_config = {"mla_absorption" : mla_absorption}
-- For No blocking with kv head replication : qaic_config = {"mla_absorption" : mla_absorption, "num_replicate_kv_heads": TS}
+- For No blocking with kv head replication : qaic_config = {"mla_absorption" : mla_absorption, "replicate_kv_heads": True}
 - For KV blocking : qaic_config = {"mla_absorption" : mla_absorption, "enable_blocking": True, "blocking_mode": "kv"}  # for KV blocking
-- For Head Blocking : qaic_config = {"mla_absorption" : mla_absorption, "enable_blocking": True, "blocking_mode": "h", "num_replicate_kv_heads": TS} for h blocking, it internally sets head_block_size equal to num_devices/num_replicate_kv_heads
+- For Head Blocking : qaic_config = {"mla_absorption" : mla_absorption, "enable_blocking": True, "blocking_mode": "h", "replicate_kv_heads": True} for h blocking, it internally sets head_block_size equal to num_devices/num_replicate_kv_heads (computed)
 
 - Currently Decode-Only model is giving best perf with Head Blocking and compressed cache.
 - Contnuous batching is not enabled yet.

--- a/examples/kimi_k2/export_kimik2.py
+++ b/examples/kimi_k2/export_kimik2.py
@@ -18,16 +18,16 @@ mla_absorption = {"cache_compressed": True, "absorption": False, "online": False
 # qaic_config = None # Full PKV Cache
 # qaic_config = {"enable_blocking": True, "blocking_mode": "h"} # Full PKV Cache with Head Blocking
 # qaic_config = {"mla_absorption": mla_absorption} # for No Blocking
-# qaic_config = {"mla_absorption": mla_absorption, "num_replicate_kv_heads": TS}  # No blocking with kv head replication
+# qaic_config = {"mla_absorption": mla_absorption, "replicate_kv_heads": True}  # No blocking with kv head replication
 # qaic_config = {"mla_absorption": mla_absorption, "enable_blocking": True, "blocking_mode": "kv"}  # for KV blocking
-# qaic_config = {"mla_absorption": mla_absorption, "enable_blocking": True, "blocking_mode": "kv",  "num_replicate_kv_heads":TS} # for KV blocking with kv head replication
+# qaic_config = {"mla_absorption": mla_absorption, "enable_blocking": True, "blocking_mode": "kv", "replicate_kv_heads": True} # for KV blocking with kv head replication
 qaic_config = {
     "mla_absorption": mla_absorption,
     "enable_blocking": True,
     "blocking_mode": "h",
-    "num_replicate_kv_heads": TS,
+    "replicate_kv_heads": True,
 }
-# for h blocking, it internally sets head_block_size equal to num_devices/num_replicate_kv_heads
+# for h blocking, it internally sets head_block_size equal to num_devices/num_replicate_kv_heads (computed)
 
 model_name = "moonshotai/Kimi-K2-Thinking"
 model = AutoModelForCausalLM.from_pretrained(

--- a/examples/text_generation/run_kimik2.py
+++ b/examples/text_generation/run_kimik2.py
@@ -19,16 +19,16 @@ mla_absorption = {"cache_compressed": False, "absorption": False, "online": Fals
 # qaic_config = None # Full PKV Cache
 # qaic_config = {"enable_blocking": True, "blocking_mode": "h"} # Full PKV Cache with Head Blocking
 # qaic_config = {"mla_absorption": mla_absorption} # for No Blocking
-# qaic_config = {"mla_absorption": mla_absorption, "num_replicate_kv_heads": TS}  # No blocking with kv head replication
+# qaic_config = {"mla_absorption": mla_absorption, "replicate_kv_heads": True}  # No blocking with kv head replication
 # qaic_config = {"mla_absorption": mla_absorption, "enable_blocking": True, "blocking_mode": "kv"}  # for KV blocking
-# qaic_config = {"mla_absorption": mla_absorption, "enable_blocking": True, "blocking_mode": "kv",  "num_replicate_kv_heads":TS} # for KV blocking with kv head replication
+# qaic_config = {"mla_absorption": mla_absorption, "enable_blocking": True, "blocking_mode": "kv", "replicate_kv_heads": True} # for KV blocking with kv head replication
 qaic_config = {
     "mla_absorption": mla_absorption,
     "enable_blocking": True,
     "blocking_mode": "h",
-    "num_replicate_kv_heads": TS,
+    "replicate_kv_heads": True,
 }
-# for h blocking, it internally sets head_block_size equal to num_devices/num_replicate_kv_heads
+# for h blocking, it internally sets head_block_size equal to num_devices/num_replicate_kv_heads (computed)
 
 model_name = "moonshotai/Kimi-K2-Thinking"
 model = AutoModelForCausalLM.from_pretrained(

--- a/tests/configs/causal_model_configs.json
+++ b/tests/configs/causal_model_configs.json
@@ -303,12 +303,25 @@
       "model_name": "ibm-granite/granite-3.1-2b-instruct",
       "model_type": "granite",
       "additional_params": {
-        "max_position_embeddings": 128,
+        "max_position_embeddings": 64,
         "num_hidden_layers": 1,
         "num_attention_heads": 2,
         "hidden_size": 64,
         "intermediate_size": 256,
         "vocab_size": 49155,
+        "num_key_value_heads": 1
+      }
+    },
+    {
+      "model_name": "hpcai-tech/grok-1",
+      "model_type": null,
+      "additional_params": {
+        "max_position_embeddings": 64,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "hidden_size": 64,
+        "intermediate_size": 256,
+        "vocab_size": 131072,
         "num_key_value_heads": 1
       }
     },

--- a/tests/transformers/models/causal_lm_models/check_causal_models.py
+++ b/tests/transformers/models/causal_lm_models/check_causal_models.py
@@ -73,8 +73,6 @@ def check_kv_repeat_causal_lm_pytorch_vs_ai100(
             f"Invalid heads in config for RepeatKV: num_attention_heads ({num_attention_heads}) "
             f"is not divisible by num_key_value_heads ({num_key_value_heads})."
         )
-    num_replicate_kv_heads = num_attention_heads // num_key_value_heads
-
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         model_name=model_name,
         manual_cleanup=manual_cleanup,
@@ -82,7 +80,7 @@ def check_kv_repeat_causal_lm_pytorch_vs_ai100(
         ctx_len=ctx_len,
         n_layer=n_layer,
         config=config,
-        qaic_config={"num_replicate_kv_heads": num_replicate_kv_heads},
+        qaic_config={"replicate_kv_heads": True},
     )
 
 

--- a/tests/transformers/models/image_text_to_text/test_image_text_to_text_models.py
+++ b/tests/transformers/models/image_text_to_text/test_image_text_to_text_models.py
@@ -32,7 +32,6 @@ from QEfficient.utils.run_utils import ApiRunnerInternVL, ApiRunnerMolmo, ApiRun
 from QEfficient.utils.test_utils import (
     InternProcessor,
     ModelConfig,
-    get_text_config,
     load_vlm_model,
     load_vlm_model_from_config,
     set_num_layers_vlm,
@@ -90,10 +89,8 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
         )
         config = set_num_layers_vlm(config, n_layer=n_layer)
         if test_kv_replicate:
-            text_config = get_text_config(config)
-            num_replicate_kv_heads = text_config.num_attention_heads // text_config.num_key_value_heads
             qaic_config = qaic_config or {}
-            qaic_config["num_replicate_kv_heads"] = num_replicate_kv_heads
+            qaic_config["replicate_kv_heads"] = True
         if hasattr(config, "model_type") and config.model_type in ["gemma3"]:
             config.text_config._sliding_window_pattern = 2
             config.text_config.layer_types = ["sliding_attention", "full_attention"]
@@ -132,10 +129,8 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
             )
     else:
         if test_kv_replicate:
-            text_config = get_text_config(config)
-            num_replicate_kv_heads = text_config.num_attention_heads // text_config.num_key_value_heads
             qaic_config = qaic_config or {}
-            qaic_config["num_replicate_kv_heads"] = num_replicate_kv_heads
+            qaic_config["replicate_kv_heads"] = True
         model_hf = load_vlm_model_from_config(config)
         qeff_model = QEFFAutoModelForImageTextToText(
             copy.deepcopy(model_hf),

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -1195,7 +1195,7 @@ def test_repeat_kv_quickcheck_hf_qeff_ort_parity(tmp_path):
     )
     torch.manual_seed(0)
     model_hf = AutoModelForCausalLM.from_config(config, **MODEL_KWARGS).eval()
-    qeff_model = QEFFAutoModelForCausalLM(deepcopy(model_hf), qaic_config={"num_replicate_kv_heads": 2})
+    qeff_model = QEFFAutoModelForCausalLM(deepcopy(model_hf), qaic_config={"replicate_kv_heads": True})
 
     input_ids = torch.arange(1, 5, dtype=torch.int64).view(1, 4)
     position_ids = torch.arange(4, dtype=torch.int64).view(1, 4)

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -1211,7 +1211,7 @@ def test_repeat_kv_quickcheck_hf_qeff_ort_parity(tmp_path):
     with torch.no_grad():
         hf_logits = model_hf(input_ids=input_ids, position_ids=position_ids).logits[:, -1:, :].detach().numpy()
 
-    qeff_model.transform(ctx_len=8, seq_len=4, bs=1, qaic_config=qeff_model.model.qaic_config)
+    qeff_model.transform(ctx_len=8, seq_len=4, bs=1, num_devices=4, qaic_config=qeff_model.model.qaic_config)
     with torch.no_grad():
         qeff_logits = qeff_model.model(**inputs).logits.detach().numpy()
 

--- a/tests/unit_test/transforms/test_transform_accuracy.py
+++ b/tests/unit_test/transforms/test_transform_accuracy.py
@@ -244,6 +244,7 @@ class TestRepeatKVTransformFast:
             ctx_len=64,
             seq_len=8,
             batch_size=1,
+            num_devices=4,
             qaic_config={"replicate_kv_heads": True},
         )
 
@@ -297,6 +298,7 @@ class TestRepeatKVTransformFast:
             ctx_len=64,
             seq_len=8,
             batch_size=1,
+            num_devices=4,
             qaic_config={"replicate_kv_heads": True},
         )
 
@@ -312,9 +314,9 @@ class TestRepeatKVTransformFast:
 
     def test_repeat_kv_mqa_config(self):
         qeff_model = self._tiny_llama_qeff(num_attention_heads=4, num_key_value_heads=1)
-        qeff_model.transform(ctx_len=64, seq_len=8, bs=1, qaic_config={"replicate_kv_heads": True})
+        qeff_model.transform(ctx_len=64, seq_len=8, bs=1, num_devices=4, qaic_config={"replicate_kv_heads": True})
         assert qeff_model.model.config.orig_kv_heads == 1
-        assert qeff_model.model.config.num_key_value_heads == 4
+        assert qeff_model.model.config.num_key_value_heads == 2
 
     def test_repeat_kv_mutate_is_attention_local(self):
         qeff_model = self._tiny_llama_qeff()
@@ -392,8 +394,8 @@ class TestRepeatKVTransformFast:
         mqa_cfg = self._tiny_llama_qeff(num_attention_heads=4, num_key_value_heads=1).model.config
         mha_cfg = self._tiny_llama_qeff(num_attention_heads=4, num_key_value_heads=4).model.config
         assert calculate_num_replicate_kv_heads(num_devices=4, text_model_config=gqa_cfg) == 2
-        assert calculate_num_replicate_kv_heads(num_devices=4, text_model_config=mqa_cfg) == 4
-        assert calculate_num_replicate_kv_heads(num_devices=4, text_model_config=mha_cfg) == 1
+        assert calculate_num_replicate_kv_heads(num_devices=4, text_model_config=mqa_cfg) == 2
+        assert calculate_num_replicate_kv_heads(num_devices=4, text_model_config=mha_cfg) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_test/transforms/test_transform_accuracy.py
+++ b/tests/unit_test/transforms/test_transform_accuracy.py
@@ -244,7 +244,7 @@ class TestRepeatKVTransformFast:
             ctx_len=64,
             seq_len=8,
             batch_size=1,
-            qaic_config={"num_replicate_kv_heads": 2},
+            qaic_config={"replicate_kv_heads": True},
         )
 
         text_model_after = get_text_model(qeff_model.model)
@@ -297,7 +297,7 @@ class TestRepeatKVTransformFast:
             ctx_len=64,
             seq_len=8,
             batch_size=1,
-            qaic_config={"num_replicate_kv_heads": 2},
+            qaic_config={"replicate_kv_heads": True},
         )
 
         text_model_after = get_text_model(qeff_model.model)
@@ -312,7 +312,7 @@ class TestRepeatKVTransformFast:
 
     def test_repeat_kv_mqa_config(self):
         qeff_model = self._tiny_llama_qeff(num_attention_heads=4, num_key_value_heads=1)
-        qeff_model.transform(ctx_len=64, seq_len=8, bs=1, qaic_config={"num_replicate_kv_heads": 4})
+        qeff_model.transform(ctx_len=64, seq_len=8, bs=1, qaic_config={"replicate_kv_heads": True})
         assert qeff_model.model.config.orig_kv_heads == 1
         assert qeff_model.model.config.num_key_value_heads == 4
 
@@ -337,12 +337,12 @@ class TestRepeatKVTransformFast:
 
     def test_repeat_kv_rejects_mha_config(self):
         qeff_model = self._tiny_llama_qeff(num_attention_heads=4, num_key_value_heads=4)
-        with pytest.raises(ValueError, match="supported only for GQA/MQA"):
-            qeff_model.transform(ctx_len=64, seq_len=8, bs=1, qaic_config={"num_replicate_kv_heads": 2})
+        qeff_model.transform(ctx_len=64, seq_len=8, bs=1, qaic_config={"replicate_kv_heads": True})
+        assert qeff_model.model.config.num_key_value_heads == 4
 
     def test_repeat_kv_idempotent_for_same_repeat(self):
         qeff_model = self._tiny_llama_qeff()
-        qaic_config = {"num_replicate_kv_heads": 2}
+        qaic_config = {"replicate_kv_heads": True}
         qeff_model.transform(ctx_len=64, seq_len=8, bs=1, qaic_config=qaic_config)
         first_shape = get_projection_layer(
             get_attention_module(qeff_model.model.model.layers[0]), ("k_proj",)
@@ -384,7 +384,7 @@ class TestRepeatKVTransformFast:
         model_hf = AutoModelForImageTextToText.from_config(cfg)
         qeff_model = QEFFAutoModelForImageTextToText(copy.deepcopy(model_hf), kv_offload=True, qaic_config={})
         assert not hasattr(qeff_model.vision_model.model, "config")
-        qeff_model.vision_model.transform(ctx_len=64, seq_len=8, bs=1, qaic_config={"num_replicate_kv_heads": 2})
+        qeff_model.vision_model.transform(ctx_len=64, seq_len=8, bs=1, qaic_config={"replicate_kv_heads": True})
         assert qeff_model.vision_model.hash_params["num_replicate_kv_heads"] == 1
 
     def test_calculate_num_replicate_kv_heads_for_gqa_mqa_and_mha(self):


### PR DESCRIPTION
  - Replace user-facing num_replicate_kv_heads int param in qaic_configwith a boolean replicate_kv_heads flag; value computation is now fully internal and never exposed to the user.
  - maybe_apply_replicate_kv_transform reads only replicate_kv_headsfrom qaic_config; computed repeat factor is kept in hash_params and never written back into qaic_config.
  - Resolve model_config.text_config before calling calculate_num_replicate_kv_heads so VLM top-level configs correctly surface text-side head counts.