### PR TITLE
Fix for subfn, rope issue in Grok1

### DIFF
--- a/QEfficient/transformers/models/grok_1/modeling_grok1.py
+++ b/QEfficient/transformers/models/grok_1/modeling_grok1.py
@@ -94,7 +94,9 @@ class QEffGrok1MultiHeadAttention(nn.Module):
             kv_seq_len = past_key_value.get_seq_length(layer_idx, cache_position)
 
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-        query_states, key_states = qeff_apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+        cos = cos[position_ids].unsqueeze(1)
+        sin = sin[position_ids].unsqueeze(1)
+        query_states, key_states = qeff_apply_rotary_pos_emb(query_states, key_states, cos, sin)
 
         if past_key_value is not None:
             cache_kwargs = {"batch_index": batch_index, "position_ids": position_ids}
@@ -332,11 +334,8 @@ class QEffGrok1Model(nn.Module):
         else:
             raise ValueError("You have to specify either input_ids or inputs_embeds")
 
-        seq_length_with_past = seq_length
-        past_key_values_length = past_key_values[0][0].shape[2]
-        seq_length_with_past = seq_length_with_past + past_key_values_length
-
         past_key_values = QEffDynamicCache.from_legacy_cache(past_key_values)
+        past_key_values_length = past_key_values.get_seq_length()
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
@@ -408,7 +407,7 @@ class QEffGrok1ModelForCausalLM(nn.Module):
             This method should return the *class object* (not an instance).
             Downstream code can use this to find/build subfunctions for repeated blocks.
         """
-        return {QEffGrok1DecoderLayer}
+        return {self.model.layers[0].__class__}
 
     def forward(
         self,

--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -1299,7 +1299,10 @@ class KVCacheExternalModuleMapperTransform(ExternalModuleMapperTransform):
             "forward": QEffMultiHeadDotProductAttention.forward,
         },
         # Mapping for grok1 model
-        "Grok1ModelForCausalLM": {"forward": QEffGrok1ModelForCausalLM.forward},
+        "Grok1ModelForCausalLM": {
+            "forward": QEffGrok1ModelForCausalLM.forward,
+            "get_submodules_for_export": QEffGrok1ModelForCausalLM.get_submodules_for_export,
+        },
         "Grok1Model": {
             "forward": QEffGrok1Model.forward,
             "__qeff_init__": QEffGrok1Model.__qeff_init__,


### PR DESCRIPTION
 This PR fixes Grok1 export/runtime support by addressing two issues:

  - Adds Grok1 decoder-layer subfunction export support.
  - Fixes Grok1 RoPE handling to match the current shared helper API.

  **RoPE Compatibility Fix**

  Grok1 was still calling the shared RoPE helper with position_ids:

`  qeff_apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
`
  The shared helper imported from the Llama wrapper now expects already-indexed RoPE tensors:

`  qeff_apply_rotary_pos_emb(q, k, cos, sin)
`
  This caused Grok1 QEff execution/export to fail with:

  TypeError: qeff_apply_rotary_pos_emb() takes 4 positional arguments but 5 were given

  The fix applies Grok1’s position_ids indexing locally before calling the shared helper:

```
  cos = cos[position_ids].unsqueeze(1)
  sin = sin[position_ids].unsqueeze(1)
  query_states, key_states = qeff_apply_rotary_pos_emb(query_states, key_states, cos, sin)
```

  This preserves Grok1’s original RoPE semantics and produces the broadcast shape expected by attention: [batch, 1, seq_len, head_dim].

**Subfunction Export Support**

  Grok1 now declares its repeated decoder block as the ONNX subfunction boundary:

```
  def get_submodules_for_export(self) -> Type[nn.Module]:
      return {QEffGrok1DecoderLayer}
```

  Grok1 support is implemented through external module mapping, so the original HF decoder layer is transformed by replacing its forward/init behavior rather than by instantiating a standalone QEff...DecoderLayer class everywhere in the model tree. Because of that, the subfunction exporter cannot rely on discovering a generic QEffDecoderLayer instance name from the original model structure.

updated :
```
  def get_submodules_for_export(self) -> Type[nn.Module]:
        return {self.model.layers[0].__class__}
```