### PR TITLE
Moe gemma4 changes

### DIFF
--- a/QEfficient/transformers/modeling_utils.py
+++ b/QEfficient/transformers/modeling_utils.py
@@ -215,7 +215,7 @@ qeff_supported_architectures = ModelArchitectures(
 DYNAMIC_SEQ_LEN_SUPPORTED_MODEL_ARCH = {"gemma3", "gemma3_text", "gemma4_text", "llama4", "llama4_text"}
 
 # This is for supporting different modelling classes specially written for prefill-only model
-SPECIALIZED_DISAGG_SERVING_MODEL_ARCH = {"gpt_oss", "qwen3_moe", "glm4_moe", "kimi_k2", "kimi_k25"}
+SPECIALIZED_DISAGG_SERVING_MODEL_ARCH = {"gpt_oss", "qwen3_moe", "glm4_moe", "kimi_k2", "kimi_k25", "gemma4"}
 
 _PROXY_ONLY_ONNX_TRANSFORMS = (FP16ClipTransform, SplitTensorsTransform)
 

--- a/QEfficient/transformers/modeling_utils.py
+++ b/QEfficient/transformers/modeling_utils.py
@@ -217,6 +217,9 @@ DYNAMIC_SEQ_LEN_SUPPORTED_MODEL_ARCH = {"gemma3", "gemma3_text", "gemma4_text", 
 # This is for supporting different modelling classes specially written for prefill-only model
 SPECIALIZED_DISAGG_SERVING_MODEL_ARCH = {"gpt_oss", "qwen3_moe", "glm4_moe", "kimi_k2", "kimi_k25", "gemma4"}
 
+# This is for supporting dynamic prefill sequence length for prefill_only model
+DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH = {"gemma4"}
+
 _PROXY_ONLY_ONNX_TRANSFORMS = (FP16ClipTransform, SplitTensorsTransform)
 
 

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -390,13 +390,35 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
     supports_moe_prefill_blocking = True
 
     def __qeff_init__(self):
+        H = self.hidden_dim
         # Derive gather-friendly split projections from the checkpoint's fused
         # gate_up_proj/down_proj, without changing on-disk checkpoint format.
         gate_up_proj = self.gate_up_proj.detach()
         down_proj = self.down_proj.detach()
-        self.gate_proj = nn.Parameter(gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2), requires_grad=False)
-        self.up_proj = nn.Parameter(gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2), requires_grad=False)
-        self.down_proj_t = nn.Parameter(down_proj.transpose(1, 2), requires_grad=False)
+        self.gate_proj_t = gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2)
+        self.up_proj_t = gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2)
+        self.num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
+        if self.num_experts % self.num_nsp != 0:
+            raise ValueError(
+                f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({self.num_nsp})"
+            )
+        self.local_experts = self.num_experts // self.num_nsp
+        self.W_g = nn.Parameter(
+            self.gate_proj_t.view(self.local_experts, self.num_nsp, H, -1).transpose(0, 1).contiguous().clone(),
+            requires_grad=False,
+        )
+        self.W_u = nn.Parameter(
+            self.up_proj_t.view(self.local_experts, self.num_nsp, H, -1).transpose(0, 1).contiguous().clone(),
+            requires_grad=False,
+        )
+        self.W_d = nn.Parameter(
+            down_proj.transpose(1, 2)
+            .view(self.local_experts, self.num_nsp, -1, H)
+            .transpose(0, 1)
+            .contiguous()
+            .clone(),
+            requires_grad=False,
+        )
 
     def forward(
         self,
@@ -416,6 +438,8 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
 
         T = x.shape[0]
 
+        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+
         # Build dense routing weights [T, E] from top-k indices/weights
         expert_weights = torch.zeros(
             T,
@@ -425,27 +449,23 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
         )
         expert_weights.scatter_add_(1, top_k_index, top_k_weights)
         expert_weights = expert_weights.to(x.dtype)
-        num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
-        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
-        if self.num_experts % num_nsp != 0:
-            raise ValueError(
-                f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
-            )
-        local_experts = self.num_experts // num_nsp
-        rw = expert_weights.transpose(0, 1).contiguous().view(local_experts, num_nsp, T).transpose(0, 1).contiguous()
-        W_g = self.gate_proj.view(local_experts, num_nsp, H, -1).transpose(0, 1).contiguous()
-        W_u = self.up_proj.view(local_experts, num_nsp, H, -1).transpose(0, 1).contiguous()
-        W_d = self.down_proj_t.view(local_experts, num_nsp, -1, H).transpose(0, 1).contiguous()
-        expert_out = x.new_zeros((num_nsp, T, H))
+        expert_out = x.new_zeros((self.num_nsp, T, H))
+        rw = (
+            expert_weights.transpose(0, 1)
+            .contiguous()
+            .view(self.local_experts, self.num_nsp, T)
+            .transpose(0, 1)
+            .contiguous()
+        )
         routing_weights_unsqueezed = rw.unsqueeze(-1)
-        for slot in range(local_experts):
+        for slot in range(self.local_experts):
             T2Ei = rw[:, slot, :] > 0
             expert_out = _cumsum_scatter_gather_update_expert_blocked(
                 x=x,
                 T2Ei=T2Ei,
-                W_g=W_g[:, slot],
-                W_u=W_u[:, slot],
-                W_d=W_d[:, slot],
+                W_g=self.W_g[:, slot],
+                W_u=self.W_u[:, slot],
+                W_d=self.W_d[:, slot],
                 routing_weight=routing_weights_unsqueezed[:, slot],
                 expert_out=expert_out,
                 act_fn=self.act_fn,
@@ -1428,8 +1448,8 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         continuous_batching: bool = False,
         **kwargs,
     ):
-        seq_len = kwargs.get("prefill_seq_len")
-        bs = kwargs.get("batch_size")
+        seq_len = kwargs.get("prefill_seq_len", None)
+        bs = kwargs.get("batch_size", None)
         if seq_len is None:
             seq_len = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
         seq_len = int(seq_len)

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -342,7 +342,7 @@ def _cumsum_scatter_gather_update_expert_blocked(
     routing_weight: torch.Tensor,
     expert_out: torch.Tensor,
     act_fn,
-    packed_chunk_size: int,
+    num_packed_chunks: int,
 ) -> torch.Tensor:
     """Cumsum-scatter-gather-update expert helper for NSP-blocked dispatch.
 
@@ -351,18 +351,24 @@ def _cumsum_scatter_gather_update_expert_blocked(
     scatters the weighted output back to original token positions.
     """
     batch_size, seq_len = T2Ei.shape
-    packed_chunk_size = max(1, min(packed_chunk_size, seq_len))
-
+    num_packed_chunks = max(1, int(num_packed_chunks))
+    assert seq_len % num_packed_chunks == 0, (
+        f"seq_len={seq_len} must be divisible by num_packed_chunks={num_packed_chunks}"
+    )
+    packed_chunk_size = seq_len // num_packed_chunks
     matched_idx = _build_matched_idx_from_cumsum(T2Ei)
     valid_rows = torch.einsum("ij->i", T2Ei.to(torch.int32)).unsqueeze(1)
-    row_range = torch.arange(packed_chunk_size, dtype=torch.int32, device=x.device).unsqueeze(0)
     x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
-    for packed_start in range(0, seq_len, packed_chunk_size):
-        packed_stop = packed_start + packed_chunk_size
+    for chunk_idx in range(num_packed_chunks):
+        packed_start = chunk_idx * packed_chunk_size
+        if chunk_idx == num_packed_chunks - 1:
+            packed_stop = seq_len
+        else:
+            packed_stop = packed_start + packed_chunk_size
+        chunk_rows = packed_stop - packed_start
+        row_range = torch.arange(chunk_rows, dtype=torch.int32, device=x.device).unsqueeze(0)
         chunk_matched_idx = matched_idx[:, packed_start:packed_stop]
-
         x_chunk = CtxGatherFunc3DGeneralized.apply(x_expanded, chunk_matched_idx)
-
         gate_prime = x_chunk @ W_g
         up_prime = x_chunk @ W_u
         down_chunk = (up_prime * act_fn(gate_prime)) @ W_d
@@ -438,7 +444,7 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
 
         T = x.shape[0]
 
-        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+        num_packed_chunks = getattr(self, "expert_blocking_packed_chunk_size", T)
 
         # Build dense routing weights [T, E] from top-k indices/weights
         expert_weights = torch.zeros(
@@ -469,7 +475,7 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
                 routing_weight=routing_weights_unsqueezed[:, slot],
                 expert_out=expert_out,
                 act_fn=self.act_fn,
-                packed_chunk_size=packed_chunk_size,
+                num_packed_chunks=num_packed_chunks,
             )
         expert_output = torch.einsum("ijk->jk", expert_out)
         if reshape_back:

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -7,7 +7,7 @@
 
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Tuple, Type, Union
 
 import onnx
 import torch
@@ -27,6 +27,7 @@ from transformers.models.gemma4.modeling_gemma4 import (
     Gemma4VisionAttention,
     apply_rotary_pos_emb,
     eager_attention_forward,
+    repeat_kv,
 )
 
 from QEfficient.customop.ctx_scatter_gather import (
@@ -96,7 +97,7 @@ def _build_additive_attention_mask(
         target_length=target_length,
         sliding_window=sliding_window,
     )
-    return causal_mask.to(dtype=dtype) * _attention_mask_min(dtype, causal_mask.device)
+    return causal_mask
 
 
 def _build_bidirectional_vision_attention_mask(
@@ -117,7 +118,7 @@ def _build_bidirectional_vision_attention_mask(
         sliding_window=sliding_window,
     )
     if mm_token_type_ids is None:
-        return base_mask.to(dtype=dtype) * _attention_mask_min(dtype, base_mask.device)
+        return base_mask
 
     is_vision = (mm_token_type_ids == 1) | (mm_token_type_ids == 2)
     is_prev_vision = torch.roll(is_vision, shifts=1, dims=-1)
@@ -134,7 +135,7 @@ def _build_bidirectional_vision_attention_mask(
 
     same_group = (vision_group_ids.unsqueeze(-1) == kv_group_ids.unsqueeze(1)) & (vision_group_ids.unsqueeze(-1) >= 0)
     attention_mask = base_mask & ~same_group.unsqueeze(1)
-    return attention_mask.to(dtype=dtype) * _attention_mask_min(dtype, attention_mask.device)
+    return attention_mask
 
 
 def apply_multidimensional_rope(
@@ -193,6 +194,40 @@ def apply_multidimensional_rope(
         unsqueeze_dim=unsqueeze_dim,
     )
     return y_grouped.reshape(*x.shape[:-1], total_rotated_channels)
+
+
+def eager_attention_forward_text(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    dropout: float = 0.0,
+    scaling: Optional[float] = None,
+    softcap: Optional[float] = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if softcap is not None:
+        attn_weights = attn_weights / softcap
+        attn_weights = torch.tanh(attn_weights)
+        attn_weights = attn_weights * softcap
+
+    if attention_mask is not None:
+        attn_weights = torch.where(
+            attention_mask,
+            torch.tensor(constants.MIN_MASKED_ATTENTION_VALUE, dtype=module.config.torch_dtype),
+            attn_weights,
+        )
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+
+    return attn_output, attn_weights
 
 
 class QEffGemma4TextRouter(Gemma4TextRouter):
@@ -616,7 +651,7 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
                 sliding_window=self.sliding_window,
             )
 
-        attn_output, attn_weights = eager_attention_forward(
+        attn_output, attn_weights = eager_attention_forward_text(
             self,
             query_states,
             key_states,

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional, Type, Union
 
-import numpy as np
 import onnx
 import torch
 import torch.nn as nn
@@ -31,7 +30,6 @@ from transformers.models.gemma4.modeling_gemma4 import (
     eager_attention_forward,
 )
 
-from QEfficient.base.onnx_transforms import FP16ClipTransform
 from QEfficient.customop.ctx_scatter_gather import (
     CtxGatherFunc3DGeneralized,
     CtxScatterFunc3DGeneralized,
@@ -327,9 +325,7 @@ def _build_matched_idx_from_cumsum(T2Ei: torch.Tensor) -> torch.Tensor:
     valid_prefix = torch.cumsum(T2Ei.to(torch.int32), dim=1)
     valid_dest = valid_prefix - 1
     scatter_pos = torch.where(T2Ei, valid_dest, int32_max_scalar)
-    # Once the compiler fix for ConstantOfShape(INT32_MAX) is available, this
-    # can be switched back to ``torch.full_like(token_idx, int32_max)``.
-    matched_idx = int32_max_scalar.expand_as(token_idx)
+    matched_idx = torch.full_like(token_idx, int32_max)
     matched_idx = CtxScatterFunc3DInt.apply(
         matched_idx.unsqueeze(-1),
         scatter_pos,
@@ -430,8 +426,8 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
         )
         expert_weights.scatter_add_(1, top_k_index, top_k_weights)
         expert_weights = expert_weights.to(x.dtype)
-        num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
-        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+        num_nsp = EXPERT_BLOCKING_NUM_NSP
+        packed_chunk_size = EXPERT_BLOCKING_PACKED_CHUNK_SIZE
         if self.num_experts % num_nsp != 0:
             raise ValueError(
                 f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
@@ -613,7 +609,7 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
 
 
 EXPERT_BLOCKING_NUM_NSP = int(os.environ.get("EXPERT_BLOCKING_NUM_NSP", "16"))
-EXPERT_BLOCKING_PACKED_CHUNK_SIZE = int(os.environ.get("EXPERT_BLOCKING_PACKED_CHUNK_SIZE", "296"))
+EXPERT_BLOCKING_PACKED_CHUNK_SIZE = int(os.environ.get("EXPERT_BLOCKING_PACKED_CHUNK_SIZE", "256"))
 
 
 class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
@@ -1431,13 +1427,21 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         return past_key_values
 
     def get_dummy_inputs(
-        self, comp_ctx_lengths: Optional[List[int]] = None, kv_offload: bool = False, continuous_batching: bool = False
+        self,
+        comp_ctx_lengths: Optional[List[int]] = None,
+        kv_offload: bool = False,
+        continuous_batching: bool = False,
+        **kwargs,
     ):
+        seq_len = kwargs.get("prefill_seq_len")
+        if seq_len is None:
+            seq_len = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
+        seq_len = int(seq_len)
+
         bs = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
         fbs = constants.ONNX_EXPORT_EXAMPLE_FBS
         max_patches = self._get_vision_max_patches()
         mm_tokens_per_image = self._get_mm_tokens_per_image()
-        seq_len = max(constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN, mm_tokens_per_image + 32)
         patch_dim = getattr(self.config.vision_config, "patch_size", 16) ** 2 * 3
 
         image_position_ids = torch.full((bs, max_patches, 2), -1, dtype=torch.int64)
@@ -1479,42 +1483,3 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         if kv_offload:
             return {"vision": vision_inputs, "lang": lang_inputs}
         return {**vision_inputs, **lang_inputs}
-
-    def remove_fp16clip_transform_if_disabled(self, effective_fp16clip: bool):
-        """
-        Remove FP16ClipTransform from ONNX transforms when FP16 clipping is disabled.
-        """
-        if not effective_fp16clip:
-            # ---- language model
-            if hasattr(self, "lang_model") and hasattr(self.lang_model, "_onnx_transforms"):
-                self.lang_model._onnx_transforms = [
-                    t for t in self.lang_model._onnx_transforms if t is not FP16ClipTransform
-                ]
-
-            # ---- vision model (optional)
-            if getattr(self, "vision_model", None) is not None:
-                if hasattr(self.vision_model, "_onnx_transforms"):
-                    self.vision_model._onnx_transforms = [
-                        t for t in self.vision_model._onnx_transforms if t is not FP16ClipTransform
-                    ]
-
-    def normalize_generated_ids(self, generated_ids):
-        array = np.asarray(generated_ids)
-        if array.dtype == object:
-            array = np.asarray([np.asarray(row).reshape(-1) for row in generated_ids], dtype=np.int64)
-        array = np.asarray(array)
-        if array.ndim == 1:
-            array = array.reshape(1, -1)
-        elif array.ndim > 2:
-            array = array.reshape(array.shape[0], -1)
-        return array.astype(np.int64, copy=False)
-
-    def effective_lens(
-        self, prefill_seq_len: int, ctx_len: int, prompt_len: int, generation_len: int, skip_vision: bool
-    ):
-        effective_ctx_len = max(ctx_len, prompt_len + generation_len)
-        if skip_vision:
-            effective_prefill_seq_len = prefill_seq_len
-        else:
-            effective_prefill_seq_len = max(prefill_seq_len, prompt_len)
-        return effective_prefill_seq_len, effective_ctx_len

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -279,29 +279,38 @@ class QEffGemma4CustomRMSNormAIC(nn.Module):
 
 
 class QEffGemma4TextExperts(Gemma4TextExperts):
+    def __qeff_init__(self):
+        # Derive gather-friendly split projections from the checkpoint's fused
+        # gate_up_proj/down_proj, without changing on-disk checkpoint format.
+        # Mirrors QEffQwen3_5MoeExperts.__qeff_init__.
+        gate_up_proj = self.gate_up_proj.detach()
+        down_proj = self.down_proj.detach()
+        self.gate_proj = nn.Parameter(gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2), requires_grad=False)
+        self.up_proj = nn.Parameter(gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2), requires_grad=False)
+        self.down_proj_t = nn.Parameter(down_proj.transpose(1, 2), requires_grad=False)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         top_k_index: torch.Tensor,
         top_k_weights: torch.Tensor,
     ) -> torch.Tensor:
-        gate_up_proj_t = self.gate_up_proj.transpose(1, 2)
-        gate_up_out = torch.matmul(hidden_states, gate_up_proj_t).permute(1, 0, 2)
-        gate, up = gate_up_out.chunk(2, dim=-1)
+        T, H = hidden_states.shape
+        K = top_k_index.shape[1]
+        idx = top_k_index.reshape(-1)
+
+        gate_proj = self.gate_proj[idx]  # [T*K, H, I] -- gather only the selected experts
+        up_proj = self.up_proj[idx]  # [T*K, H, I]
+        down_proj_t = self.down_proj_t[idx]  # [T*K, I, H]
+
+        xk = hidden_states.unsqueeze(1).expand(-1, K, -1).contiguous().view(-1, 1, H)  # [T*K, 1, H]
+        gate = torch.bmm(xk, gate_proj)  # [T*K, 1, I]
+        up = torch.bmm(xk, up_proj)  # [T*K, 1, I]
         activated = self.act_fn(gate) * up
 
-        down_proj_t = self.down_proj.transpose(1, 2)
-        experts_out = torch.matmul(activated.permute(1, 0, 2), down_proj_t).permute(1, 0, 2)
-        expert_weights = torch.zeros(
-            hidden_states.shape[0],
-            self.num_experts,
-            dtype=top_k_weights.dtype,
-            device=top_k_weights.device,
-        )
-        expert_weights.scatter_add_(1, top_k_index, top_k_weights)
-        weighted_experts = experts_out.transpose(1, 2)  # [tokens, hidden, num_experts]
-        combine_weights = expert_weights.to(experts_out.dtype).unsqueeze(-1)  # [tokens, num_experts, 1]
-        return torch.bmm(weighted_experts, combine_weights).squeeze(-1)
+        down = torch.bmm(activated, down_proj_t)  # [T*K, 1, H]
+        down = down.view(T, K, H) * top_k_weights.unsqueeze(-1)
+        return down.sum(dim=1)  # [T, H]
 
 
 class QEffPrefillChunckedGemma4TextExperts(Gemma4TextExperts):

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -615,9 +615,12 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
             token_key_states, token_value_states = key_states, value_states
 
         if past_key_values is not None:
-            if comp_ctx_lengths is not None and attention_mask is not None:
-                attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
-                cache_kwargs["CCL"] = attention_mask.shape[-1]
+            if comp_ctx_lengths is not None:
+                if attention_mask is not None:
+                    attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
+                    cache_kwargs["CCL"] = attention_mask.shape[-1]
+                elif self.sliding_window is None:
+                    cache_kwargs["CCL"] = comp_ctx_lengths.shape[-1]
             if self.is_kv_shared_layer:
                 if token_key_states is not None and token_value_states is not None:
                     key_states, value_states = past_key_values.update(

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -282,7 +282,6 @@ class QEffGemma4TextExperts(Gemma4TextExperts):
     def __qeff_init__(self):
         # Derive gather-friendly split projections from the checkpoint's fused
         # gate_up_proj/down_proj, without changing on-disk checkpoint format.
-        # Mirrors QEffQwen3_5MoeExperts.__qeff_init__.
         gate_up_proj = self.gate_up_proj.detach()
         down_proj = self.down_proj.detach()
         self.gate_proj = nn.Parameter(gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2), requires_grad=False)

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -5,7 +5,6 @@
 #
 # -----------------------------------------------------------------------------
 
-import os
 from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional, Type, Union
@@ -426,8 +425,8 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
         )
         expert_weights.scatter_add_(1, top_k_index, top_k_weights)
         expert_weights = expert_weights.to(x.dtype)
-        num_nsp = EXPERT_BLOCKING_NUM_NSP
-        packed_chunk_size = EXPERT_BLOCKING_PACKED_CHUNK_SIZE
+        num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
+        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
         if self.num_experts % num_nsp != 0:
             raise ValueError(
                 f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
@@ -606,10 +605,6 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
-
-
-EXPERT_BLOCKING_NUM_NSP = int(os.environ.get("EXPERT_BLOCKING_NUM_NSP", "16"))
-EXPERT_BLOCKING_PACKED_CHUNK_SIZE = int(os.environ.get("EXPERT_BLOCKING_PACKED_CHUNK_SIZE", "256"))
 
 
 class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
@@ -1434,11 +1429,13 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         **kwargs,
     ):
         seq_len = kwargs.get("prefill_seq_len")
+        bs = kwargs.get("batch_size")
         if seq_len is None:
             seq_len = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
         seq_len = int(seq_len)
-
-        bs = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
+        if bs is None:
+            bs = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
+        bs = int(bs)
         fbs = constants.ONNX_EXPORT_EXAMPLE_FBS
         max_patches = self._get_vision_max_patches()
         mm_tokens_per_image = self._get_mm_tokens_per_image()

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -32,6 +32,11 @@ from transformers.models.gemma4.modeling_gemma4 import (
 )
 
 from QEfficient.base.onnx_transforms import FP16ClipTransform
+from QEfficient.customop.ctx_scatter_gather import (
+    CtxGatherFunc3DGeneralized,
+    CtxScatterFunc3DGeneralized,
+    CtxScatterFunc3DInt,
+)
 from QEfficient.customop.rms_norm import CustomRMSNormFunc
 from QEfficient.transformers.cache_utils import QEffGemma4DynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
@@ -309,10 +314,95 @@ class QEffGemma4TextExperts(Gemma4TextExperts):
 
         down = torch.bmm(activated, down_proj_t)  # [T*K, 1, H]
         down = down.view(T, K, H) * top_k_weights.unsqueeze(-1)
-        return down.sum(dim=1)  # [T, H]
+        down = torch.einsum("bnh->bh", down)
+        return down
 
 
-class QEffPrefillChunckedGemma4TextExperts(Gemma4TextExperts):
+def _build_matched_idx_from_cumsum(T2Ei: torch.Tensor) -> torch.Tensor:
+    """Build packed->original token index"""
+    batch_size, seq_len = T2Ei.shape
+    int32_max = torch.iinfo(torch.int32).max
+    int32_max_scalar = torch.tensor(int32_max, dtype=torch.int32, device=T2Ei.device)
+    token_idx = torch.arange(seq_len, dtype=torch.int32, device=T2Ei.device).unsqueeze(0).expand(batch_size, -1)
+    valid_prefix = torch.cumsum(T2Ei.to(torch.int32), dim=1)
+    valid_dest = valid_prefix - 1
+    scatter_pos = torch.where(T2Ei, valid_dest, int32_max_scalar)
+    # Once the compiler fix for ConstantOfShape(INT32_MAX) is available, this
+    # can be switched back to ``torch.full_like(token_idx, int32_max)``.
+    matched_idx = int32_max_scalar.expand_as(token_idx)
+    matched_idx = CtxScatterFunc3DInt.apply(
+        matched_idx.unsqueeze(-1),
+        scatter_pos,
+        token_idx.unsqueeze(-1),
+    ).squeeze(-1)
+    return matched_idx
+
+
+def _cumsum_scatter_gather_update_expert_blocked(
+    x: torch.Tensor,
+    T2Ei: torch.Tensor,
+    W_g: torch.Tensor,
+    W_u: torch.Tensor,
+    W_d: torch.Tensor,
+    routing_weight: torch.Tensor,
+    expert_out: torch.Tensor,
+    act_fn,
+    packed_chunk_size: int,
+) -> torch.Tensor:
+    """Cumsum-scatter-gather-update expert helper for NSP-blocked dispatch.
+
+    Accumulates one local expert's contribution in-place onto ``expert_out``.
+    Uses a packed/cumsum layout so the MLP runs only over active rows, then
+    scatters the weighted output back to original token positions.
+    """
+    batch_size, seq_len = T2Ei.shape
+    packed_chunk_size = max(1, min(packed_chunk_size, seq_len))
+
+    matched_idx = _build_matched_idx_from_cumsum(T2Ei)
+    valid_rows = torch.einsum("ij->i", T2Ei.to(torch.int32)).unsqueeze(1)
+    row_range = torch.arange(packed_chunk_size, dtype=torch.int32, device=x.device).unsqueeze(0)
+    x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
+    for packed_start in range(0, seq_len, packed_chunk_size):
+        packed_stop = packed_start + packed_chunk_size
+        chunk_matched_idx = matched_idx[:, packed_start:packed_stop]
+
+        x_chunk = CtxGatherFunc3DGeneralized.apply(x_expanded, chunk_matched_idx)
+
+        gate_prime = x_chunk @ W_g
+        up_prime = x_chunk @ W_u
+        down_chunk = (up_prime * act_fn(gate_prime)) @ W_d
+
+        rw_chunk = CtxGatherFunc3DGeneralized.apply(routing_weight, chunk_matched_idx)
+        down_chunk = down_chunk * rw_chunk
+
+        expert_out_chunk = CtxGatherFunc3DGeneralized.apply(expert_out, chunk_matched_idx)
+        updated_chunk = expert_out_chunk + down_chunk
+
+        chunk_valid_rows = torch.clamp(
+            valid_rows - packed_start,
+            min=torch.zeros_like(valid_rows),
+            max=torch.full_like(valid_rows, packed_chunk_size),
+        )
+        updated_chunk = torch.where(
+            (row_range < chunk_valid_rows).unsqueeze(-1), updated_chunk, torch.zeros_like(updated_chunk)
+        )
+        expert_out = CtxScatterFunc3DGeneralized.apply(expert_out, chunk_matched_idx, updated_chunk)
+
+    return expert_out
+
+
+class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
+    supports_moe_prefill_blocking = True
+
+    def __qeff_init__(self):
+        # Derive gather-friendly split projections from the checkpoint's fused
+        # gate_up_proj/down_proj, without changing on-disk checkpoint format.
+        gate_up_proj = self.gate_up_proj.detach()
+        down_proj = self.down_proj.detach()
+        self.gate_proj = nn.Parameter(gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2), requires_grad=False)
+        self.up_proj = nn.Parameter(gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2), requires_grad=False)
+        self.down_proj_t = nn.Parameter(down_proj.transpose(1, 2), requires_grad=False)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -340,21 +430,36 @@ class QEffPrefillChunckedGemma4TextExperts(Gemma4TextExperts):
         )
         expert_weights.scatter_add_(1, top_k_index, top_k_weights)
         expert_weights = expert_weights.to(x.dtype)
-        out = x.new_zeros((T, H))
-        for e in range(self.num_experts):
-            w = expert_weights[:, e].unsqueeze(-1)  # [T, 1]
-
-            # gate_up_proj[e]: [2I, H], down_proj[e]: [H, I] (matching your original matmuls)
-            gate_up = x @ self.gate_up_proj[e].transpose(0, 1)  # [T, 2I]
-            gate, up = gate_up.chunk(2, dim=-1)  # [T, I], [T, I]
-            activated = self.act_fn(gate) * up  # [T, I]
-            down = activated @ self.down_proj[e].transpose(0, 1)  # [T, H]
-
-            out += down * w
-
+        num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
+        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+        if self.num_experts % num_nsp != 0:
+            raise ValueError(
+                f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
+            )
+        local_experts = self.num_experts // num_nsp
+        rw = expert_weights.transpose(0, 1).contiguous().view(local_experts, num_nsp, T).transpose(0, 1).contiguous()
+        W_g = self.gate_proj.view(local_experts, num_nsp, H, -1).transpose(0, 1).contiguous()
+        W_u = self.up_proj.view(local_experts, num_nsp, H, -1).transpose(0, 1).contiguous()
+        W_d = self.down_proj_t.view(local_experts, num_nsp, -1, H).transpose(0, 1).contiguous()
+        expert_out = x.new_zeros((num_nsp, T, H))
+        routing_weights_unsqueezed = rw.unsqueeze(-1)
+        for slot in range(local_experts):
+            T2Ei = rw[:, slot, :] > 0
+            expert_out = _cumsum_scatter_gather_update_expert_blocked(
+                x=x,
+                T2Ei=T2Ei,
+                W_g=W_g[:, slot],
+                W_u=W_u[:, slot],
+                W_d=W_d[:, slot],
+                routing_weight=routing_weights_unsqueezed[:, slot],
+                expert_out=expert_out,
+                act_fn=self.act_fn,
+                packed_chunk_size=packed_chunk_size,
+            )
+        expert_output = torch.einsum("ijk->jk", expert_out)
         if reshape_back:
-            return out.view(B, S, H)
-        return out
+            return expert_output.view(B, S, H)
+        return expert_output
 
 
 class QEffGemma4VisionAttention(Gemma4VisionAttention):

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1503,6 +1503,24 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         """
         return [self.vision_model.onnx_path, self.lang_model.onnx_path]
 
+    def __update_prefill_transform(
+        self,
+        enable: Optional[bool] = True,
+        enable_chunking: Optional[bool] = False,
+        retain_full_kv: Optional[bool] = False,
+    ):
+        if enable:
+            if enable_chunking:
+                self.model, tf = PrefillOnlyChunkedTransform.apply(self.model)
+            else:
+                self.model, tf = PrefillOnlyTransform.apply(self.model)
+
+        else:
+            if retain_full_kv:
+                self.model, tf = RevertPrefillKeepAttentionTransform.apply(self.model)
+            else:
+                self.model, tf = RevertPrefillOnlyTransform.apply(self.model)
+
     def export(
         self,
         export_dir: Optional[str] = None,
@@ -1512,6 +1530,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         prefill_seq_len: Optional[int] = None,
         prefill_only: bool = False,
         enable_chunking: bool = False,
+        num_cores: int = constants.DEFAULT_AIC_NUM_CORES,
+        moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
         layerwise: bool = False,
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
@@ -1552,13 +1572,28 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 kv_cache_prefix=kv_cache_prefix,
                 **kwargs,
             )
-
+        bs: int = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
+        seq_len: int = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
+        # TODO: move this to a DA Serving utility class
+        if self.model.config.model_type in SPECIALIZED_DISAGG_SERVING_MODEL_ARCH:
+            if prefill_only:
+                self.__update_prefill_transform(enable=True, enable_chunking=enable_chunking)
+                for module in self.model.modules():
+                    if getattr(module, "supports_moe_prefill_blocking", False):
+                        module.expert_blocking_num_nsp = num_cores
+                        module.expert_blocking_packed_chunk_size = moe_prefill_packed_chunk_size
+                if self.model.config.model_type in {"gemma4"}:
+                    seq_len = max(prefill_seq_len or 0, constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN)
+            else:
+                self.__update_prefill_transform(False, retain_full_kv=kwargs.get("retain_full_kv", False))
+        onnx_kwargs = {"prefill_seq_len": seq_len, "batch_size": bs}
         # TODO This is a temporary change as continous batching is enabled only for few models. Once support is added for all the models this exception handing can be removed.
         try:
             inputs = self.model.get_dummy_inputs(
                 kv_offload=True,
                 continuous_batching=self.continuous_batching,
                 comp_ctx_lengths=self.comp_ctx_lengths_decode,
+                **onnx_kwargs,
             )
             dynamic_axes = self.model.get_onnx_dynamic_axes(
                 kv_offload=True,
@@ -1567,8 +1602,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             )
         except TypeError:
             inputs = self.model.get_dummy_inputs(
-                kv_offload=True,
-                comp_ctx_lengths=self.comp_ctx_lengths_decode,
+                kv_offload=True, comp_ctx_lengths=self.comp_ctx_lengths_decode, **onnx_kwargs
             )
             dynamic_axes = self.model.get_onnx_dynamic_axes(
                 kv_offload=True, comp_ctx_lengths=self.comp_ctx_lengths_decode
@@ -1627,6 +1661,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 use_onnx_subfunctions=use_onnx_subfunctions,
                 prefill_only=prefill_only,
                 enable_chunking=enable_chunking,
+                num_cores=num_cores,
+                moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
                 prefill_seq_len=prefill_seq_len,
                 _layerwise_cache_probe=layerwise_cache_probe,
                 kv_cache_prefix=kv_cache_prefix,
@@ -1814,6 +1850,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         layerwise: bool = False,
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
+        moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
         **compiler_options,
     ) -> str:
         """
@@ -1899,6 +1936,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                     offload_pt_weights=offload_pt_weights,
                     enable_chunking=enable_chunking,
                     qaic_config=qaic_config,
+                    moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
                     kv_cache_prefix=kv_cache_prefix,
                     **compiler_options,
                 )

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -42,6 +42,7 @@ from QEfficient.generation.text_generation_inference import (
 )
 from QEfficient.generation.vlm_generation import VisionLanguageGeneration
 from QEfficient.transformers.modeling_utils import (
+    DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH,
     DYNAMIC_SEQ_LEN_SUPPORTED_MODEL_ARCH,
     SPECIALIZED_DISAGG_SERVING_MODEL_ARCH,
     _configure_proxy_for_model,
@@ -1576,13 +1577,15 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         seq_len: int = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
         # TODO: move this to a DA Serving utility class
         if self.model.config.model_type in SPECIALIZED_DISAGG_SERVING_MODEL_ARCH:
-            if prefill_only:
+            if prefill_only and enable_chunking:
                 self.__update_prefill_transform(enable=True, enable_chunking=enable_chunking)
                 for module in self.model.modules():
                     if getattr(module, "supports_moe_prefill_blocking", False):
                         module.expert_blocking_num_nsp = num_cores
                         module.expert_blocking_packed_chunk_size = moe_prefill_packed_chunk_size
-                if self.model.config.model_type in {"gemma4"}:
+                        if hasattr(module, "__qeff_init__"):
+                            module.__qeff_init__()
+                if self.model.config.model_type in DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH:
                     seq_len = max(prefill_seq_len or 0, constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN)
             else:
                 self.__update_prefill_transform(False, retain_full_kv=kwargs.get("retain_full_kv", False))

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1582,11 +1582,18 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 for module in self.model.modules():
                     if getattr(module, "supports_moe_prefill_blocking", False):
                         module.expert_blocking_num_nsp = num_cores
-                        module.expert_blocking_packed_chunk_size = moe_prefill_packed_chunk_size
+                        if prefill_seq_len % moe_prefill_packed_chunk_size == 0:
+                            module.expert_blocking_packed_chunk_size = prefill_seq_len // moe_prefill_packed_chunk_size
+                        else:
+                            raise ValueError("Prefill_seq_len must be divisible by moe_prefill_packed_chunk_size")
                         if hasattr(module, "__qeff_init__"):
                             module.__qeff_init__()
                 if self.model.config.model_type in DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH:
-                    seq_len = max(prefill_seq_len or 0, constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN)
+                    seq_len = (
+                        seq_len
+                        if prefill_seq_len % moe_prefill_packed_chunk_size == 0
+                        else moe_prefill_packed_chunk_size
+                    )
             else:
                 self.__update_prefill_transform(False, retain_full_kv=kwargs.get("retain_full_kv", False))
         onnx_kwargs = {"prefill_seq_len": seq_len, "batch_size": bs}

--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -370,7 +370,7 @@ from QEfficient.transformers.models.gemma4.modeling_gemma4 import (
     QEffGemma4TextModel,
     QEffGemma4TextRouter,
     QEffGemma4VisionAttention,
-    QEffPrefillChunckedGemma4TextExperts,
+    QEffPrefillChunkedGemma4TextExperts,
 )
 from QEfficient.transformers.models.glm4_moe.modeling_glm4_moe import (
     QEffGlm4MoeAttention,
@@ -966,7 +966,7 @@ class PrefillOnlyChunkedTransform(ModuleMappingTransform):
         # Qwen3_5Moe
         QEffQwen3_5MoeSparseMoeBlock: QEffPrefillChunkedQwen3_5MoeSparseMoeBlock,
         # Gemma4_Moe
-        QEffGemma4TextExperts: QEffPrefillChunckedGemma4TextExperts,
+        QEffGemma4TextExperts: QEffPrefillChunkedGemma4TextExperts,
     }
 
 
@@ -987,7 +987,7 @@ class RevertPrefillKeepAttentionTransform(ModuleMappingTransform):
         # Qwen3_5Moe
         QEffPrefillChunkedQwen3_5MoeSparseMoeBlock: QEffQwen3_5MoeSparseMoeBlock,
         # Gemma4_Moe
-        QEffPrefillChunckedGemma4TextExperts: QEffGemma4TextExperts,
+        QEffPrefillChunkedGemma4TextExperts: QEffGemma4TextExperts,
     }
 
 

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
@@ -77,6 +77,7 @@ prefill_qpc_path = qeff_model.compile(
     node_precision_info=True,
     prefill_only=True,
     enable_chunking=True,
+    use_onnx_subfunctions=True,
     skip_vision=True,
 )
 
@@ -93,6 +94,7 @@ decode_qpc_path = qeff_model.compile(
     aic_enable_depth_first=True,
     node_precision_info=True,
     prefill_only=False,
+    use_onnx_subfunctions=True,
     skip_vision=True,
 )
 

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
@@ -40,7 +40,7 @@ processor = AutoProcessor.from_pretrained(model_id)
 
 ENABLE_FP16_CLIP = True
 remove_fp16clip_transform_if_disabled(qeff_model, ENABLE_FP16_CLIP)
-PREFILL_SEQ_LEN = 296
+PREFILL_SEQ_LEN = 256
 CTX_LEN = 4096
 BS = 1
 gemma_vision_dir = Path(__file__).resolve().parent.parent
@@ -57,6 +57,7 @@ if not skip_vision:
         num_devices=1,
         mos=1,
         mxfp6_matmul=True,
+        mxint8_kv_cache=True,
         aic_enable_depth_first=True,
         skip_vision=skip_vision,
         split_model_io=True,
@@ -77,6 +78,7 @@ prefill_qpc_path = qeff_model.compile(
     node_precision_info=True,
     prefill_only=True,
     enable_chunking=True,
+    moe_prefill_packed_chunk_size=256,
     use_onnx_subfunctions=True,
     skip_vision=True,
 )


### PR DESCRIPTION
Optimized the moe MLP block by processing only the top-K selected experts for each token. The implementation gathers expert-specific projection weights (gate, up, and down), performs batched matrix multiplications across all (token, expert) pairs, applies the gated activation (act_fn(gate) * up), and combines expert outputs using router-provided top-K weights.


NSP-parallel expert-blocked dispatch to the chunked prefill MoE path, replacing the sequential per-expert loop with a batched packed-prefix approach.

