### PR TITLE
Fix CCL propagation for Gemma4 bidirectional-vision prefill

### DIFF
--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -452,9 +452,12 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
             token_key_states, token_value_states = key_states, value_states
 
         if past_key_values is not None:
-            if comp_ctx_lengths is not None and attention_mask is not None:
-                attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
-                cache_kwargs["CCL"] = attention_mask.shape[-1]
+            if comp_ctx_lengths is not None:
+                if attention_mask is not None:
+                    attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
+                    cache_kwargs["CCL"] = attention_mask.shape[-1]
+                elif self.sliding_window is None:
+                    cache_kwargs["CCL"] = comp_ctx_lengths.shape[-1]
             if self.is_kv_shared_layer:
                 if token_key_states is not None and token_value_states is not None:
                     key_states, value_states = past_key_values.update(


### PR DESCRIPTION
On checkpoints with text_config.use_bidirectional_attention == "vision" (e.g. Gemma4 31B), QEffGemma4TextModel defers mask construction to the attention module during multimodal prefill and passes attention_mask=None for every layer. The CCL branch in QEffGemma4TextAttention.forward was gated on attention_mask being non-None, so cache_kwargs["CCL"] was never set on that path. comp_ctx_lengths then became a dead graph input, ONNX export pruned it, and compilation failed because the specializations differed only in a symbol with no corresponding input.

Set CCL from comp_ctx_lengths directly when no mask is available, but only for full-attention layers. A sliding layer's KV is capped at sliding_window, and QEffGemma4DynamicLayer.update clamps with min(layer_ctx_len, ctx_len), which cannot constant-fold under export because comp_ctx_lengths.shape[-1] traces as a dynamic Shape -> Gather. Passing a larger CCL there makes the gather's arange(CCL) disagree with the sliding_window-length rolling indices, and the compiler rejects the resulting Where as non-broadcastable ([1024] vs [1, 1, 4000]).

The pre-existing mask path is unchanged: slicing a sliding layer's mask to a larger CCL clamps to sliding_window, so reading the width back off the sliced mask keeps the per-layer clamp intact.

I have tested the changes with no problems with disaggregated with the following command for both google/gemma-4-31B-it and google/gemma-4-26B-A4B-it models:

python3 -m qaic_disagg \
  --model "google/gemma-4-26B-A4B-it" \
  --encode-port 2300 \
  --encode-device-group 8,9 \
  --decode-port 2301 \
  --decode-device-group 10,11 \
  --decode-long-prefill-token-threshold 128 \
  --max-model-len 4096 \
  --encode-override-qaic-config '{"use_onnx_subfunctions":true, "kv_offload": true, "mxfp6_matmul": true, "mxint8_kv_cache": true, "split_model_io": true}' \
  --decode-override-qaic-config '{"node_precision_info": true, "kv_offload": true, "skip_vision": true, "mxfp6_matmul": true, "mxint8_kv_cache": true, "split_model_io": true,"ccl_enabled":true,"comp_ctx_lengths_decode":[2048,4096],"comp_ctx_lengths_prefill":[4000]}' \
  --decode-max-num-seqs 1 \
  --port 2302 \
  --encode-max-num-seqs 1 \
  --generation-config vllm \
  --quantization mxfp6 \
  --kv-cache-dtype mxint8 \
  --proxy-worker 1 \
  --limit-mm-per-prompt '{"image":1, "audio":0}' \
  --kv-handOff-port 2303 -vvv \
  --reasoning-parser gemma4 \
  --enable-auto-tool-choice \
  --tool-call-parser gemma4 