### PR TITLE
feat(0805): Add semantic ONNX names for w_sub exports

### DIFF
--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -580,6 +580,35 @@ class PruneFakeInitializersTransform(BaseOnnxTransform):
         return pruned
 
 
+class RenameWsubNodesTransform(BaseOnnxTransform):
+    """Name local-function operators from their semantic layer parameters."""
+
+    _LAYER_PARAMETER_RE = re.compile(r"(?:^|\.)layers\.\d+\.(?P<role>.+)\.weight$")
+    _WEIGHTED_OPS = {"MatMul", "Gemm", "CustomRMSNorm"}
+
+    @classmethod
+    def apply(cls, model: ModelProto) -> bool:
+        transformed = False
+        for function in model.functions:
+            function_inputs = set(function.input)
+            for node in function.node:
+                if node.op_type not in cls._WEIGHTED_OPS:
+                    continue
+                for input_name in node.input[1:]:
+                    if input_name not in function_inputs:
+                        continue
+                    match = cls._LAYER_PARAMETER_RE.search(input_name)
+                    if match is None:
+                        continue
+                    role = match.group("role").replace(".", "/")
+                    semantic_name = f"{role}/{node.op_type}"
+                    if node.name != semantic_name:
+                        node.name = semantic_name
+                        transformed = True
+                    break
+        return transformed
+
+
 class OnnxTransformPipeline(BaseOnnxTransform):
     """Pipeline to apply multiple ONNX transformations in sequence."""
 
@@ -652,6 +681,9 @@ class OnnxTransformPipeline(BaseOnnxTransform):
             applied[RenameFunctionOutputsTransform] = RenameFunctionOutputsTransform.apply(
                 model, layer_idx=kwargs.get("layer_idx", 0)
             )
+
+        if RenameWsubNodesTransform in requested:
+            applied[RenameWsubNodesTransform] = RenameWsubNodesTransform.apply(model)
 
         if PreserveNestedCacheRetainedStateTransform in requested:
             applied[PreserveNestedCacheRetainedStateTransform] = PreserveNestedCacheRetainedStateTransform.apply(model)

--- a/QEfficient/utils/export_utils.py
+++ b/QEfficient/utils/export_utils.py
@@ -22,6 +22,7 @@ from QEfficient.base.onnx_transforms import (
     PreserveNestedCacheRetainedStateTransform,
     RenameFunctionOutputsTransform,
     RenameRepeatedSubgraphTransform,
+    RenameWsubNodesTransform,
 )
 from QEfficient.transformers.cache_utils import InvalidIndexProvider
 from QEfficient.utils.cache import QEFF_HOME
@@ -375,7 +376,7 @@ def _generate_export_hash(qeff_model, args, kwargs, func):
         }
     )
     if getattr(qeff_model, "_use_onnx_subfunctions", False):
