### PR TITLE
fix(diffusers/wan): disable weight offloading for WAN DIT transformer

### DIFF
--- a/QEfficient/diffusers/pipelines/pipeline_module.py
+++ b/QEfficient/diffusers/pipelines/pipeline_module.py
@@ -625,7 +625,7 @@ class QEffWanTransformer(QEFFBaseModel):
             output_names=output_names,
             dynamic_axes=dynamic_axes,
             export_dir=export_dir,
-            offload_pt_weights=False,
+            offload_pt_weights=False,  # condition_embedder holds learned weights needed on CPU at runtime (pipeline_wan.py denoise loop)
             use_onnx_subfunctions=use_onnx_subfunctions,
         )
 
@@ -761,7 +761,7 @@ class QEffWanUnifiedTransformer(QEFFBaseModel):
             output_names=output_names,
             dynamic_axes=dynamic_axes,
             export_dir=export_dir,
-            offload_pt_weights=False,
+            offload_pt_weights=False,  # condition_embedder holds learned weights needed on CPU at runtime (pipeline_wan.py denoise loop)
             use_onnx_subfunctions=use_onnx_subfunctions,
         )
 

--- a/QEfficient/diffusers/pipelines/pipeline_module.py
+++ b/QEfficient/diffusers/pipelines/pipeline_module.py
@@ -625,7 +625,7 @@ class QEffWanTransformer(QEFFBaseModel):
             output_names=output_names,
             dynamic_axes=dynamic_axes,
             export_dir=export_dir,
-            offload_pt_weights=True,
+            offload_pt_weights=False,
             use_onnx_subfunctions=use_onnx_subfunctions,
         )
 
@@ -761,7 +761,7 @@ class QEffWanUnifiedTransformer(QEFFBaseModel):
             output_names=output_names,
             dynamic_axes=dynamic_axes,
             export_dir=export_dir,
-            offload_pt_weights=True,
+            offload_pt_weights=False,
             use_onnx_subfunctions=use_onnx_subfunctions,
         )
 


### PR DESCRIPTION
 Description:

  ## Problem

  When running the WAN pipeline for the first time (i.e., when export and compile both
  need to happen), the following error was raised during ONNX export:

  RuntimeError: Tensor on device meta is not on the expected device cpu!

  The error did not occur on subsequent runs where the QPC was already present.

  ## Fix

  Set offload_pt_weights=False in the export() methods of both QEffWanTransformer and
  QEffWanUnifiedTransformer. This keeps DIT weights on CPU throughout the
  export+compile lifecycle, preventing any meta-device contamination.


  ## Files Changed

  - QEfficient/diffusers/pipelines/pipeline_module.py — QEffWanTransformer.export()
    and QEffWanUnifiedTransformer.export(): offload_pt_weights=True →
    offload_pt_weights=False

  ## Testing

  - Verified the fix resolves the meta-device error on first-run export+compile for
    wan_lightning.py
  - Subsequent runs with existing QPC continue to work as before
  - Verified on both ai100 and ai200 HW