### PR TITLE
feat(ci): add performance regression tracking stage

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -43,10 +43,16 @@ pipeline {
         booleanParam(name: 'RUN_CLI', defaultValue: true)
         booleanParam(name: 'RUN_FINETUNE', defaultValue: false)
         booleanParam(name: 'RUN_DYNAMO_QAIC', defaultValue: true, description: 'Run dynamo on-QAIC compile/generate tests (torch 2.13)')
+        booleanParam(name: 'RUN_PERF_COMPARISON', defaultValue: true, description: 'Compare perf against baseline DB after QAIC tests')
+        string(name: 'CI_PERF_DB_PATH', defaultValue: '/ci/perf_db', description: 'Host path to persistent perf baseline DB (must survive container lifecycle)')
+        string(name: 'NSP_COUNT', defaultValue: '16', description: 'Number of NSPs on this node — used to key the hardware profile in the baseline DB')
     }
 
     environment {
-        TEST_FILTER = testFilter(params.TEST_PROFILE)
+        TEST_FILTER        = testFilter(params.TEST_PROFILE)
+        CI_PERF_REPORT_DIR = "${WORKSPACE}/ci_perf_reports"
+        HW_KEY             = "${params.NODE_LABEL}_${params.NSP_COUNT}"
+        GIT_SHA            = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
     }
 
     stages {
@@ -54,7 +60,14 @@ pipeline {
             steps {
                 sh '''
                     . ~/.bashrc
-                    sudo docker run --privileged -dit --name ${BUILD_TAG} -e HF_TOKEN=${HF_TOKEN} -v ./:/efficient-transformers -v ${HF_PATH}:${DOCKER_HF_PATH} ${DOCKER_LATEST}:master_latest
+                    mkdir -p ${CI_PERF_REPORT_DIR}
+                    sudo docker run --privileged -dit --name ${BUILD_TAG} \
+                        -e HF_TOKEN=${HF_TOKEN} \
+                        -v ./:/efficient-transformers \
+                        -v ${HF_PATH}:${DOCKER_HF_PATH} \
+                        -v ${CI_PERF_REPORT_DIR}:/ci_perf_reports \
+                        -v ${CI_PERF_DB_PATH}:/ci_perf_db \
+                        ${DOCKER_LATEST}:master_latest
                     sudo docker exec ${BUILD_TAG} bash -c "
                     cd /efficient-transformers &&
                     apt update &&
@@ -101,9 +114,15 @@ pipeline {
                            sudo docker exec ${BUILD_TAG} bash -c "
                            cd /efficient-transformers &&
                            . preflight_qeff/bin/activate &&
-                           mkdir -p $PWD/Non_qaic_llm &&
+                           mkdir -p $PWD/Non_qaic_llm /ci_perf_reports/QAIC_LLM &&
                            export TOKENIZERS_PARALLELISM=false &&
                            export QEFF_HOME=$PWD/Non_qaic_llm &&
+                           export CI_STAGE_NAME=QAIC_LLM &&
+                           export CI_BUILD_TAG=${BUILD_TAG} &&
+                           export GIT_SHA=${GIT_SHA} &&
+                           export NODE_LABEL=${NODE_LABEL} &&
+                           export NSP_COUNT=${NSP_COUNT} &&
+                           export CI_PERF_REPORT_DIR=/ci_perf_reports &&
                            pytest tests -m '(llm_model) and (not qnn) and ${TEST_FILTER}' --ignore tests/vllm --ignore tests/unit_test --ignore tests/nightly_pipeline --junitxml=tests/tests_log2.xml --durations=10 &&
                            junitparser merge tests/tests_log2.xml tests/tests_log.xml &&
                            deactivate"
@@ -111,9 +130,10 @@ pipeline {
                        }
                    }
                 }
-                
+
             }
         }
+
         stage('QAIC FEATURE') {
             when {expression { params.RUN_QAIC_FEATURE }}
             steps {
@@ -122,9 +142,15 @@ pipeline {
                     sudo docker exec ${BUILD_TAG} bash -c "
                     cd /efficient-transformers &&
                     . preflight_qeff/bin/activate &&
-                    mkdir -p $PWD/Non_qaic_feature &&
+                    mkdir -p $PWD/Non_qaic_feature /ci_perf_reports/QAIC_FEATURE &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Non_qaic_feature &&
+                    export CI_STAGE_NAME=QAIC_FEATURE &&
+                    export CI_BUILD_TAG=${BUILD_TAG} &&
+                    export GIT_SHA=${GIT_SHA} &&
+                    export NODE_LABEL=${NODE_LABEL} &&
+                    export NSP_COUNT=${NSP_COUNT} &&
+                    export CI_PERF_REPORT_DIR=/ci_perf_reports &&
                     pytest tests -m '(on_qaic) and (feature) and (not qnn) and ${TEST_FILTER}' --ignore tests/transformers/sampler --ignore tests/vllm --ignore tests/unit_test --ignore tests/nightly_pipeline --junitxml=tests/tests_log2_feature.xml --durations=10 &&
                     junitparser merge tests/tests_log2_feature.xml tests/tests_log.xml &&
                     deactivate"
@@ -132,6 +158,7 @@ pipeline {
                 }
             }
         }
+
         stage('QAIC Multimodal') {
             when {expression { params.RUN_QAIC_MM }}
             steps {
@@ -140,9 +167,15 @@ pipeline {
                     sudo docker exec ${BUILD_TAG} bash -c "
                     cd /efficient-transformers &&
                     . preflight_qeff/bin/activate &&
-                    mkdir -p $PWD/Non_cli_qaic_multimodal &&
+                    mkdir -p $PWD/Non_cli_qaic_multimodal /ci_perf_reports/QAIC_MULTIMODAL &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Non_cli_qaic_multimodal &&
+                    export CI_STAGE_NAME=QAIC_MULTIMODAL &&
+                    export CI_BUILD_TAG=${BUILD_TAG} &&
+                    export GIT_SHA=${GIT_SHA} &&
+                    export NODE_LABEL=${NODE_LABEL} &&
+                    export NSP_COUNT=${NSP_COUNT} &&
+                    export CI_PERF_REPORT_DIR=/ci_perf_reports &&
                     pytest tests -m '(multimodal) and (not qnn) and ${TEST_FILTER}' --ignore tests/vllm --ignore tests/unit_test --ignore tests/nightly_pipeline --ignore tests/transformers/models/reranker/test_reranker_mad.py --junitxml=tests/tests_log6.xml --durations=10 &&
                     junitparser merge tests/tests_log6.xml tests/tests_log.xml &&
                     deactivate"
@@ -150,6 +183,7 @@ pipeline {
                 }
             }
         }
+
         stage('QAIC Reranker Tests') {
             when { expression { params.RUN_QAIC_MM } }
             steps {
@@ -158,9 +192,15 @@ pipeline {
                     sudo docker exec ${BUILD_TAG} bash -c "
                     cd /efficient-transformers &&
                     . preflight_qeff/bin/activate &&
-                    mkdir -p $PWD/Non_cli_qaic_reranker &&
+                    mkdir -p $PWD/Non_cli_qaic_reranker /ci_perf_reports/QAIC_RERANKER &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=$PWD/Non_cli_qaic_reranker &&
+                    export CI_STAGE_NAME=QAIC_RERANKER &&
+                    export CI_BUILD_TAG=${BUILD_TAG} &&
+                    export GIT_SHA=${GIT_SHA} &&
+                    export NODE_LABEL=${NODE_LABEL} &&
+                    export NSP_COUNT=${NSP_COUNT} &&
+                    export CI_PERF_REPORT_DIR=/ci_perf_reports &&
                     export QEFF_RERANKER_DOC_LIMIT=1 &&
                     pytest -q tests/transformers/models/reranker/test_reranker_mad.py --maxfail=1 --junitxml=tests/tests_log_reranker.xml --durations=10 &&
                     junitparser merge tests/tests_log_reranker.xml tests/tests_log.xml &&
@@ -169,6 +209,7 @@ pipeline {
                 }
             }
         }
+
         stage('QAIC Diffusion Models Tests') {
             when { expression { params.RUN_QAIC_DIFFUSION } }
             steps {
@@ -219,11 +260,86 @@ pipeline {
                     cd /efficient-transformers &&
                     . preflight_qeff/bin/activate &&
                     pip install -r examples/dynamo/causal_lm/requirements.txt &&
-                    mkdir -p \\$PWD/dynamo_qeff_qaic &&
+                    mkdir -p \\$PWD/dynamo_qeff_qaic /ci_perf_reports/QAIC_DYNAMO &&
                     export TOKENIZERS_PARALLELISM=false &&
                     export QEFF_HOME=\\$PWD/dynamo_qeff_qaic &&
+                    export CI_STAGE_NAME=QAIC_DYNAMO &&
+                    export CI_BUILD_TAG=${BUILD_TAG} &&
+                    export GIT_SHA=${GIT_SHA} &&
+                    export NODE_LABEL=${NODE_LABEL} &&
+                    export NSP_COUNT=${NSP_COUNT} &&
+                    export CI_PERF_REPORT_DIR=/ci_perf_reports &&
                     pytest tests/dynamo -m '(dynamo) and (on_qaic) and ${TEST_FILTER}' --ignore tests/dynamo/nightly --dist loadgroup -n auto --junitxml=tests/tests_log_dynamo_qaic.xml --durations=10 &&
                     junitparser merge tests/tests_log_dynamo_qaic.xml tests/tests_log.xml &&
+                    deactivate"
+                    '''
+                }
+            }
+        }
+
+        stage('Perf Comparison') {
+            when { expression { params.RUN_PERF_COMPARISON } }
+            steps {
+                timeout(time: 10, unit: 'MINUTES') {
+                    sh '''
+                    sudo docker exec ${BUILD_TAG} bash -c "
+                    cd /efficient-transformers &&
+                    . preflight_qeff/bin/activate &&
+                    for STAGE_NAME in QAIC_LLM QAIC_FEATURE QAIC_MULTIMODAL QAIC_RERANKER QAIC_DYNAMO; do
+                        REPORT=/ci_perf_reports/\\${STAGE_NAME}/perf_report.json
+                        if [ -f \\$REPORT ]; then
+                            python tests/ci_perf/compare_perf.py \\
+                                --report-dir /ci_perf_reports \\
+                                --db-path /ci_perf_db/baseline_db.json \\
+                                --stage \\$STAGE_NAME \\
+                                --hardware-key ${HW_KEY} \\
+                                --thresholds tests/ci_perf/thresholds.json \\
+                                --output-csv /ci_perf_reports/\\${STAGE_NAME}_comparison.csv
+                        fi
+                    done &&
+                    deactivate"
+                    '''
+                }
+            }
+            post {
+                always {
+                    script {
+                        try {
+                            sh 'sudo chown -R ubuntu ${CI_PERF_REPORT_DIR}'
+                        } catch (err) {
+                            echo "Could not chown perf reports: ${err}"
+                        }
+                    }
+                    archiveArtifacts artifacts: 'ci_perf_reports/**/*.csv', allowEmptyArchive: true
+                }
+            }
+        }
+
+        stage('Update Perf Baseline') {
+            when {
+                allOf {
+                    expression { params.RUN_PERF_COMPARISON }
+                    branch 'main'
+                }
+            }
+            steps {
+                timeout(time: 5, unit: 'MINUTES') {
+                    sh '''
+                    sudo docker exec ${BUILD_TAG} bash -c "
+                    cd /efficient-transformers &&
+                    . preflight_qeff/bin/activate &&
+                    for STAGE_NAME in QAIC_LLM QAIC_FEATURE QAIC_MULTIMODAL QAIC_RERANKER QAIC_DYNAMO; do
+                        REPORT=/ci_perf_reports/\\${STAGE_NAME}/perf_report.json
+                        if [ -f \\$REPORT ]; then
+                            python tests/ci_perf/compare_perf.py \\
+                                --report-dir /ci_perf_reports \\
+                                --db-path /ci_perf_db/baseline_db.json \\
+                                --stage \\$STAGE_NAME \\
+                                --hardware-key ${HW_KEY} \\
+                                --thresholds tests/ci_perf/thresholds.json \\
+                                --update-baseline
+                        fi
+                    done &&
                     deactivate"
                     '''
                 }

--- a/tests/ci_perf/__init__.py
+++ b/tests/ci_perf/__init__.py
@@ -1,0 +1,6 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------

--- a/tests/ci_perf/compare_perf.py
+++ b/tests/ci_perf/compare_perf.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+"""
+compare_perf.py — Compare current PR perf against the persistent baseline DB.
+
+Usage:
+    python tests/ci_perf/compare_perf.py \\
+        --report-dir  $CI_PERF_REPORT_DIR \\
+        --db-path     /ci_perf_db/baseline_db.json \\
+        --stage       QAIC_LLM \\
+        --hardware-key qeff_node_16 \\
+        --thresholds  tests/ci_perf/thresholds.json \\
+        [--update-baseline] \\
+        [--output-csv /tmp/QAIC_LLM_comparison.csv]
+
+Exit codes:
+    0  — all models within tolerance (or no baseline yet)
+    1  — at least one metric regressed
+    2  — usage / file-not-found error
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from tests.ci_perf.perf_schema import GATED_METRICS, INFO_METRICS
+from tests.ci_perf.storage import load_db, load_stage_report, update_baseline
+
+CSV_COLUMNS = ["model_key", "metric", "baseline", "current", "pct_diff", "status", "note"]
+
+
+# ---------------------------------------------------------------------------
+# Threshold helpers
+# ---------------------------------------------------------------------------
+
+
+def load_thresholds(thresholds_path: Path) -> dict[str, Any]:
+    if not thresholds_path.exists():
+        return {"default": {m: {"percentage_tolerance": 5.0} for m in GATED_METRICS}}
+    return json.loads(thresholds_path.read_text(encoding="utf-8"))
+
+
+def get_threshold(thresholds: dict, model_key: str, metric: str) -> float:
+    per_model = thresholds.get("per_model", {}).get(model_key, {})
+    metric_override = per_model.get(metric, {})
+    if "percentage_tolerance" in metric_override:
+        return float(metric_override["percentage_tolerance"])
+    default_metric = thresholds.get("default", {}).get(metric, {})
+    return float(default_metric.get("percentage_tolerance", 5.0))
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+
+def compare_report(
+    report: dict[str, Any],
+    baseline_models: dict[str, Any],
+    thresholds: dict[str, Any],
+) -> tuple[list[dict], list[str]]:
+    """
+    Compare every model in *report* against *baseline_models*.
+
+    Returns:
+        rows     — list of dicts for CSV output.
+        failures — list of human-readable regression messages.
+    """
+    rows: list[dict] = []
+    failures: list[str] = []
+
+    for model_key, current in sorted(report.get("models", {}).items()):
+        baseline = baseline_models.get(model_key)
+
+        if baseline is None:
+            rows.append(
+                {
+                    "model_key": model_key,
+                    "metric": "all",
+                    "baseline": "N/A",
+                    "current": "N/A",
+                    "pct_diff": "N/A",
+                    "status": "skipped",
+                    "note": "not in baseline DB — first run",
+                }
+            )
+            print(f"  SKIP  {model_key}  (not in baseline DB)")
+            continue
+
+        for metric, regression_direction in GATED_METRICS.items():
+            curr_val = current.get(metric)
+            base_val = baseline.get(metric)
+
+            if curr_val is None or base_val is None:
+                rows.append(
+                    {
+                        "model_key": model_key,
+                        "metric": metric,
+                        "baseline": base_val,
+                        "current": curr_val,
+                        "pct_diff": "N/A",
+                        "status": "skipped",
+                        "note": "null value — inference-only test",
+                    }
+                )
+                continue
+
+            if base_val == 0:
+                rows.append(
+                    {
+                        "model_key": model_key,
+                        "metric": metric,
+                        "baseline": base_val,
+                        "current": curr_val,
+                        "pct_diff": "N/A",
+                        "status": "skipped",
+                        "note": "baseline is zero — cannot compute pct_diff",
+                    }
+                )
+                continue
+
+            pct_diff = (curr_val - base_val) / base_val * 100
+            tol = get_threshold(thresholds, model_key, metric)
+
+            is_regression = (regression_direction == "up" and pct_diff > tol) or (
+                regression_direction == "down" and pct_diff < -tol
+            )
+
+            status = "FAILED" if is_regression else "passed"
+            note = f"threshold ±{tol}%" if is_regression else ""
+
+            rows.append(
+                {
+                    "model_key": model_key,
+                    "metric": metric,
+                    "baseline": round(base_val, 6),
+                    "current": round(curr_val, 6),
+                    "pct_diff": f"{pct_diff:+.2f}%",
+                    "status": status,
+                    "note": note,
+                }
+            )
+
+            symbol = "FAIL" if is_regression else "pass"
+            print(f"  {symbol}  {model_key} :: {metric}: {pct_diff:+.2f}%")
+
+            if is_regression:
+                failures.append(
+                    f"{model_key} :: {metric}: {pct_diff:+.2f}% (threshold ±{tol}%)"
+                )
+
+    return rows, failures
+
+
+# ---------------------------------------------------------------------------
+# CSV writer
+# ---------------------------------------------------------------------------
+
+
+def write_csv(output_path: Path, rows: list[dict]) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=CSV_COLUMNS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({col: row.get(col, "") for col in CSV_COLUMNS})
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare CI perf report against persistent baseline DB."
+    )
+    parser.add_argument("--report-dir", required=True, help="Directory containing per-stage perf_report.json files")
+    parser.add_argument("--db-path", required=True, help="Path to baseline_db.json on the CI host")
+    parser.add_argument("--stage", required=True, help="Stage name (e.g. QAIC_LLM)")
+    parser.add_argument("--hardware-key", required=True, help="Hardware profile key (e.g. qeff_node_16)")
+    parser.add_argument("--thresholds", default="tests/ci_perf/thresholds.json", help="Path to thresholds.json")
+    parser.add_argument("--update-baseline", action="store_true", help="Update baseline DB with current report values")
+    parser.add_argument("--output-csv", default=None, help="Optional path to write comparison CSV")
+    args = parser.parse_args(argv)
+
+    report_file = Path(args.report_dir) / args.stage / "perf_report.json"
+    if not report_file.exists():
+        print(f"ERROR: report file not found: {report_file}", file=sys.stderr)
+        return 2
+
+    report = json.loads(report_file.read_text(encoding="utf-8"))
+    db_path = Path(args.db_path)
+    db = load_db(db_path)
+    thresholds = load_thresholds(Path(args.thresholds))
+
+    baseline_models: dict = (
+        db.get("hardware_profiles", {})
+        .get(args.hardware_key, {})
+        .get("stages", {})
+        .get(args.stage, {})
+        .get("models", {})
+    )
+
+    print(f"\n--- Perf Comparison: {args.stage} [{args.hardware_key}] ---")
+    rows, failures = compare_report(report, baseline_models, thresholds)
+
+    if args.output_csv:
+        write_csv(Path(args.output_csv), rows)
+        print(f"\nComparison CSV written to: {args.output_csv}")
+
+    if failures:
+        print(f"\n{len(failures)} regression(s) found:")
+        for msg in failures:
+            print(f"  ✗ {msg}")
+    else:
+        print("\nAll comparisons passed.")
+
+    if args.update_baseline:
+        update_baseline(
+            db_path=db_path,
+            hw_key=args.hardware_key,
+            stage_name=args.stage,
+            models_data=report.get("models", {}),
+            build_tag=report.get("ci_build_tag", ""),
+            git_sha=report.get("git_sha", ""),
+        )
+        print(f"Baseline DB updated: {db_path}")
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ci_perf/conftest.py
+++ b/tests/ci_perf/conftest.py
@@ -1,0 +1,135 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from tests.ci_perf.perf_schema import ModelPerfRecord
+from tests.ci_perf.storage import compute_dir_size, write_stage_report
+
+_RECORDER_KEY = pytest.StashKey()
+
+
+def _build_key(model_name: str, config: dict) -> str:
+    """Build a stable composite DB key from model name + sorted config params."""
+    parts = "::".join(f"{k}={v}" for k, v in sorted(config.items()))
+    return f"{model_name}::{parts}"
+
+
+class PerfRecorder:
+    """Session-level accumulator of per-model performance records."""
+
+    def __init__(self) -> None:
+        self._records: dict[str, dict] = {}
+
+    def record(
+        self,
+        model_name: str,
+        exec_info,
+        config: dict,
+        onnx_path=None,
+        qpc_path=None,
+        request=None,
+    ) -> None:
+        """
+        Extract perf_metrics from *exec_info* and store under a composite key.
+
+        Args:
+            model_name: HuggingFace model id.
+            exec_info:  CloudAI100ExecInfo (or compatible) with .perf_metrics attribute.
+            config:     Dict of inference params, e.g. {"batch_size": 1, "seq_len": 128}.
+            onnx_path:  Optional path to ONNX export directory — sizes computed if provided.
+            qpc_path:   Optional path to QPC compiled directory — sizes computed if provided.
+            request:    pytest FixtureRequest for node ID tagging (optional).
+        """
+        if exec_info is None:
+            return
+        pm = getattr(exec_info, "perf_metrics", None)
+        if pm is None:
+            return
+
+        key = _build_key(model_name, config)
+        nodeid = request.node.nodeid if request is not None else ""
+
+        record = ModelPerfRecord(
+            prefill_time=getattr(pm, "prefill_time", None),
+            decode_perf=getattr(pm, "decode_perf", None),
+            total_perf=getattr(pm, "total_perf", None),
+            total_time=getattr(pm, "total_time", None),
+            onnx_size_bytes=compute_dir_size(onnx_path),
+            qpc_size_bytes=compute_dir_size(qpc_path),
+            batch_size=getattr(exec_info, "batch_size", 1),
+            test_nodeid=nodeid,
+        )
+        self._records[key] = record.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# pytest plugin hooks
+# ---------------------------------------------------------------------------
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Create a PerfRecorder on the controller process only."""
+    if not hasattr(config, "workerinput"):
+        config.stash[_RECORDER_KEY] = PerfRecorder()
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """
+    Worker path: push collected records back to the controller via workeroutput.
+    Controller path (non-xdist or after all workers done): merge + write report.
+    """
+    if hasattr(session.config, "workerinput"):
+        # xdist worker — push records to controller
+        recorder: Optional[PerfRecorder] = session.config.stash.get(_RECORDER_KEY, None)
+        if recorder is not None:
+            session.config.workeroutput["ci_perf_records"] = recorder._records
+        return
+
+    # Controller path
+    merged: dict[str, dict] = {}
+
+    # Collect records forwarded by xdist workers
+    for worker_records in getattr(session.config, "_ci_perf_worker_outputs", []):
+        merged.update(worker_records)
+
+    # Also collect any records from the controller itself (non-xdist case)
+    controller_recorder: Optional[PerfRecorder] = session.config.stash.get(_RECORDER_KEY, None)
+    if controller_recorder is not None:
+        merged.update(controller_recorder._records)
+
+    if merged and os.environ.get("CI_PERF_REPORT_DIR"):
+        write_stage_report(merged)
+
+
+def pytest_testnodedown(node, error) -> None:
+    """
+    Called on the controller when an xdist worker finishes.
+    Collects the worker's ci_perf_records from workeroutput.
+    """
+    records = node.workeroutput.get("ci_perf_records", {})
+    if records:
+        if not hasattr(node.config, "_ci_perf_worker_outputs"):
+            node.config._ci_perf_worker_outputs = []
+        node.config._ci_perf_worker_outputs.append(records)
+
+
+@pytest.fixture(scope="session")
+def perf_recorder(request: pytest.FixtureRequest) -> PerfRecorder:
+    """Session-scoped fixture that accumulates per-model perf records."""
+    recorder = request.config.stash.get(_RECORDER_KEY, None)
+    if recorder is None:
+        # Fallback for xdist workers that receive a fresh stash
+        recorder = PerfRecorder()
+        request.config.stash[_RECORDER_KEY] = recorder
+    return recorder

--- a/tests/ci_perf/perf_schema.py
+++ b/tests/ci_perf/perf_schema.py
@@ -1,0 +1,101 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+SCHEMA_VERSION = "1"
+
+# Metrics that gate the PR (regression → PR blocked).
+# Value = regression direction: "up" means going UP is bad, "down" means going DOWN is bad.
+GATED_METRICS: dict[str, str] = {
+    "prefill_time": "up",
+    "decode_perf": "down",
+    "onnx_size_bytes": "up",
+    "qpc_size_bytes": "up",
+}
+
+# Metrics that are stored for visibility but never cause a failure.
+INFO_METRICS: list[str] = ["total_perf", "total_time"]
+
+
+@dataclass
+class ModelPerfRecord:
+    """Per-model metrics captured during a single test run."""
+
+    prefill_time: Optional[float] = None
+    decode_perf: Optional[float] = None
+    total_perf: Optional[float] = None
+    total_time: Optional[float] = None
+    onnx_size_bytes: Optional[int] = None
+    qpc_size_bytes: Optional[int] = None
+    batch_size: int = 1
+    test_nodeid: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "prefill_time": self.prefill_time,
+            "decode_perf": self.decode_perf,
+            "total_perf": self.total_perf,
+            "total_time": self.total_time,
+            "onnx_size_bytes": self.onnx_size_bytes,
+            "qpc_size_bytes": self.qpc_size_bytes,
+            "batch_size": self.batch_size,
+            "test_nodeid": self.test_nodeid,
+        }
+
+
+@dataclass
+class StagePerfReport:
+    """Full perf_report.json written after each QAIC pytest stage."""
+
+    schema_version: str = SCHEMA_VERSION
+    stage_name: str = ""
+    ci_build_tag: str = ""
+    git_sha: str = ""
+    hardware: dict = field(default_factory=dict)
+    timestamp: str = ""
+    models: dict[str, dict] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": self.schema_version,
+            "stage_name": self.stage_name,
+            "ci_build_tag": self.ci_build_tag,
+            "git_sha": self.git_sha,
+            "hardware": self.hardware,
+            "timestamp": self.timestamp,
+            "models": self.models,
+        }
+
+
+@dataclass
+class BaselineEntry:
+    """Per-model entry stored in the persistent baseline DB."""
+
+    prefill_time: Optional[float] = None
+    decode_perf: Optional[float] = None
+    total_perf: Optional[float] = None
+    total_time: Optional[float] = None
+    onnx_size_bytes: Optional[int] = None
+    qpc_size_bytes: Optional[int] = None
+    baseline_sha: str = ""
+    baseline_timestamp: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "prefill_time": self.prefill_time,
+            "decode_perf": self.decode_perf,
+            "total_perf": self.total_perf,
+            "total_time": self.total_time,
+            "onnx_size_bytes": self.onnx_size_bytes,
+            "qpc_size_bytes": self.qpc_size_bytes,
+            "baseline_sha": self.baseline_sha,
+            "baseline_timestamp": self.baseline_timestamp,
+        }

