### PR TITLE
Gemma4 multi resolution

### DIFF
--- a/QEfficient/generation/vlm_generation.py
+++ b/QEfficient/generation/vlm_generation.py
@@ -20,7 +20,7 @@ Key enhancements:
 
 from collections import deque
 from time import perf_counter
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 import numpy as np
 import torch
@@ -80,24 +80,24 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
     def __init__(
         self,
         qeff_model,
-        tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
+        tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast,
         processor: AutoImageProcessor,
         lang_qpc_path: str,
         vision_qpc_path: str,
-        device_id: Optional[List[int]] = None,
-        ctx_len: Optional[int] = None,
-        comp_ctx_lengths_prefill: Optional[List[int]] = None,
-        comp_ctx_lengths_decode: Optional[List[int]] = None,
+        device_id: list[int] | None = None,
+        ctx_len: int | None = None,
+        comp_ctx_lengths_prefill: list[int] | None = None,
+        comp_ctx_lengths_decode: list[int] | None = None,
         enable_debug_logs: bool = False,
-        write_io_dir: Optional[str] = None,
-        full_batch_size: Optional[int] = None,
-        image_height: Optional[int] = None,
-        image_width: Optional[int] = None,
+        write_io_dir: str | None = None,
+        full_batch_size: int | None = None,
+        image_height: int | None = None,
+        image_width: int | None = None,
         is_tlm: bool = False,
         include_sampler: bool = False,
         return_pdfs: bool = False,
         include_guided_decoding: bool = False,
-        sampling_params: Optional[Dict[str, Any]] = None,
+        sampling_params: dict[str, Any] | None = None,
     ):
         """
         Initialize vision-language generation with enhanced capabilities
@@ -201,7 +201,7 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
         # Setup vision buffer skipping
         self._setup_vision_buffer_skipping()
 
-    def _get_vision_config(self) -> Dict[str, Any]:
+    def _get_vision_config(self) -> dict[str, Any]:
         """
         Derive vision config from session
 
@@ -244,6 +244,75 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
             for x in self._session.input_names + self._session.output_names
             if is_retained_state_name(x) or x.endswith("_RetainedState")
         ]
+
+    def _find_matching_vision_spec_idx(self, vision_inputs: dict[str, np.ndarray]) -> int | None:
+        """Find the matching vision specialization index for the provided input shapes."""
+        if not getattr(self._vision_session, "allowed_shapes", None):
+            return None
+
+        for i, spec in enumerate(self._vision_session.allowed_shapes):
+            matched = True
+            for name, arr in vision_inputs.items():
+                if name not in self._vision_session.binding_index_map:
+                    continue
+                bidx = self._vision_session.binding_index_map[name]
+                if len(spec) <= bidx:
+                    matched = False
+                    break
+                expected = list(spec[bidx][1])
+                if list(arr.shape) != expected:
+                    matched = False
+                    break
+            if matched:
+                return i
+        return None
+
+    def _allocate_vision_outputs_for_spec(self, spec_idx: int):
+        """Allocate output buffers for a specific vision specialization."""
+        spec = self._vision_session.allowed_shapes[spec_idx]
+        buffers = {}
+        for output_name in self._vision_session.output_names:
+            if output_name not in self._vision_session.binding_index_map:
+                continue
+            bidx = self._vision_session.binding_index_map[output_name]
+            shape = tuple(spec[bidx][1])
+            dtype = self._vision_session.aic_to_np_dtype_mapping[self._vision_session.bindings[bidx].type]
+            buffers[output_name] = np.zeros(shape, dtype=dtype)
+        self._vision_session.set_buffers(buffers)
+
+    def _get_lang_vision_token_capacity(self) -> int | None:
+        """Returns the max vision token capacity expected by the language QPC, if available."""
+        if "vision_embeds" not in self._session.binding_index_map:
+            return None
+        v_idx = self._session.binding_index_map["vision_embeds"]
+        capacities = []
+        if getattr(self._session, "allowed_shapes", None):
+            for spec in self._session.allowed_shapes:
+                if len(spec) <= v_idx:
+                    continue
+                dims = spec[v_idx][1]
+                if len(dims) >= 2:
+                    capacities.append(int(dims[1]))
+        if capacities:
+            return max(capacities)
+        dims = tuple(self._session.bindings[v_idx].dims)
+        if len(dims) >= 2:
+            return int(dims[1])
+        return None
+
+    @staticmethod
+    def _pad_or_trim_axis(arr: np.ndarray, axis: int, target: int) -> np.ndarray:
+        """Pad with zeros or trim tensor along one axis to target length."""
+        current = arr.shape[axis]
+        if current == target:
+            return arr
+        if current > target:
+            slicer = [slice(None)] * arr.ndim
+            slicer[axis] = slice(0, target)
+            return arr[tuple(slicer)]
+        pad_width = [(0, 0)] * arr.ndim
+        pad_width[axis] = (0, target - current)
+        return np.pad(arr, pad_width=tuple(pad_width), mode="constant", constant_values=0)
 
     def run_prefill_for_all_inputs(self, prompt_queue, generation_len):
         """
@@ -294,11 +363,11 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
 
     def _execute_chunked_prefill(
         self,
-        lang_inputs: Dict[str, np.ndarray],
+        lang_inputs: dict[str, np.ndarray],
         num_chunks: int,
-        decode_batch_id: Optional[np.ndarray] = None,
+        decode_batch_id: np.ndarray | None = None,
         prefill_logit_bs: int = 1,
-    ) -> Dict[str, np.ndarray]:
+    ) -> dict[str, np.ndarray]:
         """
         Execute chunked prefill with language inputs
 
@@ -510,12 +579,12 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
 
     def generate(
         self,
-        images: List[str],
-        prompts: List[str],
+        images: list[str],
+        prompts: list[str],
         inputs: torch.Tensor = None,
-        num_frames: Optional[int] = None,
-        multi_specs: Optional[bool] = None,
-        generation_len: Optional[int] = None,
+        num_frames: int | None = None,
+        multi_specs: bool | None = None,
+        generation_len: int | None = None,
         stream: bool = True,
         **kwargs,
     ) -> CloudAI100ExecInfo:
