### PR TITLE
feat: add w_sub ONNX semantic weight + node rename transform

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -26,6 +26,7 @@ from QEfficient.base.onnx_transforms import (
     OnnxTransformPipeline,
     PruneFakeInitializersTransform,
     RenameFunctionOutputsTransform,
+    RenameWsubTransform,
     SplitTensorsTransform,
 )
 from QEfficient.base.pytorch_transforms import PytorchTransform
@@ -60,6 +61,44 @@ from QEfficient.utils.export_utils import export_wrapper
 from QEfficient.utils.torch_patches import layerwise_safe_onnx_export_patches
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_hf_cache_path(pretrained_model_name_or_path: str) -> Optional[str]:
+    """Resolve the local HF cache path for a model given its HF hub name.
+
+    Looks in HF_HOME (or ~/.cache/huggingface) for the cached snapshot.
+    Returns the snapshot directory path if found, else None.
+    """
+    if not pretrained_model_name_or_path:
+        return None
+    if os.path.isdir(pretrained_model_name_or_path):
+        safetensors_index = os.path.join(pretrained_model_name_or_path, "model.safetensors.index.json")
+        safetensors_single = os.path.join(pretrained_model_name_or_path, "model.safetensors")
+        if os.path.exists(safetensors_index) or os.path.exists(safetensors_single):
+            return pretrained_model_name_or_path
+    hf_home = (
+        os.environ.get("HF_HOME")
+        or os.environ.get("HUGGINGFACE_HUB_CACHE")
+        or os.path.join(os.path.expanduser("~"), ".cache", "huggingface")
+    )
+    hub_dir = os.path.join(hf_home, "hub")
+    if not os.path.isdir(hub_dir):
+        return None
+    model_dir_name = "models--" + pretrained_model_name_or_path.replace("/", "--")
+    snapshots_dir = os.path.join(hub_dir, model_dir_name, "snapshots")
+    if not os.path.isdir(snapshots_dir):
+        return None
+    snapshots = [
+        os.path.join(snapshots_dir, s)
+        for s in os.listdir(snapshots_dir)
+        if os.path.isdir(os.path.join(snapshots_dir, s))
+    ]
+    for snap in sorted(snapshots, key=lambda p: -os.path.getmtime(p)):
+        if os.path.exists(os.path.join(snap, "model.safetensors.index.json")) or os.path.exists(
+            os.path.join(snap, "model.safetensors")
+        ):
+            return snap
+    return None
 
 
 def _rename_graph_value(graph: onnx.GraphProto, old_name: str, new_name: str) -> None:
@@ -441,6 +480,7 @@ class QEFFBaseModel(ABC):
         prefill_only: Optional[bool] = False,
         dynamo: bool = False,
         dynamic_shapes: Optional[Dict[str, Dict[int, Any]]] = None,