-        copy_of_hash_params["onnx_subfunction_version"] = 2
+        copy_of_hash_params["onnx_subfunction_version"] = 3
     # Generate hash from relevant parameters
     export_hash, filtered_hash_params = create_export_hash(
         model_params=copy_of_hash_params,
@@ -421,7 +422,7 @@ def _setup_onnx_subfunctions(qeff_model, args, kwargs, dynamo=False):
     orig_hash_subfunction_version = qeff_model.hash_params.get("onnx_subfunction_version")
     qeff_model._use_onnx_subfunctions = True
     qeff_model.hash_params["use_onnx_subfunctions"] = True
-    qeff_model.hash_params["onnx_subfunction_version"] = 2
+    qeff_model.hash_params["onnx_subfunction_version"] = 3
     # TorchScript patches are irrelevant on the dynamo path.
     if not dynamo:
         apply_torch_patches()
@@ -468,6 +469,8 @@ def _setup_onnx_subfunctions(qeff_model, args, kwargs, dynamo=False):
             qeff_model._onnx_transforms.append(RenameFunctionOutputsTransform)
         if CustomOpTransform not in qeff_model._onnx_transforms:
             qeff_model._onnx_transforms.append(CustomOpTransform)
+        if RenameWsubNodesTransform not in qeff_model._onnx_transforms:
+            qeff_model._onnx_transforms.append(RenameWsubNodesTransform)
 
     # TODO: Handle this in the modelling class QEFFTransformersBase, remove from here.
     decoder_layer_classes = get_decoder_layer_classes_for_export(qeff_model.model)

--- a/QEfficient/utils/torch_patches.py
+++ b/QEfficient/utils/torch_patches.py
@@ -43,6 +43,7 @@ except ModuleNotFoundError:
 # Store original references before patching
 _original_setup_trace_module_map = onnx_utils._setup_trace_module_map
 _original_get_module_attributes = getattr(onnx_utils, "_get_module_attributes", None)
+_original_model_to_graph = onnx_utils._model_to_graph
 _original_track_scope_attrs = getattr(_C, "_jit_pass_onnx_track_scope_attributes", None)
 _original_ts_setup_trace_module_map = ts_utils._setup_trace_module_map if _ts_utils_available else None
 _original_ts_get_module_attributes = getattr(ts_utils, "_get_module_attributes", None) if _ts_utils_available else None
@@ -92,6 +93,35 @@ _SAFE_EXPORT_PASS_REPLACEMENTS = {
     "_jit_pass_onnx_graph_shape_type_inference": _noop,
     "_jit_pass_onnx_deduplicate_initializers": _return_params,
 }
+
+
+def _model_to_graph_patched(model, *args, **kwargs):
+    """Preserve model parameter names through TorchScript ONNX export."""
+    graph, params_dict, torch_out = _original_model_to_graph(model, *args, **kwargs)
+
+    parameter_names = {}
+    for name, parameter in model.named_parameters():
+        if parameter.numel():
+            parameter_names.setdefault(parameter.data_ptr(), name)
+
+    graph_inputs = {value.debugName(): value for value in graph.inputs()}
+    renamed_params = {}
+    for old_name, parameter in params_dict.items():
+        new_name = parameter_names.get(parameter.data_ptr())
+        graph_input = graph_inputs.get(old_name)
+        if (
+            old_name.startswith("onnx::")
+            and new_name
+            and new_name not in params_dict
+            and new_name not in renamed_params
+            and graph_input is not None
+        ):
+            graph_input.setDebugName(new_name)
+        else:
+            new_name = old_name
+        renamed_params[new_name] = parameter
+
+    return graph, renamed_params, torch_out
 
 
 def _setup_trace_module_map_patched(
@@ -264,6 +294,7 @@ def apply_torch_patches():
 
     # Patch onnx_utils (used by both TorchScript and as fallback)
     onnx_utils._setup_trace_module_map = _setup_trace_module_map_patched
+    onnx_utils._model_to_graph = _model_to_graph_patched
     if hasattr(onnx_utils, "_get_module_attributes"):
         onnx_utils._get_module_attributes = _get_module_attributes
 
@@ -287,6 +318,7 @@ def undo_torch_patches():
         return
 
     onnx_utils._setup_trace_module_map = _original_setup_trace_module_map
+    onnx_utils._model_to_graph = _original_model_to_graph
     if _original_get_module_attributes:
         onnx_utils._get_module_attributes = _original_get_module_attributes
 

--- a/tests/base/test_onnx_transforms.py
+++ b/tests/base/test_onnx_transforms.py
@@ -11,6 +11,7 @@ import onnx
 from QEfficient.base.onnx_transforms import (
     FP16ClipTransform,
     OnnxTransformPipeline,
+    RenameWsubNodesTransform,
     SplitTensorsTransform,
 )
 
@@ -73,6 +74,44 @@ def test_fp16clip_transform_external(tmp_path):
     transformed_onnx, transformed = onnx_transforms.apply(test_onnx, model_name="", onnx_base_dir=str(tmp_path))
     assert transformed
     assert onnx.numpy_helper.to_array(transformed_onnx.graph.initializer[0]) == -65504.0
+
+
+def test_rename_wsub_nodes_transform():
+    weighted_ops = [
+        ("self_attn.q_proj", "MatMul"),
+        ("self_attn.k_proj", "MatMul"),
+        ("self_attn.v_proj", "MatMul"),
+        ("self_attn.o_proj", "MatMul"),
+        ("mlp.gate_proj", "MatMul"),
+        ("mlp.up_proj", "MatMul"),
+        ("mlp.down_proj", "MatMul"),
+        ("input_layernorm", "CustomRMSNorm"),
+    ]
+    weight_names = [f"model.layers.1.{role}.weight" for role, _ in weighted_ops]
+    nodes = [
+        onnx.helper.make_node(op_type, ["hidden", weight_name], [f"output_{index}"], name=f"{op_type}_{index}")
+        for index, ((_, op_type), weight_name) in enumerate(zip(weighted_ops, weight_names))
+    ]
+    function = onnx.helper.make_function(
+        "test",
+        "DecoderLayer",
+        ["hidden", *weight_names],
+        [nodes[-1].output[0]],
+        nodes,
+        [onnx.helper.make_opsetid("", 17)],
+    )
+    model = onnx.helper.make_model(
+        onnx.helper.make_graph([], "test", [], []),
+        functions=[function],
+        opset_imports=[onnx.helper.make_opsetid("", 17)],
+    )
+
+    assert RenameWsubNodesTransform.apply(model)
+    transformed_function = model.functions[0]
+    assert [node.name for node in transformed_function.node] == [
+        role.replace(".", "/") + "/" + op_type for role, op_type in weighted_ops
+    ]
+    assert not RenameWsubNodesTransform.apply(model)
 
 
 def test_split_tensors_transform(tmp_path):

--- a/tests/transformers/qeff_classes/test_automodel_for_causal_lm.py
+++ b/tests/transformers/qeff_classes/test_automodel_for_causal_lm.py
@@ -183,7 +183,7 @@ def test_causal_lm_hash_creation(config, cb, subfunc, prefill_only, tmp_path):
     hash_params["onnx_transform_version"] = 1
     hash_params["dynamo"] = False
     if subfunc:
-        hash_params["onnx_subfunction_version"] = 2
+        hash_params["onnx_subfunction_version"] = 3
 
     # Create parameters separately for hash creation
     bs: int = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -1259,6 +1259,34 @@ def test_causal_subfunction_export_smoke(tmp_path):
 
 
 @pytest.mark.llm_model
+def test_causal_subfunction_export_uses_semantic_weight_and_node_names(tmp_path):
+    config = LlamaConfig(
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+    )
+    model_hf = AutoModelForCausalLM.from_config(config, **MODEL_KWARGS).eval()
+    qeff_model = QEFFAutoModelForCausalLM(model_hf)
+
+    onnx_path = _exported_onnx_path(
+        qeff_model.export(tmp_path / "semantic-wsub-names", use_onnx_subfunctions=True, offload_pt_weights=False)
+    )
+    onnx_model = onnx.load(onnx_path, load_external_data=False)
+
+    initializer_names = {initializer.name for initializer in onnx_model.graph.initializer}
+    assert "model.layers.0.self_attn.q_proj.weight" in initializer_names
+    assert not any(name.startswith("onnx::MatMul_") for name in initializer_names)
+
+    function_node_names = {node.name for function in onnx_model.functions for node in function.node}
+    assert "self_attn/q_proj/MatMul" in function_node_names
+    assert "mlp/down_proj/MatMul" in function_node_names
+
+
+@pytest.mark.llm_model
 def test_gemma3_vlm_export_parity_with_and_without_subfunctions(tmp_path):
     """Gemma3 VLM export keeps retained-state/output signatures stable across subfunction toggles.
 


### PR DESCRIPTION
## Summary
  - Preserve semantic HF parameter names during TorchScript w_sub export
  - Rename local-function weighted nodes such as `self_attn/q_proj/MatMul`
  - Register the graph-only rename transform automatically for `use_onnx_subfunctions=True`
  - Bump the `w_sub export` cache version to avoid reusing older opaque ONNX artifacts
  - Add focused ONNX transform and quickcheck coverage.

  ## Tests
  - pytest -q tests/base/test_onnx_transforms.py -k rename_wsub
  - pytest -q tests/unit_test/models/test_model_quickcheck.py -k semantic_weight_and_node_names 
  - pytest -q tests/transformers/qeff_classes/test_automodel_for_causal_lm.py -k "hash_creation and llama and
  subfunc"