@@ -558,7 +627,7 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
             return self._generate_regular_batching(vision_prompts, generation_len, stream, **kwargs)
 
     def run_prefill_multi_frame_specialization(
-        self, inputs: Optional[torch.Tensor], num_frames: Optional[int] = 1, generation_len: int = None
+        self, inputs: torch.Tensor | None, num_frames: int | None = 1, generation_len: int = None
     ):
         """
         Run prefill for multi-frame specialization. This is a special case where we have a fixed number of frames
@@ -620,91 +689,89 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
         inputs["attention_mask"] = torch.nn.functional.pad(
             inputs["attention_mask"], (0, padded_len - input_ids_length), "constant", 0
         )
+        if "mm_token_type_ids" in inputs:
+            inputs["mm_token_type_ids"] = torch.nn.functional.pad(
+                inputs["mm_token_type_ids"], (0, padded_len - input_ids_length), "constant", 0
+            )
+        if "cross_attention_mask" in inputs:
+            inputs["cross_attention_mask"] = torch.nn.functional.pad(
+                inputs["cross_attention_mask"], (0, 0, 0, 0, 0, padded_len - input_ids_length)
+            )
 
         for k, v in inputs.items():
             inputs[k] = np.array(v)
 
-        vision_inputs = {
-            k: v
-            for k, v in inputs.items()
-            if k
-            in {"pixel_values", "image_masks", "image_input_idx", "valid_idx", "aspect_ratio_ids", "aspect_ratio_mask"}
-        }
+        vision_inputs = {k: v for k, v in inputs.items() if k in self._vision_session.input_names}
 
         vision_inputs_fp16 = {"pixel_values", "image_masks"}
-        vision_inputs.update({k: vision_inputs[k].astype("float16") for k in vision_inputs_fp16 if k in vision_inputs})
+        for k in vision_inputs_fp16:
+            if k in vision_inputs:
+                vision_inputs[k] = vision_inputs[k].astype("float16")
 
         vision_outputs = {}
         if vision_inputs:
-            vision_size = vision_inputs["pixel_values"].shape[0] // num_frames
-
-            pixel_values_shape = list(vision_inputs["pixel_values"][:vision_size].shape)
-
-            idx = next(
-                i for i, inner in enumerate(self._vision_session.allowed_shapes) if (2, pixel_values_shape) in inner
+            is_qwen_multiframe = (
+                self.is_qwen_vl
+                and num_frames is not None
+                and int(num_frames) > 1
+                and "pixel_values" in vision_inputs
+                and "image_grid_thw" in vision_inputs
             )
 
-            buffer_set = {
-                "vision_embeds": np.zeros(
-                    self._vision_session.allowed_shapes[idx][self._vision_session.binding_index_map["vision_embeds"]][
-                        1
-                    ],
-                    dtype=np.float16,
-                ),
-                "image_grid_thw": np.zeros(
-                    self._vision_session.allowed_shapes[idx][self._vision_session.binding_index_map["image_grid_thw"]][
-                        1
-                    ],
-                    dtype=np.int64,
-                ),
-            }
-            if "deepstack_features" in self._vision_session.binding_index_map:
-                buffer_set["deepstack_features"] = np.zeros(
-                    self._vision_session.allowed_shapes[idx][
-                        self._vision_session.binding_index_map["deepstack_features"]
-                    ][1],
-                    dtype=np.float16,
-                )
+            if is_qwen_multiframe:
+                vision_size = vision_inputs["pixel_values"].shape[0] // int(num_frames)
+                chunk_inputs = vision_inputs.copy()
+                for i in range(int(num_frames)):
+                    chunk_inputs["pixel_values"] = vision_inputs["pixel_values"][
+                        i * vision_size : (i + 1) * vision_size
+                    ]
+                    idx = self._find_matching_vision_spec_idx(chunk_inputs)
+                    if idx is None:
+                        raise ValueError(
+                            f"No matching vision specialization for chunk {i} with shapes: "
+                            f"{ {k: list(v.shape) for k, v in chunk_inputs.items()} }"
+                        )
+                    self._allocate_vision_outputs_for_spec(idx)
+                    chunk_outputs = self._vision_session.run(chunk_inputs)
+                    if i == 0:
+                        vision_outputs = chunk_outputs
+                    else:
+                        if "vision_embeds" in vision_outputs and "vision_embeds" in chunk_outputs:
+                            vision_outputs["vision_embeds"] = np.concatenate(
+                                (vision_outputs["vision_embeds"], chunk_outputs["vision_embeds"]), axis=1
+                            )
+                        if "deepstack_features" in vision_outputs and "deepstack_features" in chunk_outputs:
+                            vision_outputs["deepstack_features"] = np.concatenate(
+                                (vision_outputs["deepstack_features"], chunk_outputs["deepstack_features"]), axis=2
+                            )
+            else:
+                idx = self._find_matching_vision_spec_idx(vision_inputs)
+                if idx is None:
+                    raise ValueError(
+                        "No matching vision specialization found for shapes: "
+                        f"{ {k: list(v.shape) for k, v in vision_inputs.items()} }"
+                    )
+                self._allocate_vision_outputs_for_spec(idx)
+                vision_outputs = self._vision_session.run(vision_inputs)
 
-            self._vision_session.set_buffers(buffer_set)
-
-            chunk_inputs = vision_inputs.copy()
-
-            for i in range(num_frames):
-                chunk_inputs["pixel_values"] = vision_inputs["pixel_values"][i * vision_size : (i + 1) * vision_size]
-                chunk_outputs = self._vision_session.run(chunk_inputs)
-                if i == 0:
-                    vision_outputs = chunk_outputs
-                else:
-                    vision_outputs["vision_embeds"] = np.concatenate(
-                        (vision_outputs["vision_embeds"], chunk_outputs["vision_embeds"]), axis=1
+            # Language QPC expects a fixed vision token capacity. Align vision outputs to that contract.
+            lang_vision_tokens = self._get_lang_vision_token_capacity()
+            if lang_vision_tokens is not None:
+                if "vision_embeds" in vision_outputs:
+                    vision_outputs["vision_embeds"] = self._pad_or_trim_axis(
+                        vision_outputs["vision_embeds"], axis=1, target=lang_vision_tokens
+                    )
+                if "deepstack_features" in vision_outputs:
+                    vision_outputs["deepstack_features"] = self._pad_or_trim_axis(
+                        vision_outputs["deepstack_features"], axis=2, target=lang_vision_tokens
                     )
 
-            vision_outputs["vision_embeds"] = np.pad(
-                vision_outputs["vision_embeds"],
-                pad_width=(
-                    (0, 0),
-                    (0, self._session.allowed_shapes[0][1][1][1] - vision_outputs["vision_embeds"].shape[-2]),
-                    (0, 0),
-                ),  # pad axis=1 only
-                mode="constant",
-                constant_values=0,
-            )
-            if "deepstack_features" in vision_outputs:
-                vision_outputs["deepstack_features"] = np.pad(
-                    vision_outputs["deepstack_features"],
-                    pad_width=(
-                        (0, 0),
-                        (0, 0),
-                        (0, self._session.allowed_shapes[0][1][1][1] - vision_outputs["deepstack_features"].shape[-2]),
-                        (0, 0),
-                    ),  # pad axis=1 only
-                    mode="constant",
-                    constant_values=0,
-                )
-
         lang_inputs = {k: v for k, v in inputs.items() if k not in vision_inputs}
-        lang_inputs.pop("attention_mask")
+        if "position_ids" in lang_inputs:
+            lang_inputs.pop("attention_mask", None)
+        else:
+            padded_len = lang_inputs["input_ids"].shape[1]
+            lang_inputs["position_ids"] = np.where(lang_inputs.pop("attention_mask"), np.arange(padded_len), -1)
 
         if self._vision_qpc_path:
             self._vision_session.deactivate()
@@ -732,10 +799,10 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
 
     def _generate_multi_frame_specialization(
         self,
-        inputs: Optional[torch.Tensor],
-        num_frames: Optional[int] = 1,
+        inputs: torch.Tensor | None,
+        num_frames: int | None = 1,
         generation_len: int = None,
-        stream: List[str] = None,
+        stream: list[str] = None,
     ):
 
         exec_batch_size = self.batch_size
@@ -1048,7 +1115,7 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
         )
 
     def generate_stream_tokens(
-        self, images: List[str], prompts: List[str], generation_len: Optional[int] = None, **kwargs
+        self, images: list[str], prompts: list[str], generation_len: int | None = None, **kwargs
     ):
         """
         Enable token-by-token streaming for vision models (new capability)