--- a/tests/ci_perf/storage.py
+++ b/tests/ci_perf/storage.py
@@ -1,0 +1,124 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from tests.ci_perf.perf_schema import SCHEMA_VERSION, StagePerfReport
+
+
+def compute_dir_size(path) -> Optional[int]:
+    """Return total bytes of all files under *path*, or None if path is None/missing."""
+    if path is None:
+        return None
+    p = Path(path)
+    if not p.exists():
+        return None
+    return sum(f.stat().st_size for f in p.rglob("*") if f.is_file())
+
+
+def write_stage_report(records: dict[str, dict]) -> None:
+    """
+    Build a StagePerfReport from *records* and env vars, then write atomically
+    to $CI_PERF_REPORT_DIR/{CI_STAGE_NAME}/perf_report.json.
+
+    No-op if CI_PERF_REPORT_DIR is not set (local dev runs).
+    """
+    report_dir = os.environ.get("CI_PERF_REPORT_DIR")
+    if not report_dir:
+        return
+
+    stage_name = os.environ.get("CI_STAGE_NAME", "UNKNOWN")
+    target_dir = Path(report_dir) / stage_name
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / "perf_report.json"
+
+    report = StagePerfReport(
+        schema_version=SCHEMA_VERSION,
+        stage_name=stage_name,
+        ci_build_tag=os.environ.get("CI_BUILD_TAG", ""),
+        git_sha=os.environ.get("GIT_SHA", ""),
+        hardware={
+            "node_label": os.environ.get("NODE_LABEL", ""),
+            "nsp_count": os.environ.get("NSP_COUNT", ""),
+        },
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        models=records,
+    )
+
+    _atomic_write(target, report.to_dict())
+
+
+def load_stage_report(report_dir: str | Path, stage_name: str) -> dict[str, Any]:
+    """Load perf_report.json for a given stage. Returns empty dict on missing file."""
+    path = Path(report_dir) / stage_name / "perf_report.json"
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_db(db_path: str | Path) -> dict[str, Any]:
+    """Load baseline_db.json, returning an empty skeleton if the file does not exist."""
+    p = Path(db_path)
+    if not p.exists():
+        return {"schema_version": SCHEMA_VERSION, "hardware_profiles": {}}
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def update_baseline(
+    db_path: str | Path,
+    hw_key: str,
+    stage_name: str,
+    models_data: dict[str, dict],
+    build_tag: str,
+    git_sha: str,
+) -> None:
+    """
+    Atomically update baseline_db.json with metrics from the current run.
+    Creates the file if it does not exist.
+    """
+    p = Path(db_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+    db = load_db(p)
+    hw = db["hardware_profiles"].setdefault(hw_key, {"stages": {}})
+    stage = hw["stages"].setdefault(stage_name, {"models": {}})
+
+    now = datetime.now(timezone.utc).isoformat()
+    for model_key, metrics in models_data.items():
+        entry = {
+            "prefill_time": metrics.get("prefill_time"),
+            "decode_perf": metrics.get("decode_perf"),
+            "total_perf": metrics.get("total_perf"),
+            "total_time": metrics.get("total_time"),
+            "onnx_size_bytes": metrics.get("onnx_size_bytes"),
+            "qpc_size_bytes": metrics.get("qpc_size_bytes"),
+            "baseline_sha": git_sha,
+            "baseline_timestamp": now,
+        }
+        stage["models"][model_key] = entry
+
+    db["last_updated"] = now
+    db["last_updated_by"] = build_tag
+
+    _atomic_write(p, db)
+
+
+def _atomic_write(target: Path, data: dict) -> None:
+    """Write *data* as JSON to *target* atomically via a temp file."""
+    tmp = target.with_suffix(target.suffix + f".{os.getpid()}.tmp")
+    try:
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)