+        rename_onnx_nodes: bool = False,
         **export_kwargs,
     ) -> str:
         """
@@ -601,6 +641,40 @@ class QEFFBaseModel(ABC):
                 onnx.StringStringEntryProto(key="qeff_transforms", value=",".join(self._transform_names()))
             )
             logger.info("ONNX transforms applied")
+
+            # W_Sub semantic rename: when enabled, rename opaque weights/nodes
+            # to semantic HF names using fingerprint matching.
+            if rename_onnx_nodes and not export_kwargs.get("use_onnx_subfunctions", False):
+                logger.warning(
+                    "rename_onnx_nodes=True requires use_onnx_subfunctions=True. "
+                    "Skipping semantic rename."
+                )
+            elif rename_onnx_nodes and export_kwargs.get("use_onnx_subfunctions", False):
+                hf_model_path = (onnx_transform_kwargs or {}).get("hf_model_path")
+                if hf_model_path is None:
+                    hf_model_path = _resolve_hf_cache_path(
+                        self.hash_params.get("pretrained_model_name_or_path", "")
+                    )
+                if hf_model_path:
+                    logger.info(
+                        f"RenameWsubTransform: applying semantic rename (hf_model_path={hf_model_path})"
+                    )
+                    model, renamed = RenameWsubTransform.apply(
+                        model,
+                        hf_model_path=hf_model_path,
+                        onnx_base_dir=str(export_dir),
+                    )
+                    if renamed:
+                        logger.info("RenameWsubTransform: semantic names baked into ONNX")
+                    else:
+                        logger.warning(
+                            "RenameWsubTransform: rename failed — check hf_model_path and ONNX weights"
+                        )
+                else:
+                    logger.warning(
+                        "RenameWsubTransform: HF model path not found. "
+                        "Set HF_HOME or pass onnx_transform_kwargs={'hf_model_path': ...}"
+                    )
 
             onnx_path_tmp = onnx_path.with_suffix(onnx_path.suffix + ".tmp")
             onnx.save(model, onnx_path_tmp)

--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -667,3 +667,313 @@ class OnnxTransformPipeline(BaseOnnxTransform):
             logger.info(f"Transform '{t.__name__}' applied={done}")
 
         return model, any(applied.values())
+
+
+class RenameWsubTransform(BaseOnnxTransform):
+    """Rename opaque w_sub ONNX weights and nodes to semantic HF names.
+
+    Uses 256-byte fingerprint matching between ONNX external weight data and
+    HF safetensors to build a rename map, then applies weight rename + node rename.
+
+    Handles both individual external files (onnx__MatMul_NNN) and consolidated
+    data files (model.onnx.data with offset+length metadata).
+    """
+
+    FINGERPRINT_BYTES = 256
+
+    # Regex: model.layers.N.<role>.weight -> extract <role> for node rename
+    _SEMANTIC_PARAM_RE = re.compile(
+        r"model\.layers\.\d+\.((?:self_attn|mlp)[\w.]+?)(?:\.weight)?$"
+    )
+    _NORM_ROLE_RE = re.compile(
+        r"model\.layers\.\d+\.(input_layernorm|post_attention_layernorm)\.weight$"
+    )
+
+    @classmethod
+    def apply(
+        cls,
+        model: ModelProto,
+        *,
+        hf_model_path: str,
+        onnx_base_dir: str,
+        **kwargs,
+    ) -> Tuple[ModelProto, bool]:
+        """Apply weight + node rename to a w_sub ONNX model.
+
+        Args:
+            model: ONNX ModelProto (loaded with load_external_data=False).
+            hf_model_path: Path to HF model dir containing safetensors.
+            onnx_base_dir: Directory containing ONNX external data files.
+
+        Returns:
+            (model, transformed) tuple.
+        """
+        if not hf_model_path or not os.path.isdir(hf_model_path):
+            logger.warning(f"RenameWsubTransform: hf_model_path not found: {hf_model_path}")
+            return model, False
+
+        if not onnx_base_dir or not os.path.isdir(onnx_base_dir):
+            logger.warning(f"RenameWsubTransform: onnx_base_dir not found: {onnx_base_dir}")
+            return model, False
+
+        # Step 1: Collect opaque initializer info
+        opaque_infos = cls._get_opaque_initializer_info(model, onnx_base_dir)
+        if not opaque_infos:
+            logger.info("RenameWsubTransform: no opaque initializers found, skipping")
+            return model, False
+
+        # Step 2: Detect ONNX weight dtype
+        onnx_dtype_code = opaque_infos[0]["data_type"]
+        if onnx_dtype_code == onnx.TensorProto.FLOAT:
+            target_np_dtype = np.float32
+        elif onnx_dtype_code == onnx.TensorProto.FLOAT16:
+            target_np_dtype = np.float16
+        else:
+            logger.warning(f"RenameWsubTransform: unsupported ONNX dtype code {onnx_dtype_code}")
+            return model, False
+
+        # Step 3: Build HF fingerprint map
+        hf_fp_map = cls._build_hf_fingerprint_map(hf_model_path, target_np_dtype)
+        if not hf_fp_map:
+            logger.warning("RenameWsubTransform: no HF fingerprints built")
+            return model, False
+
+        # Step 4: Match ONNX fingerprints to HF
+        rename_map: Dict[str, str] = {}
+        for info in opaque_infos:
+            onnx_fp = cls._read_onnx_fingerprint(info)
+            if onnx_fp is None:
+                continue
+            hf_param = hf_fp_map.get(onnx_fp)
+            if hf_param:
+                clean_name = hf_param
+                for prefix in ("language_model.",):
+                    if clean_name.startswith(prefix):
+                        clean_name = clean_name[len(prefix):]
+                rename_map[info["name"]] = clean_name
+
+        if not rename_map:
+            logger.warning("RenameWsubTransform: no fingerprint matches found")
+            return model, False
+
+        logger.info(f"RenameWsubTransform: matched {len(rename_map)}/{len(opaque_infos)} weights")
+
+        # Step 5: Apply weight rename + node rename
+        weight_count, node_count = cls._apply_weight_and_node_rename(model, rename_map)
+        logger.info(f"RenameWsubTransform: renamed {weight_count} weights, {node_count} nodes")
+
+        # Step 6: Stamp metadata
+        model.metadata_props.append(
+            onnx.StringStringEntryProto(key="qeff_weight_names", value="semantic_hf")
+        )
+        if node_count > 0:
+            model.metadata_props.append(
+                onnx.StringStringEntryProto(key="qeff_node_names", value="semantic_role")
+            )
+
+        return model, True
+
+    @classmethod
+    def _get_opaque_initializer_info(cls, model: ModelProto, onnx_base_dir: str) -> List[Dict[str, Any]]:
+        """Extract external data info for opaque initializers."""
+        results = []
+        for init in model.graph.initializer:
+            if not ("onnx::MatMul_" in init.name or "onnx::Add_" in init.name):
+                continue
+            ext = {}
+            for entry in init.external_data:
+                ext[entry.key] = entry.value
+            location = ext.get("location", "")
+            offset = int(ext.get("offset", 0))
+            length = int(ext.get("length", 0))
+            if location:
+                filepath = os.path.join(onnx_base_dir, location)
+            else:
+                bare_name = init.name.replace("::", "__")
+                filepath = os.path.join(onnx_base_dir, bare_name)
+                offset = 0
+            results.append({
+                "name": init.name,
+                "filepath": filepath,
+                "offset": offset,
+                "length": length,
+                "data_type": init.data_type,
+            })
+        return results
+
+    @classmethod
+    def _read_onnx_fingerprint(cls, info: Dict[str, Any]) -> Optional[bytes]:
+        """Read first FINGERPRINT_BYTES from an ONNX external weight."""
+        if not os.path.exists(info["filepath"]):
+            return None
+        read_len = min(cls.FINGERPRINT_BYTES, info["length"]) if info["length"] > 0 else cls.FINGERPRINT_BYTES
+        try:
+            with open(info["filepath"], "rb") as fh:
+                fh.seek(info["offset"])
+                data = fh.read(read_len)
+            return data if len(data) == read_len else None
+        except OSError:
+            return None
+
+    @classmethod
+    def _build_hf_fingerprint_map(cls, hf_model_path: str, target_dtype) -> Dict[bytes, str]:
+        """Build {fingerprint_bytes -> hf_param_name} from HF safetensors."""
+        import json as _json
+        import math as _math
+        import struct as _struct
+
+        fp_map: Dict[bytes, str] = {}
+        index_path = os.path.join(hf_model_path, "model.safetensors.index.json")
+        if os.path.exists(index_path):
+            with open(index_path) as f:
+                weight_map = _json.load(f)["weight_map"]
+        else:
+            single = os.path.join(hf_model_path, "model.safetensors")
+            if not os.path.exists(single):
+                return fp_map
+            with open(single, "rb") as f:
+                hdr_size = _struct.unpack("<Q", f.read(8))[0]
+                hdr = _json.loads(f.read(hdr_size))
+            weight_map = {k: "model.safetensors" for k in hdr if k != "__metadata__"}
+
+        target_params = [
+            k for k in weight_map
+            if k.endswith(".weight")
+            and "layers." in k
+            and any(sub in k for sub in (
+                "proj", "gate_proj", "up_proj", "down_proj", "router", "mlp.gate."
+            ))
+            and "mlp.experts." not in k
+        ]
+
+        for param_name in target_params:
+            shard_path = os.path.join(hf_model_path, weight_map[param_name])
+            if not os.path.exists(shard_path):
+                continue
+            fp = cls._read_hf_fingerprint(shard_path, param_name, target_dtype)
+            if fp:
+                fp_map[fp] = param_name
+
+        return fp_map
+
+    @classmethod
+    def _read_hf_fingerprint(cls, shard_path: str, param_name: str, target_dtype) -> Optional[bytes]:
+        """Read, transpose, dtype-convert a HF weight and return fingerprint bytes."""
+        import json as _json
+        import math as _math
+        import struct as _struct
+
+        target_bytes_per_elem = 4 if target_dtype == np.float32 else 2
+        try:
+            with open(shard_path, "rb") as f:
+                hdr_size = _struct.unpack("<Q", f.read(8))[0]
+                hdr = _json.loads(f.read(hdr_size))
+                if param_name not in hdr:
+                    return None
+                info = hdr[param_name]
+                hf_dtype = info["dtype"]
+                shape = info["shape"]
+                start = info["data_offsets"][0]
+                if len(shape) < 2:
+                    return None
+                out_features, in_features = shape[0], shape[1]
+                bytes_per_elem = {"BF16": 2, "F16": 2, "F32": 4}.get(hf_dtype, 0)
+                if bytes_per_elem == 0:
+                    return None
+                n_rows = min(
+                    out_features,
+                    _math.ceil(cls.FINGERPRINT_BYTES / target_bytes_per_elem),
+                )
+                n_rows = max(n_rows, 1)
+                read_bytes = n_rows * in_features * bytes_per_elem
+                f.seek(8 + hdr_size + start)
+                raw = f.read(read_bytes)
+        except (OSError, KeyError, ValueError):
+            return None
+
+        if len(raw) < n_rows * in_features * bytes_per_elem:
+            return None
+
+        arr = np.frombuffer(raw, dtype=np.uint16 if hf_dtype in ("BF16", "F16") else np.float32)
+        if hf_dtype == "BF16":
+            fp32 = (arr.astype(np.uint32) << 16).view(np.float32)
+        elif hf_dtype == "F16":
+            fp32 = arr.view(np.float16).astype(np.float32)
+        else:
+            fp32 = arr.copy()
+
+        fp32 = fp32.reshape(n_rows, in_features).T.copy()
+        if target_dtype == np.float16:
+            result = fp32.astype(np.float16)
+        else:
+            result = fp32
+        return result.tobytes()[:cls.FINGERPRINT_BYTES]
+
+    @classmethod
+    def _get_node_role(cls, weight_name: str) -> Optional[str]:
+        """Extract semantic role from a renamed weight name."""
+        match = cls._SEMANTIC_PARAM_RE.match(weight_name)
+        if match:
+            return match.group(1).replace(".", "/")
+        return None
+
+    @classmethod
+    def _apply_weight_and_node_rename(
+        cls, model: ModelProto, rename_map: Dict[str, str]
+    ) -> Tuple[int, int]:
+        """Apply rename_map throughout the model and rename anchored nodes."""
+        weight_count = 0
+        node_count = 0
+
+        # 1. Rename graph initializers
+        for init in model.graph.initializer:
+            if init.name in rename_map:
+                init.name = rename_map[init.name]
+                weight_count += 1
+
+        # 2. Rename graph inputs
+        for inp in model.graph.input:
+            if inp.name in rename_map:
+                inp.name = rename_map[inp.name]
+
+        # 3. Rename main graph node inputs (call-site bindings)
+        for node in model.graph.node:
+            for i, inp_name in enumerate(node.input):
+                if inp_name in rename_map:
+                    node.input[i] = rename_map[inp_name]
+
+        # 4. Rename function formals + internal node inputs
+        for fn in model.functions:
+            for i, inp_name in enumerate(fn.input):
+                if inp_name in rename_map:
+                    fn.input[i] = rename_map[inp_name]
+            for node in fn.node:
+                for i, inp_name in enumerate(node.input):
+                    if inp_name in rename_map:
+                        node.input[i] = rename_map[inp_name]
+
+        # 5. Node rename: MatMul/Gemm nodes using renamed weight as input[1]
+        for fn in model.functions:
+            fn_input_set = set(fn.input)
+            for node in fn.node:
+                if node.op_type in ("MatMul", "Gemm") and len(node.input) >= 2:
+                    weight_inp = node.input[1]
+                    if weight_inp in fn_input_set:
+                        role = cls._get_node_role(weight_inp)
+                        if role:
+                            node.name = role + "/" + node.op_type
+                            node_count += 1
+
+        # 6. Node rename: CustomRMSNorm nodes using layernorm weight
+        for fn in model.functions:
+            fn_input_set = set(fn.input)
+            for node in fn.node:
+                if node.op_type == "CustomRMSNorm" and len(node.input) >= 2:
+                    weight_inp = node.input[1]
+                    if weight_inp in fn_input_set:
+                        match = cls._NORM_ROLE_RE.match(weight_inp)
+                        if match:
+                            node.name = match.group(1) + "/CustomRMSNorm"
+                            node_count += 1
+
+        return weight_count, node_count

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -4050,6 +4050,8 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
                 dynamo=dynamo,
                 offload_pt_weights=kwargs.get("offload_pt_weights", True),
                 prefill_only=prefill_only,
+                rename_onnx_nodes=kwargs.get("rename_onnx_nodes", False),
+                onnx_transform_kwargs=kwargs.get("onnx_transform_kwargs"),
             )
 
     def build_prefill_specialization(


### PR DESCRIPTION
Adds opt-in semantic renaming for w_sub ONNX exports. When rename_onnx_nodes=True is passed alongside use_onnx_subfunctions=True, opaque ONNX names (e.g., onnx::MatMul_5898) are renamed to their HF equivalents (e.g., model.layers.0.self_attn.q_proj.weight) using 256-byte fingerprint matching against HF safetensors. This makes exported traces self-sufficient for llm_breakdown without a separate rename step.

What it does:

1. RenameWsubTransform in onnx_transforms.py (+310 lines) - fingerprint-matches ONNX external weights to HF params, renames weights + anchored MatMul/RMSNorm nodes, stamps metadata. Handles both individual files and consolidated .onnx.data with offsets. Supports BF16/FP16/FP32 auto-detection.
2. Integration in modeling_qeff.py (+74 lines) - adds rename_onnx_nodes param (default False), resolves HF cache path, calls the transform after existing ONNX transforms. Warns if rename_onnx_nodes=True without use_onnx_subfunctions=True.
3. Kwarg threading in modeling_auto.py (+2 lines) - passes rename_onnx_nodes through to the export call.

Safety: Default is False - zero impact on existing behavior unless explicitly opted in.

Validated Models: LLaMA-3-8B, GPT-OSS 120B and Kimi-K2.5 on AI100