--- a/QEfficient/transformers/modeling_utils.py
+++ b/QEfficient/transformers/modeling_utils.py
@@ -215,7 +215,7 @@ qeff_supported_architectures = ModelArchitectures(
 DYNAMIC_SEQ_LEN_SUPPORTED_MODEL_ARCH = {"gemma3", "gemma3_text", "gemma4_text", "llama4", "llama4_text"}
 
 # This is for supporting different modelling classes specially written for prefill-only model
-SPECIALIZED_DISAGG_SERVING_MODEL_ARCH = {"gpt_oss", "qwen3_moe", "glm4_moe", "kimi_k2", "kimi_k25"}
+SPECIALIZED_DISAGG_SERVING_MODEL_ARCH = {"gpt_oss", "qwen3_moe", "glm4_moe", "kimi_k2", "kimi_k25", "gemma4"}
 
 _PROXY_ONLY_ONNX_TRANSFORMS = (FP16ClipTransform, SplitTensorsTransform)
 

--- a/QEfficient/transformers/modeling_utils.py
+++ b/QEfficient/transformers/modeling_utils.py
@@ -217,6 +217,9 @@ DYNAMIC_SEQ_LEN_SUPPORTED_MODEL_ARCH = {"gemma3", "gemma3_text", "gemma4_text", 
 # This is for supporting different modelling classes specially written for prefill-only model
 SPECIALIZED_DISAGG_SERVING_MODEL_ARCH = {"gpt_oss", "qwen3_moe", "glm4_moe", "kimi_k2", "kimi_k25", "gemma4"}
 
+# This is for supporting dynamic prefill sequence length for prefill_only model
+DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH = {"gemma4"}
+
 _PROXY_ONLY_ONNX_TRANSFORMS = (FP16ClipTransform, SplitTensorsTransform)
 
 

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -390,13 +390,35 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
     supports_moe_prefill_blocking = True
 
     def __qeff_init__(self):
+        H = self.hidden_dim
         # Derive gather-friendly split projections from the checkpoint's fused
         # gate_up_proj/down_proj, without changing on-disk checkpoint format.
         gate_up_proj = self.gate_up_proj.detach()
         down_proj = self.down_proj.detach()
-        self.gate_proj = nn.Parameter(gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2), requires_grad=False)
-        self.up_proj = nn.Parameter(gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2), requires_grad=False)
-        self.down_proj_t = nn.Parameter(down_proj.transpose(1, 2), requires_grad=False)
+        self.gate_proj_t = gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2)
+        self.up_proj_t = gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2)
+        self.num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
+        if self.num_experts % self.num_nsp != 0:
+            raise ValueError(
+                f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({self.num_nsp})"
+            )
+        self.local_experts = self.num_experts // self.num_nsp
+        self.W_g = nn.Parameter(
+            self.gate_proj_t.view(self.local_experts, self.num_nsp, H, -1).transpose(0, 1).contiguous().clone(),
+            requires_grad=False,
+        )
+        self.W_u = nn.Parameter(
+            self.up_proj_t.view(self.local_experts, self.num_nsp, H, -1).transpose(0, 1).contiguous().clone(),
+            requires_grad=False,
+        )
+        self.W_d = nn.Parameter(
+            down_proj.transpose(1, 2)
+            .view(self.local_experts, self.num_nsp, -1, H)
+            .transpose(0, 1)
+            .contiguous()
+            .clone(),
+            requires_grad=False,
+        )
 
     def forward(
         self,
@@ -416,6 +438,8 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
 
         T = x.shape[0]
 
+        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+
         # Build dense routing weights [T, E] from top-k indices/weights
         expert_weights = torch.zeros(
             T,
@@ -425,27 +449,23 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
         )
         expert_weights.scatter_add_(1, top_k_index, top_k_weights)
         expert_weights = expert_weights.to(x.dtype)
-        num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
-        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
-        if self.num_experts % num_nsp != 0:
-            raise ValueError(
-                f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
-            )
-        local_experts = self.num_experts // num_nsp
-        rw = expert_weights.transpose(0, 1).contiguous().view(local_experts, num_nsp, T).transpose(0, 1).contiguous()
-        W_g = self.gate_proj.view(local_experts, num_nsp, H, -1).transpose(0, 1).contiguous()
-        W_u = self.up_proj.view(local_experts, num_nsp, H, -1).transpose(0, 1).contiguous()
-        W_d = self.down_proj_t.view(local_experts, num_nsp, -1, H).transpose(0, 1).contiguous()
-        expert_out = x.new_zeros((num_nsp, T, H))
+        expert_out = x.new_zeros((self.num_nsp, T, H))
+        rw = (
+            expert_weights.transpose(0, 1)
+            .contiguous()
+            .view(self.local_experts, self.num_nsp, T)
+            .transpose(0, 1)
+            .contiguous()
+        )
         routing_weights_unsqueezed = rw.unsqueeze(-1)
-        for slot in range(local_experts):
+        for slot in range(self.local_experts):
             T2Ei = rw[:, slot, :] > 0
             expert_out = _cumsum_scatter_gather_update_expert_blocked(
                 x=x,
                 T2Ei=T2Ei,
-                W_g=W_g[:, slot],
-                W_u=W_u[:, slot],
-                W_d=W_d[:, slot],
+                W_g=self.W_g[:, slot],
+                W_u=self.W_u[:, slot],
+                W_d=self.W_d[:, slot],
                 routing_weight=routing_weights_unsqueezed[:, slot],
                 expert_out=expert_out,
                 act_fn=self.act_fn,
@@ -1428,8 +1448,8 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         continuous_batching: bool = False,
         **kwargs,
     ):
-        seq_len = kwargs.get("prefill_seq_len")
-        bs = kwargs.get("batch_size")
+        seq_len = kwargs.get("prefill_seq_len", None)
+        bs = kwargs.get("batch_size", None)
         if seq_len is None:
             seq_len = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
         seq_len = int(seq_len)

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -342,7 +342,7 @@ def _cumsum_scatter_gather_update_expert_blocked(
     routing_weight: torch.Tensor,
     expert_out: torch.Tensor,
     act_fn,
-    packed_chunk_size: int,
+    num_packed_chunks: int,
 ) -> torch.Tensor:
     """Cumsum-scatter-gather-update expert helper for NSP-blocked dispatch.
 
@@ -351,18 +351,24 @@ def _cumsum_scatter_gather_update_expert_blocked(
     scatters the weighted output back to original token positions.
     """
     batch_size, seq_len = T2Ei.shape
-    packed_chunk_size = max(1, min(packed_chunk_size, seq_len))
-
+    num_packed_chunks = max(1, int(num_packed_chunks))
+    assert seq_len % num_packed_chunks == 0, (
+        f"seq_len={seq_len} must be divisible by num_packed_chunks={num_packed_chunks}"
+    )
+    packed_chunk_size = seq_len // num_packed_chunks
     matched_idx = _build_matched_idx_from_cumsum(T2Ei)
     valid_rows = torch.einsum("ij->i", T2Ei.to(torch.int32)).unsqueeze(1)
-    row_range = torch.arange(packed_chunk_size, dtype=torch.int32, device=x.device).unsqueeze(0)
     x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
-    for packed_start in range(0, seq_len, packed_chunk_size):
-        packed_stop = packed_start + packed_chunk_size
+    for chunk_idx in range(num_packed_chunks):
+        packed_start = chunk_idx * packed_chunk_size
+        if chunk_idx == num_packed_chunks - 1:
+            packed_stop = seq_len
+        else:
+            packed_stop = packed_start + packed_chunk_size
+        chunk_rows = packed_stop - packed_start
+        row_range = torch.arange(chunk_rows, dtype=torch.int32, device=x.device).unsqueeze(0)
         chunk_matched_idx = matched_idx[:, packed_start:packed_stop]
-
         x_chunk = CtxGatherFunc3DGeneralized.apply(x_expanded, chunk_matched_idx)
-
         gate_prime = x_chunk @ W_g
         up_prime = x_chunk @ W_u
         down_chunk = (up_prime * act_fn(gate_prime)) @ W_d
@@ -438,7 +444,7 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
 
         T = x.shape[0]
 
-        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+        num_packed_chunks = getattr(self, "expert_blocking_packed_chunk_size", T)
 
         # Build dense routing weights [T, E] from top-k indices/weights
         expert_weights = torch.zeros(
@@ -469,7 +475,7 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
                 routing_weight=routing_weights_unsqueezed[:, slot],
                 expert_out=expert_out,
                 act_fn=self.act_fn,
-                packed_chunk_size=packed_chunk_size,
+                num_packed_chunks=num_packed_chunks,
             )
         expert_output = torch.einsum("ijk->jk", expert_out)
         if reshape_back:

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -7,7 +7,7 @@
 
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Tuple, Type, Union
 
 import onnx
 import torch
@@ -27,6 +27,7 @@ from transformers.models.gemma4.modeling_gemma4 import (
     Gemma4VisionAttention,
     apply_rotary_pos_emb,
     eager_attention_forward,
+    repeat_kv,
 )
 
 from QEfficient.customop.ctx_scatter_gather import (
@@ -96,7 +97,7 @@ def _build_additive_attention_mask(
         target_length=target_length,
         sliding_window=sliding_window,
     )
-    return causal_mask.to(dtype=dtype) * _attention_mask_min(dtype, causal_mask.device)
+    return causal_mask
 
 
 def _build_bidirectional_vision_attention_mask(
@@ -117,7 +118,7 @@ def _build_bidirectional_vision_attention_mask(
         sliding_window=sliding_window,
     )
     if mm_token_type_ids is None:
-        return base_mask.to(dtype=dtype) * _attention_mask_min(dtype, base_mask.device)
+        return base_mask
 
     is_vision = (mm_token_type_ids == 1) | (mm_token_type_ids == 2)
     is_prev_vision = torch.roll(is_vision, shifts=1, dims=-1)
@@ -134,7 +135,7 @@ def _build_bidirectional_vision_attention_mask(
 
     same_group = (vision_group_ids.unsqueeze(-1) == kv_group_ids.unsqueeze(1)) & (vision_group_ids.unsqueeze(-1) >= 0)
     attention_mask = base_mask & ~same_group.unsqueeze(1)
-    return attention_mask.to(dtype=dtype) * _attention_mask_min(dtype, attention_mask.device)
+    return attention_mask
 
 
 def apply_multidimensional_rope(
@@ -193,6 +194,40 @@ def apply_multidimensional_rope(
         unsqueeze_dim=unsqueeze_dim,
     )
     return y_grouped.reshape(*x.shape[:-1], total_rotated_channels)
+
+
+def eager_attention_forward_text(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    dropout: float = 0.0,
+    scaling: Optional[float] = None,
+    softcap: Optional[float] = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if softcap is not None:
+        attn_weights = attn_weights / softcap
+        attn_weights = torch.tanh(attn_weights)
+        attn_weights = attn_weights * softcap
+
+    if attention_mask is not None:
+        attn_weights = torch.where(
+            attention_mask,
+            torch.tensor(constants.MIN_MASKED_ATTENTION_VALUE, dtype=module.config.torch_dtype),
+            attn_weights,
+        )
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+
+    return attn_output, attn_weights
 
 
 class QEffGemma4TextRouter(Gemma4TextRouter):
@@ -616,7 +651,7 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
                 sliding_window=self.sliding_window,
             )
 
-        attn_output, attn_weights = eager_attention_forward(
+        attn_output, attn_weights = eager_attention_forward_text(
             self,
             query_states,
             key_states,

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional, Type, Union
 
-import numpy as np
 import onnx
 import torch
 import torch.nn as nn
@@ -31,7 +30,6 @@ from transformers.models.gemma4.modeling_gemma4 import (
     eager_attention_forward,
 )
 
-from QEfficient.base.onnx_transforms import FP16ClipTransform
 from QEfficient.customop.ctx_scatter_gather import (
     CtxGatherFunc3DGeneralized,
     CtxScatterFunc3DGeneralized,
@@ -327,9 +325,7 @@ def _build_matched_idx_from_cumsum(T2Ei: torch.Tensor) -> torch.Tensor:
     valid_prefix = torch.cumsum(T2Ei.to(torch.int32), dim=1)
     valid_dest = valid_prefix - 1
     scatter_pos = torch.where(T2Ei, valid_dest, int32_max_scalar)
-    # Once the compiler fix for ConstantOfShape(INT32_MAX) is available, this
-    # can be switched back to ``torch.full_like(token_idx, int32_max)``.
-    matched_idx = int32_max_scalar.expand_as(token_idx)
+    matched_idx = torch.full_like(token_idx, int32_max)
     matched_idx = CtxScatterFunc3DInt.apply(
         matched_idx.unsqueeze(-1),
         scatter_pos,
@@ -430,8 +426,8 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
         )
         expert_weights.scatter_add_(1, top_k_index, top_k_weights)
         expert_weights = expert_weights.to(x.dtype)
-        num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
-        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+        num_nsp = EXPERT_BLOCKING_NUM_NSP
+        packed_chunk_size = EXPERT_BLOCKING_PACKED_CHUNK_SIZE
         if self.num_experts % num_nsp != 0:
             raise ValueError(
                 f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
@@ -613,7 +609,7 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
 
 
 EXPERT_BLOCKING_NUM_NSP = int(os.environ.get("EXPERT_BLOCKING_NUM_NSP", "16"))
-EXPERT_BLOCKING_PACKED_CHUNK_SIZE = int(os.environ.get("EXPERT_BLOCKING_PACKED_CHUNK_SIZE", "296"))
+EXPERT_BLOCKING_PACKED_CHUNK_SIZE = int(os.environ.get("EXPERT_BLOCKING_PACKED_CHUNK_SIZE", "256"))
 
 
 class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
@@ -1431,13 +1427,21 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         return past_key_values
 
     def get_dummy_inputs(
-        self, comp_ctx_lengths: Optional[List[int]] = None, kv_offload: bool = False, continuous_batching: bool = False
+        self,
+        comp_ctx_lengths: Optional[List[int]] = None,
+        kv_offload: bool = False,
+        continuous_batching: bool = False,
+        **kwargs,
     ):
+        seq_len = kwargs.get("prefill_seq_len")
+        if seq_len is None:
+            seq_len = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
+        seq_len = int(seq_len)
+
         bs = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
         fbs = constants.ONNX_EXPORT_EXAMPLE_FBS
         max_patches = self._get_vision_max_patches()
         mm_tokens_per_image = self._get_mm_tokens_per_image()
-        seq_len = max(constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN, mm_tokens_per_image + 32)
         patch_dim = getattr(self.config.vision_config, "patch_size", 16) ** 2 * 3
 
         image_position_ids = torch.full((bs, max_patches, 2), -1, dtype=torch.int64)
@@ -1479,42 +1483,3 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         if kv_offload:
             return {"vision": vision_inputs, "lang": lang_inputs}
         return {**vision_inputs, **lang_inputs}
-
-    def remove_fp16clip_transform_if_disabled(self, effective_fp16clip: bool):
-        """
-        Remove FP16ClipTransform from ONNX transforms when FP16 clipping is disabled.
-        """
-        if not effective_fp16clip:
-            # ---- language model
-            if hasattr(self, "lang_model") and hasattr(self.lang_model, "_onnx_transforms"):
-                self.lang_model._onnx_transforms = [
-                    t for t in self.lang_model._onnx_transforms if t is not FP16ClipTransform
-                ]
-
-            # ---- vision model (optional)
-            if getattr(self, "vision_model", None) is not None:
-                if hasattr(self.vision_model, "_onnx_transforms"):
-                    self.vision_model._onnx_transforms = [
-                        t for t in self.vision_model._onnx_transforms if t is not FP16ClipTransform
-                    ]
-
-    def normalize_generated_ids(self, generated_ids):
-        array = np.asarray(generated_ids)
-        if array.dtype == object:
-            array = np.asarray([np.asarray(row).reshape(-1) for row in generated_ids], dtype=np.int64)
-        array = np.asarray(array)
-        if array.ndim == 1:
-            array = array.reshape(1, -1)
-        elif array.ndim > 2:
-            array = array.reshape(array.shape[0], -1)
-        return array.astype(np.int64, copy=False)
-
-    def effective_lens(
-        self, prefill_seq_len: int, ctx_len: int, prompt_len: int, generation_len: int, skip_vision: bool
-    ):
-        effective_ctx_len = max(ctx_len, prompt_len + generation_len)
-        if skip_vision:
-            effective_prefill_seq_len = prefill_seq_len
-        else:
-            effective_prefill_seq_len = max(prefill_seq_len, prompt_len)
-        return effective_prefill_seq_len, effective_ctx_len

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -279,29 +279,38 @@ class QEffGemma4CustomRMSNormAIC(nn.Module):
 
 
 class QEffGemma4TextExperts(Gemma4TextExperts):
+    def __qeff_init__(self):
+        # Derive gather-friendly split projections from the checkpoint's fused
+        # gate_up_proj/down_proj, without changing on-disk checkpoint format.
+        # Mirrors QEffQwen3_5MoeExperts.__qeff_init__.
+        gate_up_proj = self.gate_up_proj.detach()
+        down_proj = self.down_proj.detach()
+        self.gate_proj = nn.Parameter(gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2), requires_grad=False)
+        self.up_proj = nn.Parameter(gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2), requires_grad=False)
+        self.down_proj_t = nn.Parameter(down_proj.transpose(1, 2), requires_grad=False)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         top_k_index: torch.Tensor,
         top_k_weights: torch.Tensor,
     ) -> torch.Tensor:
-        gate_up_proj_t = self.gate_up_proj.transpose(1, 2)
-        gate_up_out = torch.matmul(hidden_states, gate_up_proj_t).permute(1, 0, 2)
-        gate, up = gate_up_out.chunk(2, dim=-1)
+        T, H = hidden_states.shape
+        K = top_k_index.shape[1]
+        idx = top_k_index.reshape(-1)
+
+        gate_proj = self.gate_proj[idx]  # [T*K, H, I] -- gather only the selected experts
+        up_proj = self.up_proj[idx]  # [T*K, H, I]
+        down_proj_t = self.down_proj_t[idx]  # [T*K, I, H]
+
+        xk = hidden_states.unsqueeze(1).expand(-1, K, -1).contiguous().view(-1, 1, H)  # [T*K, 1, H]
+        gate = torch.bmm(xk, gate_proj)  # [T*K, 1, I]
+        up = torch.bmm(xk, up_proj)  # [T*K, 1, I]
         activated = self.act_fn(gate) * up
 
-        down_proj_t = self.down_proj.transpose(1, 2)
-        experts_out = torch.matmul(activated.permute(1, 0, 2), down_proj_t).permute(1, 0, 2)
-        expert_weights = torch.zeros(
-            hidden_states.shape[0],
-            self.num_experts,
-            dtype=top_k_weights.dtype,
-            device=top_k_weights.device,
-        )
-        expert_weights.scatter_add_(1, top_k_index, top_k_weights)
-        weighted_experts = experts_out.transpose(1, 2)  # [tokens, hidden, num_experts]
-        combine_weights = expert_weights.to(experts_out.dtype).unsqueeze(-1)  # [tokens, num_experts, 1]
-        return torch.bmm(weighted_experts, combine_weights).squeeze(-1)
+        down = torch.bmm(activated, down_proj_t)  # [T*K, 1, H]
+        down = down.view(T, K, H) * top_k_weights.unsqueeze(-1)
+        return down.sum(dim=1)  # [T, H]
 
 
 class QEffPrefillChunckedGemma4TextExperts(Gemma4TextExperts):

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -5,14 +5,14 @@
 #
 # -----------------------------------------------------------------------------
 
+import math
 from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional, Tuple, Type, Union
-
 import onnx
 import torch
-import torch.nn as nn
 import yaml
+from torch import nn
 from transformers.cache_utils import Cache
 from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from transformers.models.gemma4.modeling_gemma4 import (
@@ -43,6 +43,7 @@ from QEfficient.utils import constants
 _FP16_CLAMP_MIN = -65504.0
 _FP16_CLAMP_MAX = 65504.0
 _DISABLE_EXPORT_FP16_CLAMP = False
+MAX_VISION_SIZE = 0
 
 
 def _is_onnx_export() -> bool:
@@ -90,7 +91,7 @@ def _build_additive_attention_mask(
     position_ids: torch.Tensor,
     target_length,
     dtype: torch.dtype,
-    sliding_window: Optional[int] = None,
+    sliding_window: int | None = None,
 ) -> torch.Tensor:
     causal_mask = _create_causal_mask(
         position_ids=position_ids,
@@ -102,10 +103,10 @@ def _build_additive_attention_mask(
 
 def _build_bidirectional_vision_attention_mask(
     position_ids: torch.Tensor,
-    mm_token_type_ids: Optional[torch.Tensor],
+    mm_token_type_ids: torch.Tensor | None,
     target_length: int,
     dtype: torch.dtype,
-    sliding_window: Optional[int] = None,
+    sliding_window: int | None = None,
 ) -> torch.Tensor:
     """
     Export-safe eager attention mask that mirrors Gemma4's HF image-token semantics:
@@ -201,12 +202,12 @@ def eager_attention_forward_text(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
-    attention_mask: Optional[torch.Tensor],
+    attention_mask: torch.Tensor | None,
     dropout: float = 0.0,
-    scaling: Optional[float] = None,
-    softcap: Optional[float] = None,
+    scaling: float | None = None,
+    softcap: float | None = None,
     **kwargs,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     key_states = repeat_kv(key, module.num_key_value_groups)
     value_states = repeat_kv(value, module.num_key_value_groups)
 
@@ -573,12 +574,12 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
         self,
         hidden_states: torch.Tensor,
         position_embeddings: torch.Tensor,
-        attention_mask: Optional[torch.Tensor],
-        past_key_values: Optional[Cache] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        mm_token_type_ids: Optional[torch.Tensor] = None,
-        batch_index: Optional[torch.LongTensor] = None,
-        comp_ctx_lengths: Optional[torch.Tensor] = None,
+        attention_mask: torch.Tensor | None,
+        past_key_values: Cache | None = None,
+        position_ids: torch.LongTensor | None = None,
+        mm_token_type_ids: torch.Tensor | None = None,
+        batch_index: torch.LongTensor | None = None,
+        comp_ctx_lengths: torch.Tensor | None = None,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         input_shape = hidden_states.shape[:-1]
@@ -615,12 +616,9 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
             token_key_states, token_value_states = key_states, value_states
 
         if past_key_values is not None:
-            if comp_ctx_lengths is not None:
-                if attention_mask is not None:
-                    attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
-                    cache_kwargs["CCL"] = attention_mask.shape[-1]
-                elif self.sliding_window is None:
-                    cache_kwargs["CCL"] = comp_ctx_lengths.shape[-1]
+            if comp_ctx_lengths is not None and attention_mask is not None:
+                attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
+                cache_kwargs["CCL"] = attention_mask.shape[-1]
             if self.is_kv_shared_layer:
                 if token_key_states is not None and token_value_states is not None:
                     key_states, value_states = past_key_values.update(
@@ -684,7 +682,7 @@ class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
         past_key_values: Cache | None = None,
-        comp_ctx_lengths: Optional[torch.Tensor] = None,
+        comp_ctx_lengths: torch.Tensor | None = None,
         **kwargs,
     ) -> torch.Tensor:
         hidden_states = _clamp_to_fp16_range(hidden_states)
@@ -737,15 +735,15 @@ class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
 class QEffGemma4TextModel(Gemma4TextModel):
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[Cache] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        per_layer_inputs: Optional[torch.Tensor] = None,
-        comp_ctx_lengths: Optional[torch.Tensor] = None,
-        use_cache: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        per_layer_inputs: torch.Tensor | None = None,
+        comp_ctx_lengths: torch.Tensor | None = None,
+        use_cache: bool | None = None,
+        return_dict: bool | None = None,
         **kwargs,
     ) -> BaseModelOutputWithPast:
         use_cache = use_cache if use_cache is not None else self.config.use_cache
@@ -858,14 +856,14 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
         return output_name == semantic_name or output_name.startswith(f"{semantic_name}.")
 
     @classmethod
-    def _find_output_name(cls, output_names: list[str], semantic_name: str) -> Optional[str]:
+    def _find_output_name(cls, output_names: list[str], semantic_name: str) -> str | None:
         for output_name in output_names:
             if cls._matches_semantic_name(output_name, semantic_name):
                 return output_name
         return None
 
     @staticmethod
-    def _find_consumer(consumers: dict[str, list], input_name: Optional[str], op_type: str):
+    def _find_consumer(consumers: dict[str, list], input_name: str | None, op_type: str):
         if input_name is None:
             return None
         for node in consumers.get(input_name, []):
@@ -878,7 +876,7 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
         consumers = defaultdict(list)
         output_names = []
 
-        def add_output(name: Optional[str]):
+        def add_output(name: str | None):
             if name is not None:
                 output_names.append(name)
 
@@ -957,7 +955,7 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
 
         return output_names
 
-    def generate_npi_file(self, onnx_path: Union[str, Path], model_name: Optional[str] = None) -> str:
+    def generate_npi_file(self, onnx_path: str | Path, model_name: str | None = None) -> str:
         del model_name
         onnx_path = onnx_path or self.onnx_path
         if onnx_path is None:
@@ -997,11 +995,11 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
         batch_size: int,
         prefill_seq_len: int,
         ctx_len: int,
-        comp_ctx_lengths_prefill: Optional[List[int]] = None,
-        comp_ctx_lengths_decode: Optional[List[int]] = None,
+        comp_ctx_lengths_prefill: list[int] | None = None,
+        comp_ctx_lengths_decode: list[int] | None = None,
         continuous_batching: bool = False,
-        kv_cache_batch_size: Optional[int] = None,
-        full_batch_size: Optional[int] = None,
+        kv_cache_batch_size: int | None = None,
+        full_batch_size: int | None = None,
         **kwargs,
     ):
         del kwargs
@@ -1010,7 +1008,7 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
         ctx_len = ctx_len if ctx_len else constants.INTERN_CTX_LEN
         kv_cache_batch_size = kv_cache_batch_size or full_batch_size or batch_size
 
-        def build_prefill_spec(comp_ctx_lengths: Optional[int] = None):
+        def build_prefill_spec(comp_ctx_lengths: int | None = None):
             spec = {
                 "batch_size": 1 if continuous_batching else batch_size,
                 "seq_len": prefill_seq_len,
@@ -1027,7 +1025,7 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
                 spec["full_batch_exec_size"] = full_batch_size
             return spec
 
-        def build_decode_spec(comp_ctx_lengths: Optional[int] = None):
+        def build_decode_spec(comp_ctx_lengths: int | None = None):
             spec = {
                 "batch_size": full_batch_size if continuous_batching else batch_size,
                 "seq_len": "1",
@@ -1051,8 +1049,8 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
 
     def get_pkv_dynamic_axes(
         self,
-        retain_full_kv: Optional[bool] = False,
-        continuous_batching: Optional[bool] = False,
+        retain_full_kv: bool | None = False,
+        continuous_batching: bool | None = False,
     ):
         del retain_full_kv
         return [
@@ -1066,7 +1064,7 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
 
     def get_onnx_dynamic_axes(
         self,
-        comp_ctx_lengths: Optional[List[int]] = None,
+        comp_ctx_lengths: list[int] | None = None,
         continuous_batching: bool = False,
     ):
         dynamic_axes = {
@@ -1084,7 +1082,7 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
             dynamic_axes["comp_ctx_lengths"] = {0: "comp_ctx_lengths"}
         return dynamic_axes
 
-    def get_submodules_for_export(self) -> Type[nn.Module]:
+    def get_submodules_for_export(self) -> type[nn.Module]:
         return {QEffGemma4TextDecoderLayer}
 
     def get_dummy_pkv_cache(self, config, batch_size, seq_len):
@@ -1114,14 +1112,14 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
 
     def forward(
         self,
-        input_ids: Optional[torch.LongTensor] = None,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_ids: Optional[torch.LongTensor] = None,
-        past_key_values: Optional[Cache] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        labels: Optional[torch.LongTensor] = None,
-        use_cache: Optional[bool] = None,
-        logits_to_keep: Union[int, torch.Tensor] = 0,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
         **kwargs,
     ) -> CausalLMOutputWithPast:
         del attention_mask, labels, logits_to_keep
@@ -1162,7 +1160,7 @@ class QEffGemma4DecoderWrapper(nn.Module):
         self.config = self.model.config
         self.lm_head = self.model.lm_head
 
-    def get_submodules_for_export(self) -> Type[nn.Module]:
+    def get_submodules_for_export(self) -> type[nn.Module]:
         return {QEffGemma4TextDecoderLayer}
 
     def forward(
@@ -1173,8 +1171,8 @@ class QEffGemma4DecoderWrapper(nn.Module):
         image_idx,
         past_key_values,
         mm_token_type_ids=None,
-        batch_index: Optional[torch.LongTensor] = None,
-        comp_ctx_lengths: Optional[List[int]] = None,
+        batch_index: torch.LongTensor | None = None,
+        comp_ctx_lengths: list[int] | None = None,
         **kwargs,
     ):
         del kwargs
@@ -1252,11 +1250,6 @@ class QEffGemma4EncoderWrapper(nn.Module):
         super().__init__()
         self.model = model
         self.model.vision_model = self.model.model.vision_tower
-        self.mm_tokens_per_image = getattr(
-            self.model.config,
-            "mm_tokens_per_image",
-            getattr(self.model.config.vision_config, "default_output_length", 280),
-        )
 
     def get_submodules_for_export(self) -> Type[nn.Module]:
         return {self.model.model.vision_tower.encoder.layers[0].__class__}
@@ -1286,7 +1279,7 @@ class QEffGemma4EncoderWrapper(nn.Module):
                 position_ids=image_position_ids,
             )
 
-        output_length = getattr(vision_tower.config, "default_output_length", None)
+        output_length = MAX_VISION_SIZE
         if output_length is None:
             output_length = pixel_values.shape[-2] // (
                 vision_tower.config.pooling_kernel_size * vision_tower.config.pooling_kernel_size
@@ -1304,12 +1297,17 @@ class QEffGemma4EncoderWrapper(nn.Module):
         if vision_embeds.dim() == 2:
             vision_embeds = vision_embeds.unsqueeze(0)
 
-        # Keep the encoder output fixed-shape for dual-QPC export/compile.
-        # Gemma4 uses vision_config.default_output_length/image_seq_length
-        # image placeholders (280), while the vision pooler may emit extra
-        # padded bins for the max-patch canvas.
+        # Keep encoder output fixed-shape for dual-QPC export/compile.
+        # IMPORTANT: don't capture MAX_VISION_SIZE in __init__ because it is
+        # populated later during get_specializations().
+        mm_tokens_per_image = MAX_VISION_SIZE
+        if mm_tokens_per_image <= 0:
+            mm_tokens_per_image = int(
+                getattr(self.model.config, "vision_soft_tokens_per_image", 0)
+                or getattr(vision_tower.config, "default_output_length", 280)
+            )
         del pooler_mask
-        return vision_embeds[:, : self.mm_tokens_per_image, :]
+        return vision_embeds[:, : mm_tokens_per_image, :]
 
 
 class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
@@ -1320,15 +1318,20 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
     _NPI_BAD_OUTPUT_TOKENS = QEffGemma4ForCausalLM._NPI_BAD_OUTPUT_TOKENS
     _NPI_EXCLUDED_OPS = QEffGemma4ForCausalLM._NPI_EXCLUDED_OPS
 
-    def _get_vision_max_patches(self) -> int:
+    def _get_vision_max_patches(self, vision_soft_tokens_per_image) -> int:
         pooling_kernel_size = getattr(self.config.vision_config, "pooling_kernel_size", 3)
-        default_output_length = getattr(self.config.vision_config, "default_output_length", 280)
-        return default_output_length * pooling_kernel_size * pooling_kernel_size
+        return vision_soft_tokens_per_image * pooling_kernel_size * pooling_kernel_size
 
-    def _get_mm_tokens_per_image(self) -> int:
-        return getattr(
-            self.config, "mm_tokens_per_image", getattr(self.config.vision_config, "default_output_length", 280)
-        )
+    def choose_gemma4_max_soft_tokens(self, height, width):
+        pooling_kernel_size = getattr(self.config.vision_config, "pooling_kernel_size", 3)
+        patch_size = getattr(self.config.vision_config, "patch_size", 3)
+        tile = patch_size * pooling_kernel_size  # 48
+        needed = math.ceil(height / tile) * math.ceil(width / tile)
+        supported = constants.SUPPORTED_NUM_SOFT_TOKENS_PER_IMAGE
+        for budget in supported:
+            if needed <= budget:
+                return budget
+        return supported[-1]  # fallback to max
 
     def get_qeff_vision_encoder(self):
         return QEffGemma4EncoderWrapper(self)
@@ -1336,10 +1339,10 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
     def get_qeff_language_decoder(self):
         return QEffGemma4DecoderWrapper(self)
 
-    def generate_npi_file(self, onnx_path: Union[str, Path], model_name: Optional[str] = None) -> str:
+    def generate_npi_file(self, onnx_path: str | Path, model_name: str | None = None) -> str:
         return QEffGemma4ForCausalLM.generate_npi_file(self, onnx_path, model_name)
 
-    def generate_vision_npi_file(self, onnx_path: Union[str, Path], model_name: Optional[str] = None) -> str:
+    def generate_vision_npi_file(self, onnx_path: str | Path, model_name: str | None = None) -> str:
         del model_name
         onnx_path = Path(onnx_path)
         npi_path = onnx_path.with_name(f"{onnx_path.stem}_gemma4_vision_npi.yaml")
@@ -1361,35 +1364,37 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         prefill_seq_len: int,
         ctx_len: int,
         img_size: int,
-        comp_ctx_lengths_prefill: Optional[List[int]] = None,
-        comp_ctx_lengths_decode: Optional[List[int]] = None,
+        comp_ctx_lengths_prefill: list[int] | None = None,
+        comp_ctx_lengths_decode: list[int] | None = None,
+        height: int | list[int] = None,
+        width: int | list[int] = None,
         kv_offload: bool = False,
         continuous_batching: bool = False,
-        kv_cache_batch_size: Optional[int] = None,
-        full_batch_size: Optional[int] = None,
+        kv_cache_batch_size: int | None = None,
+        full_batch_size: int | None = None,
         **compiler_options,
     ):
         prefill_seq_len = prefill_seq_len if prefill_seq_len else 32
         ctx_len = ctx_len if ctx_len else constants.INTERN_CTX_LEN
-        max_patches = self._get_vision_max_patches()
         user_vision_size = compiler_options.pop("vision_size", None)
-        if user_vision_size:
-            if user_vision_size >= ctx_len:
-                raise ValueError("vision_size must be less than ctx_len")
-            vision_size = user_vision_size
-        else:
-            vision_size = self._get_mm_tokens_per_image()
+        if height is None or width is None:
+            height = constants.GEMMA4_HEIGHT
+            width = constants.GEMMA4_WIDTH
+            logger.warning(
+                f"Setting height and width to be {height} and {width} respectively, as it was neither passed nor found in vision_config"
+            )
 
-        vision = [{"batch_size": batch_size, "max_patches": max_patches}]
+        height = [height] if isinstance(height, int) else height
+        width = [width] if isinstance(width, int) else width
 
-        def build_lang_prefill_spec(comp_ctx_lengths: Optional[int] = None):
+        def build_lang_prefill_spec(comp_ctx_lengths: int | None = None):
             spec = {
                 "batch_size": 1 if continuous_batching else batch_size,
                 "seq_len": prefill_seq_len,
                 "ctx_len": ctx_len,
                 "sliding_window": self.model.language_model.config.sliding_window,
                 "vision_batch_size": batch_size,
-                "vision_size": vision_size,
+                "vision_size": MAX_VISION_SIZE,
             }
             if comp_ctx_lengths is not None:
                 spec["comp_ctx_lengths"] = comp_ctx_lengths
@@ -1401,14 +1406,14 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
                 spec["full_batch_exec_size"] = full_batch_size
             return spec
 
-        def build_lang_decode_spec(comp_ctx_lengths: Optional[int] = None):
+        def build_lang_decode_spec(comp_ctx_lengths: int | None = None):
             spec = {
                 "batch_size": full_batch_size if continuous_batching else batch_size,
                 "seq_len": "1",
                 "ctx_len": ctx_len,
                 "sliding_window": self.model.language_model.config.sliding_window,
                 "vision_batch_size": batch_size,
-                "vision_size": vision_size,
+                "vision_size": MAX_VISION_SIZE,
             }
             if comp_ctx_lengths is not None:
                 spec["comp_ctx_lengths"] = comp_ctx_lengths
@@ -1418,6 +1423,16 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
                 spec["batch_size"] = kv_cache_batch_size or batch_size
             return spec
 
+        vision = []
+
+        global MAX_VISION_SIZE
+        for h, w in zip(height, width):
+            vision_size = self.choose_gemma4_max_soft_tokens(h, w)
+            MAX_VISION_SIZE = max(MAX_VISION_SIZE, vision_size)
+            if vision_size >= ctx_len:
+                raise ValueError("vision_size must be less than ctx_len")
+            max_patches = self._get_vision_max_patches(vision_size)
+            vision.append({"batch_size": batch_size, "max_patches": max_patches, "vision_size": vision_size})
         if comp_ctx_lengths_prefill or comp_ctx_lengths_decode:
             lang = [build_lang_prefill_spec(length) for length in (comp_ctx_lengths_prefill or [])]
             lang.extend(build_lang_decode_spec(length) for length in (comp_ctx_lengths_decode or []))
@@ -1428,7 +1443,7 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         return lang, compiler_options
 
     def get_onnx_dynamic_axes(
-        self, comp_ctx_lengths: Optional[List[int]] = None, kv_offload: bool = False, continuous_batching: bool = False
+        self, comp_ctx_lengths: list[int] | None = None, kv_offload: bool = False, continuous_batching: bool = False
     ):
         vision_dynamic_axes = {
             "pixel_values": {0: "batch_size", 1: "max_patches"},
@@ -1495,7 +1510,7 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
 
     def get_dummy_inputs(
         self,
-        comp_ctx_lengths: Optional[List[int]] = None,
+        comp_ctx_lengths: list[int] | None = None,
         kv_offload: bool = False,
         continuous_batching: bool = False,
         **kwargs,
@@ -1509,8 +1524,8 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
             bs = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
         bs = int(bs)
         fbs = constants.ONNX_EXPORT_EXAMPLE_FBS
-        max_patches = self._get_vision_max_patches()
-        mm_tokens_per_image = self._get_mm_tokens_per_image()
+        mm_tokens_per_image = MAX_VISION_SIZE
+        max_patches = self._get_vision_max_patches(MAX_VISION_SIZE)
         patch_dim = getattr(self.config.vision_config, "patch_size", 16) ** 2 * 3
 
         image_position_ids = torch.full((bs, max_patches, 2), -1, dtype=torch.int64)

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -615,9 +615,12 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
             token_key_states, token_value_states = key_states, value_states
 
         if past_key_values is not None:
-            if comp_ctx_lengths is not None and attention_mask is not None:
-                attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
-                cache_kwargs["CCL"] = attention_mask.shape[-1]
+            if comp_ctx_lengths is not None:
+                if attention_mask is not None:
+                    attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
+                    cache_kwargs["CCL"] = attention_mask.shape[-1]
+                elif self.sliding_window is None:
+                    cache_kwargs["CCL"] = comp_ctx_lengths.shape[-1]
             if self.is_kv_shared_layer:
                 if token_key_states is not None and token_value_states is not None:
                     key_states, value_states = past_key_values.update(

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -282,7 +282,6 @@ class QEffGemma4TextExperts(Gemma4TextExperts):
     def __qeff_init__(self):
         # Derive gather-friendly split projections from the checkpoint's fused
         # gate_up_proj/down_proj, without changing on-disk checkpoint format.
-        # Mirrors QEffQwen3_5MoeExperts.__qeff_init__.
         gate_up_proj = self.gate_up_proj.detach()
         down_proj = self.down_proj.detach()
         self.gate_proj = nn.Parameter(gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2), requires_grad=False)

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -5,7 +5,6 @@
 #
 # -----------------------------------------------------------------------------
 
-import os
 from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional, Type, Union
@@ -426,8 +425,8 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
         )
         expert_weights.scatter_add_(1, top_k_index, top_k_weights)
         expert_weights = expert_weights.to(x.dtype)
-        num_nsp = EXPERT_BLOCKING_NUM_NSP
-        packed_chunk_size = EXPERT_BLOCKING_PACKED_CHUNK_SIZE
+        num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
+        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
         if self.num_experts % num_nsp != 0:
             raise ValueError(
                 f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
@@ -606,10 +605,6 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
-
-
-EXPERT_BLOCKING_NUM_NSP = int(os.environ.get("EXPERT_BLOCKING_NUM_NSP", "16"))
-EXPERT_BLOCKING_PACKED_CHUNK_SIZE = int(os.environ.get("EXPERT_BLOCKING_PACKED_CHUNK_SIZE", "256"))
 
 
 class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
@@ -1434,11 +1429,13 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         **kwargs,
     ):
         seq_len = kwargs.get("prefill_seq_len")
+        bs = kwargs.get("batch_size")
         if seq_len is None:
             seq_len = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
         seq_len = int(seq_len)
-
-        bs = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
+        if bs is None:
+            bs = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
+        bs = int(bs)
         fbs = constants.ONNX_EXPORT_EXAMPLE_FBS
         max_patches = self._get_vision_max_patches()
         mm_tokens_per_image = self._get_mm_tokens_per_image()

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -32,6 +32,11 @@ from transformers.models.gemma4.modeling_gemma4 import (
 )
 
 from QEfficient.base.onnx_transforms import FP16ClipTransform
+from QEfficient.customop.ctx_scatter_gather import (
+    CtxGatherFunc3DGeneralized,
+    CtxScatterFunc3DGeneralized,
+    CtxScatterFunc3DInt,
+)
 from QEfficient.customop.rms_norm import CustomRMSNormFunc
 from QEfficient.transformers.cache_utils import QEffGemma4DynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
@@ -309,10 +314,95 @@ class QEffGemma4TextExperts(Gemma4TextExperts):
 
         down = torch.bmm(activated, down_proj_t)  # [T*K, 1, H]
         down = down.view(T, K, H) * top_k_weights.unsqueeze(-1)
-        return down.sum(dim=1)  # [T, H]
+        down = torch.einsum("bnh->bh", down)
+        return down
 
 
-class QEffPrefillChunckedGemma4TextExperts(Gemma4TextExperts):
+def _build_matched_idx_from_cumsum(T2Ei: torch.Tensor) -> torch.Tensor:
+    """Build packed->original token index"""
+    batch_size, seq_len = T2Ei.shape
+    int32_max = torch.iinfo(torch.int32).max
+    int32_max_scalar = torch.tensor(int32_max, dtype=torch.int32, device=T2Ei.device)
+    token_idx = torch.arange(seq_len, dtype=torch.int32, device=T2Ei.device).unsqueeze(0).expand(batch_size, -1)
+    valid_prefix = torch.cumsum(T2Ei.to(torch.int32), dim=1)
+    valid_dest = valid_prefix - 1
+    scatter_pos = torch.where(T2Ei, valid_dest, int32_max_scalar)
+    # Once the compiler fix for ConstantOfShape(INT32_MAX) is available, this
+    # can be switched back to ``torch.full_like(token_idx, int32_max)``.
+    matched_idx = int32_max_scalar.expand_as(token_idx)
+    matched_idx = CtxScatterFunc3DInt.apply(
+        matched_idx.unsqueeze(-1),
+        scatter_pos,
+        token_idx.unsqueeze(-1),
+    ).squeeze(-1)
+    return matched_idx
+
+
+def _cumsum_scatter_gather_update_expert_blocked(
+    x: torch.Tensor,
+    T2Ei: torch.Tensor,
+    W_g: torch.Tensor,
+    W_u: torch.Tensor,
+    W_d: torch.Tensor,
+    routing_weight: torch.Tensor,
+    expert_out: torch.Tensor,
+    act_fn,
+    packed_chunk_size: int,
+) -> torch.Tensor:
+    """Cumsum-scatter-gather-update expert helper for NSP-blocked dispatch.
+
+    Accumulates one local expert's contribution in-place onto ``expert_out``.
+    Uses a packed/cumsum layout so the MLP runs only over active rows, then
+    scatters the weighted output back to original token positions.
+    """
+    batch_size, seq_len = T2Ei.shape
+    packed_chunk_size = max(1, min(packed_chunk_size, seq_len))
+
+    matched_idx = _build_matched_idx_from_cumsum(T2Ei)
+    valid_rows = torch.einsum("ij->i", T2Ei.to(torch.int32)).unsqueeze(1)
+    row_range = torch.arange(packed_chunk_size, dtype=torch.int32, device=x.device).unsqueeze(0)
+    x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
+    for packed_start in range(0, seq_len, packed_chunk_size):
+        packed_stop = packed_start + packed_chunk_size
+        chunk_matched_idx = matched_idx[:, packed_start:packed_stop]
+
+        x_chunk = CtxGatherFunc3DGeneralized.apply(x_expanded, chunk_matched_idx)
+
+        gate_prime = x_chunk @ W_g
+        up_prime = x_chunk @ W_u
+        down_chunk = (up_prime * act_fn(gate_prime)) @ W_d
+
+        rw_chunk = CtxGatherFunc3DGeneralized.apply(routing_weight, chunk_matched_idx)
+        down_chunk = down_chunk * rw_chunk
+
+        expert_out_chunk = CtxGatherFunc3DGeneralized.apply(expert_out, chunk_matched_idx)
+        updated_chunk = expert_out_chunk + down_chunk
+
+        chunk_valid_rows = torch.clamp(
+            valid_rows - packed_start,
+            min=torch.zeros_like(valid_rows),
+            max=torch.full_like(valid_rows, packed_chunk_size),
+        )
+        updated_chunk = torch.where(
+            (row_range < chunk_valid_rows).unsqueeze(-1), updated_chunk, torch.zeros_like(updated_chunk)
+        )
+        expert_out = CtxScatterFunc3DGeneralized.apply(expert_out, chunk_matched_idx, updated_chunk)
+
+    return expert_out
+
+
+class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
+    supports_moe_prefill_blocking = True
+
+    def __qeff_init__(self):
+        # Derive gather-friendly split projections from the checkpoint's fused
+        # gate_up_proj/down_proj, without changing on-disk checkpoint format.
+        gate_up_proj = self.gate_up_proj.detach()
+        down_proj = self.down_proj.detach()
+        self.gate_proj = nn.Parameter(gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2), requires_grad=False)
+        self.up_proj = nn.Parameter(gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2), requires_grad=False)
+        self.down_proj_t = nn.Parameter(down_proj.transpose(1, 2), requires_grad=False)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -340,21 +430,36 @@ class QEffPrefillChunckedGemma4TextExperts(Gemma4TextExperts):
         )
         expert_weights.scatter_add_(1, top_k_index, top_k_weights)
         expert_weights = expert_weights.to(x.dtype)
-        out = x.new_zeros((T, H))
-        for e in range(self.num_experts):
-            w = expert_weights[:, e].unsqueeze(-1)  # [T, 1]
-
-            # gate_up_proj[e]: [2I, H], down_proj[e]: [H, I] (matching your original matmuls)
-            gate_up = x @ self.gate_up_proj[e].transpose(0, 1)  # [T, 2I]
-            gate, up = gate_up.chunk(2, dim=-1)  # [T, I], [T, I]
-            activated = self.act_fn(gate) * up  # [T, I]
-            down = activated @ self.down_proj[e].transpose(0, 1)  # [T, H]
-
-            out += down * w
-
+        num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
+        packed_chunk_size = getattr(self, "expert_blocking_packed_chunk_size", T)
+        if self.num_experts % num_nsp != 0:
+            raise ValueError(
+                f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({num_nsp})"
+            )
+        local_experts = self.num_experts // num_nsp
+        rw = expert_weights.transpose(0, 1).contiguous().view(local_experts, num_nsp, T).transpose(0, 1).contiguous()
+        W_g = self.gate_proj.view(local_experts, num_nsp, H, -1).transpose(0, 1).contiguous()
+        W_u = self.up_proj.view(local_experts, num_nsp, H, -1).transpose(0, 1).contiguous()
+        W_d = self.down_proj_t.view(local_experts, num_nsp, -1, H).transpose(0, 1).contiguous()
+        expert_out = x.new_zeros((num_nsp, T, H))
+        routing_weights_unsqueezed = rw.unsqueeze(-1)
+        for slot in range(local_experts):
+            T2Ei = rw[:, slot, :] > 0
+            expert_out = _cumsum_scatter_gather_update_expert_blocked(
+                x=x,
+                T2Ei=T2Ei,
+                W_g=W_g[:, slot],
+                W_u=W_u[:, slot],
+                W_d=W_d[:, slot],
+                routing_weight=routing_weights_unsqueezed[:, slot],
+                expert_out=expert_out,
+                act_fn=self.act_fn,
+                packed_chunk_size=packed_chunk_size,
+            )
+        expert_output = torch.einsum("ijk->jk", expert_out)
         if reshape_back:
-            return out.view(B, S, H)
-        return out
+            return expert_output.view(B, S, H)
+        return expert_output
 
 
 class QEffGemma4VisionAttention(Gemma4VisionAttention):

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1503,6 +1503,24 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         """
         return [self.vision_model.onnx_path, self.lang_model.onnx_path]
 
+    def __update_prefill_transform(
+        self,
+        enable: Optional[bool] = True,
+        enable_chunking: Optional[bool] = False,
+        retain_full_kv: Optional[bool] = False,
+    ):
+        if enable:
+            if enable_chunking:
+                self.model, tf = PrefillOnlyChunkedTransform.apply(self.model)
+            else:
+                self.model, tf = PrefillOnlyTransform.apply(self.model)
+
+        else:
+            if retain_full_kv:
+                self.model, tf = RevertPrefillKeepAttentionTransform.apply(self.model)
+            else:
+                self.model, tf = RevertPrefillOnlyTransform.apply(self.model)
+
     def export(
         self,
         export_dir: Optional[str] = None,
@@ -1512,6 +1530,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         prefill_seq_len: Optional[int] = None,
         prefill_only: bool = False,
         enable_chunking: bool = False,
+        num_cores: int = constants.DEFAULT_AIC_NUM_CORES,
+        moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
         layerwise: bool = False,
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
@@ -1552,13 +1572,28 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 kv_cache_prefix=kv_cache_prefix,
                 **kwargs,
             )
-
+        bs: int = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
+        seq_len: int = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
+        # TODO: move this to a DA Serving utility class
+        if self.model.config.model_type in SPECIALIZED_DISAGG_SERVING_MODEL_ARCH:
+            if prefill_only:
+                self.__update_prefill_transform(enable=True, enable_chunking=enable_chunking)
+                for module in self.model.modules():
+                    if getattr(module, "supports_moe_prefill_blocking", False):
+                        module.expert_blocking_num_nsp = num_cores
+                        module.expert_blocking_packed_chunk_size = moe_prefill_packed_chunk_size
+                if self.model.config.model_type in {"gemma4"}:
+                    seq_len = max(prefill_seq_len or 0, constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN)
+            else:
+                self.__update_prefill_transform(False, retain_full_kv=kwargs.get("retain_full_kv", False))
+        onnx_kwargs = {"prefill_seq_len": seq_len, "batch_size": bs}
         # TODO This is a temporary change as continous batching is enabled only for few models. Once support is added for all the models this exception handing can be removed.
         try:
             inputs = self.model.get_dummy_inputs(
                 kv_offload=True,
                 continuous_batching=self.continuous_batching,
                 comp_ctx_lengths=self.comp_ctx_lengths_decode,
+                **onnx_kwargs,
             )
             dynamic_axes = self.model.get_onnx_dynamic_axes(
                 kv_offload=True,
@@ -1567,8 +1602,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             )
         except TypeError:
             inputs = self.model.get_dummy_inputs(
-                kv_offload=True,
-                comp_ctx_lengths=self.comp_ctx_lengths_decode,
+                kv_offload=True, comp_ctx_lengths=self.comp_ctx_lengths_decode, **onnx_kwargs
             )
             dynamic_axes = self.model.get_onnx_dynamic_axes(
                 kv_offload=True, comp_ctx_lengths=self.comp_ctx_lengths_decode
@@ -1627,6 +1661,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 use_onnx_subfunctions=use_onnx_subfunctions,
                 prefill_only=prefill_only,
                 enable_chunking=enable_chunking,
+                num_cores=num_cores,
+                moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
                 prefill_seq_len=prefill_seq_len,
                 _layerwise_cache_probe=layerwise_cache_probe,
                 kv_cache_prefix=kv_cache_prefix,
@@ -1814,6 +1850,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         layerwise: bool = False,
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
+        moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
         **compiler_options,
     ) -> str:
         """
@@ -1899,6 +1936,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                     offload_pt_weights=offload_pt_weights,
                     enable_chunking=enable_chunking,
                     qaic_config=qaic_config,
+                    moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
                     kv_cache_prefix=kv_cache_prefix,
                     **compiler_options,
                 )

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -42,6 +42,7 @@ from QEfficient.generation.text_generation_inference import (
 )
 from QEfficient.generation.vlm_generation import VisionLanguageGeneration
 from QEfficient.transformers.modeling_utils import (
+    DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH,
     DYNAMIC_SEQ_LEN_SUPPORTED_MODEL_ARCH,
     SPECIALIZED_DISAGG_SERVING_MODEL_ARCH,
     _configure_proxy_for_model,
@@ -1576,13 +1577,15 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         seq_len: int = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
         # TODO: move this to a DA Serving utility class
         if self.model.config.model_type in SPECIALIZED_DISAGG_SERVING_MODEL_ARCH:
-            if prefill_only:
+            if prefill_only and enable_chunking:
                 self.__update_prefill_transform(enable=True, enable_chunking=enable_chunking)
                 for module in self.model.modules():
                     if getattr(module, "supports_moe_prefill_blocking", False):
                         module.expert_blocking_num_nsp = num_cores
                         module.expert_blocking_packed_chunk_size = moe_prefill_packed_chunk_size
-                if self.model.config.model_type in {"gemma4"}:
+                        if hasattr(module, "__qeff_init__"):
+                            module.__qeff_init__()
+                if self.model.config.model_type in DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH:
                     seq_len = max(prefill_seq_len or 0, constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN)
             else:
                 self.__update_prefill_transform(False, retain_full_kv=kwargs.get("retain_full_kv", False))

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1582,11 +1582,18 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 for module in self.model.modules():
                     if getattr(module, "supports_moe_prefill_blocking", False):
                         module.expert_blocking_num_nsp = num_cores
-                        module.expert_blocking_packed_chunk_size = moe_prefill_packed_chunk_size
+                        if prefill_seq_len % moe_prefill_packed_chunk_size == 0:
+                            module.expert_blocking_packed_chunk_size = prefill_seq_len // moe_prefill_packed_chunk_size
+                        else:
+                            raise ValueError("Prefill_seq_len must be divisible by moe_prefill_packed_chunk_size")
                         if hasattr(module, "__qeff_init__"):
                             module.__qeff_init__()
                 if self.model.config.model_type in DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH:
-                    seq_len = max(prefill_seq_len or 0, constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN)
+                    seq_len = (
+                        seq_len
+                        if prefill_seq_len % moe_prefill_packed_chunk_size == 0
+                        else moe_prefill_packed_chunk_size
+                    )
             else:
                 self.__update_prefill_transform(False, retain_full_kv=kwargs.get("retain_full_kv", False))
         onnx_kwargs = {"prefill_seq_len": seq_len, "batch_size": bs}

--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -370,7 +370,7 @@ from QEfficient.transformers.models.gemma4.modeling_gemma4 import (
     QEffGemma4TextModel,
     QEffGemma4TextRouter,
     QEffGemma4VisionAttention,
-    QEffPrefillChunckedGemma4TextExperts,
+    QEffPrefillChunkedGemma4TextExperts,
 )
 from QEfficient.transformers.models.glm4_moe.modeling_glm4_moe import (
     QEffGlm4MoeAttention,
@@ -966,7 +966,7 @@ class PrefillOnlyChunkedTransform(ModuleMappingTransform):
         # Qwen3_5Moe
         QEffQwen3_5MoeSparseMoeBlock: QEffPrefillChunkedQwen3_5MoeSparseMoeBlock,
         # Gemma4_Moe
-        QEffGemma4TextExperts: QEffPrefillChunckedGemma4TextExperts,
+        QEffGemma4TextExperts: QEffPrefillChunkedGemma4TextExperts,
     }
 
 
@@ -987,7 +987,7 @@ class RevertPrefillKeepAttentionTransform(ModuleMappingTransform):
         # Qwen3_5Moe
         QEffPrefillChunkedQwen3_5MoeSparseMoeBlock: QEffQwen3_5MoeSparseMoeBlock,
         # Gemma4_Moe
-        QEffPrefillChunckedGemma4TextExperts: QEffGemma4TextExperts,
+        QEffPrefillChunkedGemma4TextExperts: QEffGemma4TextExperts,
     }
 
 

--- a/QEfficient/utils/constants.py
+++ b/QEfficient/utils/constants.py
@@ -259,6 +259,12 @@ CCL_UNIQNE_STEP = 32
 # used for gpt-oss prefill-only model Q-blocking
 GPT_OSS_PREFILL_Q_BLOCK_SIZE = 256
 
+# Gemma4
+SUPPORTED_NUM_SOFT_TOKENS_PER_IMAGE = [70, 140, 280, 560, 1120]
+GEMMA4_HEIGHT = 786
+GEMMA4_WIDTH = 786
+DUMMY_SOFT_TOKEN = 560
+
 
 class Constants:
     # Export Constants.

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
@@ -77,6 +77,7 @@ prefill_qpc_path = qeff_model.compile(
     node_precision_info=True,
     prefill_only=True,
     enable_chunking=True,
+    use_onnx_subfunctions=True,
     skip_vision=True,
 )
 
@@ -93,6 +94,7 @@ decode_qpc_path = qeff_model.compile(
     aic_enable_depth_first=True,
     node_precision_info=True,
     prefill_only=False,
+    use_onnx_subfunctions=True,
     skip_vision=True,
 )
 

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
@@ -40,7 +40,7 @@ processor = AutoProcessor.from_pretrained(model_id)
 
 ENABLE_FP16_CLIP = True
 remove_fp16clip_transform_if_disabled(qeff_model, ENABLE_FP16_CLIP)
-PREFILL_SEQ_LEN = 296
+PREFILL_SEQ_LEN = 256
 CTX_LEN = 4096
 BS = 1
 gemma_vision_dir = Path(__file__).resolve().parent.parent
@@ -57,6 +57,7 @@ if not skip_vision:
         num_devices=1,
         mos=1,
         mxfp6_matmul=True,
+        mxint8_kv_cache=True,
         aic_enable_depth_first=True,
         skip_vision=skip_vision,
         split_model_io=True,
@@ -77,6 +78,7 @@ prefill_qpc_path = qeff_model.compile(
     node_precision_info=True,
     prefill_only=True,
     enable_chunking=True,
+    moe_prefill_packed_chunk_size=256,
     use_onnx_subfunctions=True,
     skip_vision=True,
 )

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_multi_resolution.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_multi_resolution.py
@@ -1,0 +1,169 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+
+
+import requests
+from gemma4_utils import *
+from PIL import Image
+from transformers import AutoConfig, AutoProcessor
+
+from QEfficient import QEFFAutoModelForImageTextToText
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+MODEL_ID = "google/gemma-4-E2B-it"
+
+# ---------------------------------------------------------------------------
+# Sequence-length budget
+# ---------------------------------------------------------------------------
+PREFILL_SEQ_LEN = 256  # Must be >= longest tokenised vision prompt
+CTX_LEN = 2048
+GENERATION_LEN = 100
+BATCH_SIZE = 1
+
+# ---------------------------------------------------------------------------
+# Testing knobs: reduce layers for fast end-to-end validation
+# ---------------------------------------------------------------------------
+NUM_LANG_HIDDEN_LAYER = 2
+NUM_VISION_HIDDEN_LAYER = 2
+
+# ---------------------------------------------------------------------------
+# Compiler settings
+# ---------------------------------------------------------------------------
+NUM_CORES = 16
+NUM_DEVICES = 2
+NODE_PRECISION_INFO = True  # Auto-generate Gemma4 NPI file for mixed precision
+
+# ---------------------------------------------------------------------------
+# Sample inputs ( prompts / images)
+# ---------------------------------------------------------------------------
+IMAGE_URL = (
+    "https://wallup.net/wp-content/uploads/2017/03/28/351036-San_Francisco-USA-bridge-sunset-Golden_Gate_Bridge-lights.jpg"
+)
+IMAGE_PROMPT = "Can you Describe this image in detail?"
+SYSTEM_PROMPT = "You are a helpful assistant."
+
+
+def _apply_reduced_layer_config(config, num_lang_layers: int, num_vision_layers: int):
+    """Shrink layer counts so the model fits in CPU RAM during testing."""
+    config.text_config.num_hidden_layers = num_lang_layers
+    config.vision_config.num_hidden_layers = num_vision_layers
+
+    if hasattr(config.text_config, "layer_types") and config.text_config.layer_types:
+        config.text_config.layer_types = config.text_config.layer_types[:num_lang_layers]
+
+    if hasattr(config.text_config, "num_kv_shared_layers"):
+        # Avoid invalid first_kv_shared_layer_idx=0 edge case with few layers.
+        config.text_config.num_kv_shared_layers = 0
+
+    return config
+
+
+def main():
+    # ------------------------------------------------------------------
+    # STEP 1: Processor / tokenizer
+    # ------------------------------------------------------------------
+    processor = AutoProcessor.from_pretrained(MODEL_ID, trust_remote_code=True)
+    tokenizer = processor.tokenizer
+    chat_template = (
+        getattr(processor, "chat_template", None) or getattr(tokenizer, "chat_template", None) or CHAT_TEMPLATE
+    )
+
+    # ------------------------------------------------------------------
+    # STEP 2: Config (with layer reduction for testing)
+    # ------------------------------------------------------------------
+    config = AutoConfig.from_pretrained(MODEL_ID)
+    # For Testing Purpose Only
+    # config = _apply_reduced_layer_config(config, NUM_LANG_HIDDEN_LAYER, NUM_VISION_HIDDEN_LAYER)
+    # ------------------------------------------------------------------
+    # STEP 3: Height and Width config
+    # ------------------------------------------------------------------
+
+    resolutions = [
+        {"width": 360, "height": 240},
+        {"width": 536, "height": 354},
+        {"width": 1024, "height": 1024},
+    ]
+
+    widths = [s["width"] for s in resolutions]
+    heights = [s["height"] for s in resolutions]
+    # ------------------------------------------------------------------
+    # STEP 4: Model Loading
+    # ------------------------------------------------------------------
+    qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
+        MODEL_ID,
+        config=config,
+        trust_remote_code=True,
+        dtype="float32",
+        kv_offload=True,  # Dual-QPC: vision encoder + LM decoder
+        ignore_mismatched_sizes=True,
+    )
+    remove_fp16clip_transform_if_disabled(qeff_model, effective_fp16clip=True)
+
+    # ------------------------------------------------------------------
+    # STEP 5: Compile both QPCs
+    # ------------------------------------------------------------------
+    qeff_model.compile(
+        prefill_seq_len=PREFILL_SEQ_LEN,
+        ctx_len=CTX_LEN,
+        batch_size=BATCH_SIZE,
+        num_cores=NUM_CORES,
+        num_devices=NUM_DEVICES,
+        mxfp6_matmul=True,
+        mxint8_kv_cache=True,
+        height=heights,
+        width=widths,
+        aic_enable_depth_first=True,
+        mos=1,
+        split_model_io=True,
+        node_precision_info=NODE_PRECISION_INFO,
+        use_onnx_subfunctions=False,
+    )
+
+    # ------------------------------------------------------------------
+    # STEP 6: Generate
+    # ------------------------------------------------------------------
+    messages = build_messages(SYSTEM_PROMPT, IMAGE_PROMPT, use_image=True)
+
+    for i, (w, h) in enumerate(zip(widths, heights)):
+        image = Image.open(requests.get(IMAGE_URL, stream=True).raw)
+        image = image.resize((w, h))
+        messages[-1]["content"][0]["url"] = image
+        required_soft_tokens = qeff_model.model.choose_gemma4_max_soft_tokens(h, w)
+        processor.image_processor.max_soft_tokens = required_soft_tokens
+        config.vision_soft_tokens_per_image = required_soft_tokens
+        inputs = processor.apply_chat_template(
+            messages,
+            chat_template=chat_template,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+        output = qeff_model.generate(
+            inputs=inputs,
+            generation_len=GENERATION_LEN,
+            multi_specs=True,
+            tokenizer=tokenizer,
+            processor=processor,
+        )
+        qeff_ids = normalize_generated_ids(output.generated_ids)[:, :GENERATION_LEN]
+        generated_texts = tokenizer.batch_decode(qeff_ids, skip_special_tokens=True)
+
+        for text in generated_texts:
+            print(f"\n--- Response [{i}] ---")
+            print(text)
+        i = i + 1
+
+        print("\nExecution info:")
+        print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds multi-resolution Gemma4 vision workflow support via a new example script:
  gemma4_multi_resolution.py.

  The script compiles a single Gemma4 setup with multiple (height, width) specializations, then runs
  generation across those resolutions by dynamically selecting the required vision token budget
  (choose_gemma4_max_soft_tokens). This demonstrates
  end-to-end compile + generate for variable image sizes without per-resolution recompilation.