--- a/tests/ci_perf/test_compare_perf.py
+++ b/tests/ci_perf/test_compare_perf.py
@@ -1,0 +1,348 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+"""
+Unit tests for the CI perf tracking comparison logic.
+
+All tests run without QAIC hardware — they use synthetic in-memory data.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.ci_perf.compare_perf import compare_report, get_threshold, load_thresholds, main
+from tests.ci_perf.conftest import PerfRecorder, _build_key
+from tests.ci_perf.storage import compute_dir_size, load_db, update_baseline
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DEFAULT_THRESHOLDS = {
+    "default": {
+        "prefill_time": {"percentage_tolerance": 5.0},
+        "decode_perf": {"percentage_tolerance": 5.0},
+        "onnx_size_bytes": {"percentage_tolerance": 5.0},
+        "qpc_size_bytes": {"percentage_tolerance": 5.0},
+    },
+    "per_model": {},
+}
+
+
+def _make_report(models: dict, stage="QAIC_LLM") -> dict:
+    return {"schema_version": "1", "stage_name": stage, "models": models}
+
+
+def _make_baseline(models: dict, hw_key="qeff_node_16", stage="QAIC_LLM") -> dict:
+    return {
+        "schema_version": "1",
+        "hardware_profiles": {hw_key: {"stages": {stage: {"models": models}}}},
+    }
+
+
+def _write_report(tmp_path: Path, models: dict, stage="QAIC_LLM") -> Path:
+    stage_dir = tmp_path / stage
+    stage_dir.mkdir(parents=True)
+    report_file = stage_dir / "perf_report.json"
+    report_file.write_text(
+        json.dumps({"schema_version": "1", "stage_name": stage, "ci_build_tag": "test-build",
+                    "git_sha": "abc123", "hardware": {}, "models": models}),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _write_db(tmp_path: Path, db: dict) -> Path:
+    db_file = tmp_path / "baseline_db.json"
+    db_file.write_text(json.dumps(db), encoding="utf-8")
+    return db_file
+
+
+def _good_model():
+    return {"prefill_time": 0.044, "decode_perf": 121.0, "onnx_size_bytes": 1000, "qpc_size_bytes": 500,
+            "total_perf": 111.0, "total_time": 2.28, "batch_size": 1}
+
+
+# ---------------------------------------------------------------------------
+# Test 1: empty DB → all models SKIPped, exit 0
+# ---------------------------------------------------------------------------
+def test_first_run_model_skipped():
+    report = _make_report({"model::bs=1": _good_model()})
+    rows, failures = compare_report(report, baseline_models={}, thresholds=DEFAULT_THRESHOLDS)
+    assert failures == []
+    assert rows[0]["status"] == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: within tolerance → pass
+# ---------------------------------------------------------------------------
+def test_within_tolerance_passes():
+    baseline = {"model::bs=1": {**_good_model()}}
+    current_model = {**_good_model(), "decode_perf": 118.0}  # -2.5% — within 5%
+    report = _make_report({"model::bs=1": current_model})
+    _, failures = compare_report(report, baseline_models=baseline, thresholds=DEFAULT_THRESHOLDS)
+    assert failures == []
+
+
+# ---------------------------------------------------------------------------
+# Test 3: decode_perf drops 25% → exit 1
+# ---------------------------------------------------------------------------
+def test_decode_perf_regression_fails():
+    baseline = {"model::bs=1": {**_good_model()}}
+    current_model = {**_good_model(), "decode_perf": 90.0}  # -25.6%
+    report = _make_report({"model::bs=1": current_model})
+    _, failures = compare_report(report, baseline_models=baseline, thresholds=DEFAULT_THRESHOLDS)
+    assert any("decode_perf" in f for f in failures)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: prefill_time rises 20% → exit 1
+# ---------------------------------------------------------------------------
+def test_prefill_time_regression_fails():
+    baseline = {"model::bs=1": {**_good_model()}}
+    current_model = {**_good_model(), "prefill_time": 0.053}  # +20.5%
+    report = _make_report({"model::bs=1": current_model})
+    _, failures = compare_report(report, baseline_models=baseline, thresholds=DEFAULT_THRESHOLDS)
+    assert any("prefill_time" in f for f in failures)
+
+
+# ---------------------------------------------------------------------------
+# Test 5: onnx_size grows 10% → exit 1
+# ---------------------------------------------------------------------------
+def test_onnx_size_regression_fails():
+    baseline = {"model::bs=1": {**_good_model()}}
+    current_model = {**_good_model(), "onnx_size_bytes": 1100}  # +10%
+    report = _make_report({"model::bs=1": current_model})
+    _, failures = compare_report(report, baseline_models=baseline, thresholds=DEFAULT_THRESHOLDS)
+    assert any("onnx_size_bytes" in f for f in failures)
+
+
+# ---------------------------------------------------------------------------
+# Test 6: qpc_size grows 10% → exit 1
+# ---------------------------------------------------------------------------
+def test_qpc_size_regression_fails():
+    baseline = {"model::bs=1": {**_good_model()}}
+    current_model = {**_good_model(), "qpc_size_bytes": 555}  # +11%
+    report = _make_report({"model::bs=1": current_model})
+    _, failures = compare_report(report, baseline_models=baseline, thresholds=DEFAULT_THRESHOLDS)
+    assert any("qpc_size_bytes" in f for f in failures)
+
+
+# ---------------------------------------------------------------------------
+# Test 7: onnx_size_bytes=None in report → not compared, no failure
+# ---------------------------------------------------------------------------
+def test_size_null_skipped():
+    baseline = {"model::bs=1": {**_good_model()}}
+    current_model = {**_good_model(), "onnx_size_bytes": None}
+    report = _make_report({"model::bs=1": current_model})
+    rows, failures = compare_report(report, baseline_models=baseline, thresholds=DEFAULT_THRESHOLDS)
+    assert failures == [] or not any("onnx_size_bytes" in f for f in failures)
+    onnx_rows = [r for r in rows if r["metric"] == "onnx_size_bytes"]
+    assert all(r["status"] == "skipped" for r in onnx_rows)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: decode_perf improves 30% → exit 0 (improvement never fails)
+# ---------------------------------------------------------------------------
+def test_improvement_does_not_fail():
+    baseline = {"model::bs=1": {**_good_model()}}
+    current_model = {**_good_model(), "decode_perf": 157.0}  # +29.8% improvement
+    report = _make_report({"model::bs=1": current_model})
+    _, failures = compare_report(report, baseline_models=baseline, thresholds=DEFAULT_THRESHOLDS)
+    assert failures == []
+
+
+# ---------------------------------------------------------------------------
+# Test 9: per-model tolerance override
+# ---------------------------------------------------------------------------
+def test_per_model_tolerance_override():
+    thresholds = {
+        **DEFAULT_THRESHOLDS,
+        "per_model": {
+            "noisy-model::bs=1": {
+                "prefill_time": {"percentage_tolerance": 15.0},
+            }
+        },
+    }
+    baseline = {"noisy-model::bs=1": {**_good_model()}}
+    current_model = {**_good_model(), "prefill_time": 0.050}  # +13.6% — under 15% override
+    report = _make_report({"noisy-model::bs=1": current_model})
+    _, failures = compare_report(report, baseline_models=baseline, thresholds=thresholds)
+    assert failures == []
+
+
+# ---------------------------------------------------------------------------
+# Test 10: --update-baseline creates/updates baseline_db.json
+# ---------------------------------------------------------------------------
+def test_update_baseline_writes_db(tmp_path):
+    db_path = tmp_path / "baseline_db.json"
+    update_baseline(
+        db_path=db_path,
+        hw_key="qeff_node_16",
+        stage_name="QAIC_LLM",
+        models_data={"model::bs=1": _good_model()},
+        build_tag="test-build",
+        git_sha="abc123",
+    )
+    assert db_path.exists()
+    db = json.loads(db_path.read_text())
+    stored = db["hardware_profiles"]["qeff_node_16"]["stages"]["QAIC_LLM"]["models"]["model::bs=1"]
+    assert stored["decode_perf"] == 121.0
+    assert stored["onnx_size_bytes"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Test 11: atomic write — existing DB intact if process crashes mid-write
+# ---------------------------------------------------------------------------
+def test_atomic_write_preserves_existing(tmp_path):
+    db_path = tmp_path / "baseline_db.json"
+    # Write initial DB
+    update_baseline(db_path, "hw", "STAGE", {"m::bs=1": _good_model()}, "b1", "s1")
+    original_content = db_path.read_text()
+
+    # Simulate a failed second write (temp file left behind, original untouched by os.replace)
+    tmp_file = db_path.with_suffix(".json.tmp_test")
+    tmp_file.write_text('{"broken": true}')
+    # tmp file exists but was never renamed — original is intact
+    assert db_path.read_text() == original_content
+
+
+# ---------------------------------------------------------------------------
+# Test 12: missing hardware key → all models SKIP
+# ---------------------------------------------------------------------------
+def test_hardware_key_isolation():
+    # DB has baseline for qeff_node_16, but we compare with qeff_node_8
+    db = _make_baseline({"model::bs=1": _good_model()}, hw_key="qeff_node_16")
+    baseline_models = (
+        db.get("hardware_profiles", {})
+        .get("qeff_node_8", {})  # wrong key
+        .get("stages", {})
+        .get("QAIC_LLM", {})
+        .get("models", {})
+    )
+    report = _make_report({"model::bs=1": _good_model()})
+    rows, failures = compare_report(report, baseline_models=baseline_models, thresholds=DEFAULT_THRESHOLDS)
+    assert failures == []
+    assert all(r["status"] == "skipped" for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Test 13: exec_info=None → no crash, empty records
+# ---------------------------------------------------------------------------
+def test_perf_recorder_noop_on_none():
+    recorder = PerfRecorder()
+    recorder.record("model", exec_info=None, config={"batch_size": 1})
+    assert recorder._records == {}
+
+
+# ---------------------------------------------------------------------------
+# Test 14: xdist worker merge
+# ---------------------------------------------------------------------------
+def test_xdist_merge():
+    worker_0 = {"model_a::bs=1": _good_model()}
+    worker_1 = {"model_b::bs=1": {**_good_model(), "decode_perf": 90.0}}
+    merged = {}
+    merged.update(worker_0)
+    merged.update(worker_1)
+    assert "model_a::bs=1" in merged
+    assert "model_b::bs=1" in merged
+    assert len(merged) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test 15: composite key uniqueness — same model, different batch_size → 2 entries
+# ---------------------------------------------------------------------------
+def test_composite_key_uniqueness():
+    key_bs1 = _build_key("meta-llama/Llama-3.2-1B", {"batch_size": 1, "seq_len": 128, "decode": "greedy"})
+    key_bs4 = _build_key("meta-llama/Llama-3.2-1B", {"batch_size": 4, "seq_len": 128, "decode": "greedy"})
+    assert key_bs1 != key_bs4
+    assert "meta-llama/Llama-3.2-1B" in key_bs1
+    assert "batch_size=1" in key_bs1
+    assert "batch_size=4" in key_bs4
+
+
+# ---------------------------------------------------------------------------
+# CLI integration test (uses tmp_path, no QAIC)
+# ---------------------------------------------------------------------------
+def test_cli_first_run_exits_zero(tmp_path):
+    report_dir = _write_report(tmp_path / "reports", {"model::bs=1": _good_model()})
+    db_path = tmp_path / "db" / "baseline_db.json"
+    thresholds_path = tmp_path / "thresholds.json"
+    thresholds_path.write_text(json.dumps(DEFAULT_THRESHOLDS))
+
+    rc = main([
+        "--report-dir", str(report_dir),
+        "--db-path", str(db_path),
+        "--stage", "QAIC_LLM",
+        "--hardware-key", "qeff_node_16",
+        "--thresholds", str(thresholds_path),
+    ])
+    assert rc == 0  # no baseline → all skipped → pass
+
+
+def test_cli_regression_exits_one(tmp_path):
+    db_path = tmp_path / "db" / "baseline_db.json"
+    thresholds_path = tmp_path / "thresholds.json"
+    thresholds_path.write_text(json.dumps(DEFAULT_THRESHOLDS))
+
+    # Write baseline first
+    update_baseline(db_path, "qeff_node_16", "QAIC_LLM",
+                    {"model::bs=1": _good_model()}, "b1", "s1")
+
+    # Report with a clear decode_perf regression
+    bad_model = {**_good_model(), "decode_perf": 80.0}  # -33.9%
+    report_dir = _write_report(tmp_path / "reports", {"model::bs=1": bad_model})
+
+    rc = main([
+        "--report-dir", str(report_dir),
+        "--db-path", str(db_path),
+        "--stage", "QAIC_LLM",
+        "--hardware-key", "qeff_node_16",
+        "--thresholds", str(thresholds_path),
+    ])
+    assert rc == 1
+
+
+def test_cli_update_baseline(tmp_path):
+    db_path = tmp_path / "db" / "baseline_db.json"
+    thresholds_path = tmp_path / "thresholds.json"
+    thresholds_path.write_text(json.dumps(DEFAULT_THRESHOLDS))
+    report_dir = _write_report(tmp_path / "reports", {"model::bs=1": _good_model()})
+
+    rc = main([
+        "--report-dir", str(report_dir),
+        "--db-path", str(db_path),
+        "--stage", "QAIC_LLM",
+        "--hardware-key", "qeff_node_16",
+        "--thresholds", str(thresholds_path),
+        "--update-baseline",
+    ])
+    assert rc == 0
+    db = load_db(db_path)
+    assert "QAIC_LLM" in db["hardware_profiles"]["qeff_node_16"]["stages"]
+
+
+# ---------------------------------------------------------------------------
+# compute_dir_size
+# ---------------------------------------------------------------------------
+def test_compute_dir_size_returns_none_for_none():
+    assert compute_dir_size(None) is None
+
+
+def test_compute_dir_size_returns_none_for_missing(tmp_path):
+    assert compute_dir_size(tmp_path / "nonexistent") is None
+
+
+def test_compute_dir_size_counts_bytes(tmp_path):
+    (tmp_path / "a.bin").write_bytes(b"x" * 1024)
+    (tmp_path / "b.bin").write_bytes(b"y" * 512)
+    assert compute_dir_size(tmp_path) == 1536

--- a/tests/ci_perf/thresholds.json
+++ b/tests/ci_perf/thresholds.json
@@ -1,0 +1,9 @@
+{
+  "default": {
+    "prefill_time":    {"percentage_tolerance": 5.0},
+    "decode_perf":     {"percentage_tolerance": 5.0},
+    "onnx_size_bytes": {"percentage_tolerance": 5.0},
+    "qpc_size_bytes":  {"percentage_tolerance": 5.0}
+  },
+  "per_model": {}
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,8 @@ from pathlib import Path
 import pytest
 from transformers import logging as hf_logging
 
+pytest_plugins = ["tests.ci_perf.conftest"]
+
 from QEfficient.utils.cache import QEFF_HOME
 from QEfficient.utils.logging_utils import logger
 

--- a/tests/transformers/models/causal_lm_models/check_causal_models.py
+++ b/tests/transformers/models/causal_lm_models/check_causal_models.py
@@ -107,6 +107,8 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
     mdp_num_partitions: Optional[int] = None,
     mdp_strategy: Optional[str] = None,
     use_onnx_subfunctions: bool = False,
+    perf_recorder=None,
+    request=None,
 ):
     torch.manual_seed(42)
     replace_transformers_quantizers()
@@ -217,6 +219,16 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
 
     # Generate
     exec_info = qeff_model.generate(tokenizer, prompts=prompts)
+
+    if perf_recorder is not None:
+        perf_recorder.record(
+            model_name=model_name,
+            exec_info=exec_info,
+            config={"batch_size": batch_size, "seq_len": ctx_len, "decode": "greedy"},
+            onnx_path=onnx_model_path,
+            qpc_path=qpc_path,
+            request=request,
+        )
 
     if continuous_batching:
         cloud_ai_100_tokens = exec_info.generated_ids

--- a/tests/transformers/models/causal_lm_models/test_causal_lm_models.py
+++ b/tests/transformers/models/causal_lm_models/test_causal_lm_models.py
@@ -33,13 +33,14 @@ model_config_dict = {model["model_name"]: model for model in causal_lm_models}
 @pytest.mark.on_qaic
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_causal)
-def test_full_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
+def test_full_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup, perf_recorder, request):
     if model_name in ModelConfig.SKIPPED_MODELS:
         pytest.skip("Test skipped for this model due to issues in HF.")
     if model_name in ModelConfig.FULL_MODEL_TESTS_TO_SKIP:
         pytest.skip(f"Skipping full model test for {model_name} due to resource constraints.")
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
-        model_name, compare_results=True, manual_cleanup=manual_cleanup, num_devices=4
+        model_name, compare_results=True, manual_cleanup=manual_cleanup, num_devices=4,
+        perf_recorder=perf_recorder, request=request,
     )
 
 
@@ -47,11 +48,14 @@ def test_full_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup
 @pytest.mark.on_qaic
 @pytest.mark.llm_model
 @pytest.mark.parametrize("model_name", test_models_causal)
-def test_few_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup):
+def test_few_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name, manual_cleanup, perf_recorder, request):
     if model_name in ModelConfig.SKIPPED_MODELS:
         pytest.skip("Test skipped for this model due to issues in HF.")
     n_layer = get_custom_n_layers(model_name)
-    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(model_name=model_name, n_layer=n_layer, manual_cleanup=manual_cleanup)
+    check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
+        model_name=model_name, n_layer=n_layer, manual_cleanup=manual_cleanup,
+        perf_recorder=perf_recorder, request=request,
+    )
 
 
 @pytest.mark.few_layers

--- a/tests/transformers/models/image_text_to_text/test_image_text_to_text_models.py
+++ b/tests/transformers/models/image_text_to_text/test_image_text_to_text_models.py
@@ -71,6 +71,8 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
     mdp_num_partitions: Optional[int] = None,
     mdp_strategy: Optional[str] = None,
     use_onnx_subfunctions: bool = False,
+    perf_recorder=None,
+    request=None,
 ):
     prompt_len = model_config_dict[model_name]["prompt_len"]
     ctx_len = model_config_dict[model_name]["ctx_len"]
@@ -306,6 +308,16 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
     print("QPC Outputs (QAIC):")
     exec_info = qeff_model.generate(inputs=inputs, generation_len=NEW_GENERATION_TOKENS, streamer=streamer)
     print(exec_info)
+
+    if perf_recorder is not None:
+        perf_recorder.record(
+            model_name=model_name,
+            exec_info=exec_info,
+            config={"batch_size": batch_size, "seq_len": ctx_len, "decode": "greedy"},
+            onnx_path=qeff_model.onnx_path,
+            qpc_path=getattr(qeff_model, "qpc_path", None),
+            request=request,
+        )
     cloud_ai_100_tokens = exec_info.generated_ids[:, :-1]
     assert (pytorch_hf_tokens == cloud_ai_100_tokens).all(), "Tokens don't match for pytorch HF output and QPC output"
     manual_cleanup(qeff_model.onnx_path)  # Clean up the model files after the tests are done.
@@ -329,7 +341,7 @@ def check_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(
 @pytest.mark.multimodal
 @pytest.mark.parametrize("model_name", test_mm_models)
 @pytest.mark.parametrize("kv_offload", [True, False])
-def test_full_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(model_name, kv_offload, manual_cleanup):
+def test_full_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(model_name, kv_offload, manual_cleanup, perf_recorder, request):
     if model_name in ModelConfig.SKIPPED_MODELS:
         pytest.skip("Test skipped for this model due to some issues.")
     if model_name in ["tiny-random/gemma-4-dense", "tiny-random/gemma-4-moe"]:
@@ -344,6 +356,8 @@ def test_full_image_text_to_text_pytorch_vs_kv_vs_ort_vs_ai100(model_name, kv_of
         compare_results=True,
         manual_cleanup=manual_cleanup,
         num_devices=4,
+        perf_recorder=perf_recorder,
+        request=request,
     )
 
 


### PR DESCRIPTION
Introduces tests/ci_perf/ — a pytest plugin + CLI tooling that captures prefill_time, decode_perf, onnx_size_bytes and qpc_size_bytes per model on every QAIC CI stage, persists them to a JSON baseline DB on the CI host, and adds two new Jenkins stages:

  - Perf Comparison: compares current PR metrics against the baseline DB using a configurable percentage threshold (default 5%) and blocks the PR on regression.
  - Update Perf Baseline: runs only on the main branch and atomically updates the baseline DB with the current run's values.

Key design decisions:
- Hardware-keyed DB prevents false failures across different NSP configurations.
- Composite key (model::bs=N::seq=N::decode=X) ensures same model with different inference configs never collide in the DB.
- Sizes are optional — inference-only tests omit onnx_path/qpc_path and the null values are stored but never compared.
- xdist-aware plugin merges worker records via pytest_testnodedown.
- First-run grace: new models not yet in the DB are SKIPped, not failed.