### PR TITLE
Gemma4 Moe and Prefill changes

### DIFF
--- a/QEfficient/transformers/modeling_utils.py
+++ b/QEfficient/transformers/modeling_utils.py
@@ -215,7 +215,10 @@ qeff_supported_architectures = ModelArchitectures(
 DYNAMIC_SEQ_LEN_SUPPORTED_MODEL_ARCH = {"gemma3", "gemma3_text", "gemma4_text", "llama4", "llama4_text"}
 
 # This is for supporting different modelling classes specially written for prefill-only model
-SPECIALIZED_DISAGG_SERVING_MODEL_ARCH = {"gpt_oss", "qwen3_moe", "glm4_moe", "kimi_k2", "kimi_k25"}
+SPECIALIZED_DISAGG_SERVING_MODEL_ARCH = {"gpt_oss", "qwen3_moe", "glm4_moe", "kimi_k2", "kimi_k25", "gemma4"}
+
+# This is for supporting dynamic prefill sequence length for prefill_only model
+DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH = {"gemma4"}
 
 _PROXY_ONLY_ONNX_TRANSFORMS = (FP16ClipTransform, SplitTensorsTransform)
 

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -5,12 +5,10 @@
 #
 # -----------------------------------------------------------------------------
 
-import os
 from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional, Type, Union
 
-import numpy as np
 import onnx
 import torch
 import torch.nn as nn
@@ -31,7 +29,6 @@ from transformers.models.gemma4.modeling_gemma4 import (
     eager_attention_forward,
 )
 
-from QEfficient.base.onnx_transforms import FP16ClipTransform
 from QEfficient.customop.rms_norm import CustomRMSNormFunc
 from QEfficient.transformers.cache_utils import QEffGemma4DynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
@@ -279,32 +276,41 @@ class QEffGemma4CustomRMSNormAIC(nn.Module):
 
 
 class QEffGemma4TextExperts(Gemma4TextExperts):
+    def __qeff_init__(self):
+        # Derive gather-friendly split projections from the checkpoint's fused
+        # gate_up_proj/down_proj, without changing on-disk checkpoint format.
+        gate_up_proj = self.gate_up_proj.detach()
+        down_proj = self.down_proj.detach()
+        self.gate_proj = nn.Parameter(gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2), requires_grad=False)
+        self.up_proj = nn.Parameter(gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2), requires_grad=False)
+        self.down_proj_t = nn.Parameter(down_proj.transpose(1, 2), requires_grad=False)
+
     def forward(
         self,
         hidden_states: torch.Tensor,
         top_k_index: torch.Tensor,
         top_k_weights: torch.Tensor,
     ) -> torch.Tensor:
-        gate_up_proj_t = self.gate_up_proj.transpose(1, 2)
-        gate_up_out = torch.matmul(hidden_states, gate_up_proj_t).permute(1, 0, 2)
-        gate, up = gate_up_out.chunk(2, dim=-1)
+        T, H = hidden_states.shape
+        K = top_k_index.shape[1]
+        idx = top_k_index.reshape(-1)
+
+        gate_proj = self.gate_proj[idx]  # [T*K, H, I] -- gather only the selected experts
+        up_proj = self.up_proj[idx]  # [T*K, H, I]
+        down_proj_t = self.down_proj_t[idx]  # [T*K, I, H]
+
+        xk = hidden_states.unsqueeze(1).expand(-1, K, -1).contiguous().view(-1, 1, H)  # [T*K, 1, H]
+        gate = torch.bmm(xk, gate_proj)  # [T*K, 1, I]
+        up = torch.bmm(xk, up_proj)  # [T*K, 1, I]
         activated = self.act_fn(gate) * up
 
-        down_proj_t = self.down_proj.transpose(1, 2)
-        experts_out = torch.matmul(activated.permute(1, 0, 2), down_proj_t).permute(1, 0, 2)
-        expert_weights = torch.zeros(
-            hidden_states.shape[0],
-            self.num_experts,
-            dtype=top_k_weights.dtype,
-            device=top_k_weights.device,
-        )
-        expert_weights.scatter_add_(1, top_k_index, top_k_weights)
-        weighted_experts = experts_out.transpose(1, 2)  # [tokens, hidden, num_experts]
-        combine_weights = expert_weights.to(experts_out.dtype).unsqueeze(-1)  # [tokens, num_experts, 1]
-        return torch.bmm(weighted_experts, combine_weights).squeeze(-1)
+        down = torch.bmm(activated, down_proj_t)  # [T*K, 1, H]
+        down = down.view(T, K, H) * top_k_weights.unsqueeze(-1)
+        down = torch.einsum("bnh->bh", down)
+        return down
 
 
-class QEffPrefillChunckedGemma4TextExperts(Gemma4TextExperts):
+class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -498,10 +504,6 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
         attn_output = attn_output.reshape(*input_shape, -1).contiguous()
         attn_output = self.o_proj(attn_output)
         return attn_output, attn_weights
-
-
-EXPERT_BLOCKING_NUM_NSP = int(os.environ.get("EXPERT_BLOCKING_NUM_NSP", "16"))
-EXPERT_BLOCKING_PACKED_CHUNK_SIZE = int(os.environ.get("EXPERT_BLOCKING_PACKED_CHUNK_SIZE", "296"))
 
 
 class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
@@ -1319,13 +1321,23 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         return past_key_values
 
     def get_dummy_inputs(
-        self, comp_ctx_lengths: Optional[List[int]] = None, kv_offload: bool = False, continuous_batching: bool = False
+        self,
+        comp_ctx_lengths: Optional[List[int]] = None,
+        kv_offload: bool = False,
+        continuous_batching: bool = False,
+        **kwargs,
     ):
-        bs = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
+        seq_len = kwargs.get("prefill_seq_len", None)
+        bs = kwargs.get("batch_size", None)
+        if seq_len is None:
+            seq_len = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
+        seq_len = int(seq_len)
+        if bs is None:
+            bs = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
+        bs = int(bs)
         fbs = constants.ONNX_EXPORT_EXAMPLE_FBS
         max_patches = self._get_vision_max_patches()
         mm_tokens_per_image = self._get_mm_tokens_per_image()
-        seq_len = max(constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN, mm_tokens_per_image + 32)
         patch_dim = getattr(self.config.vision_config, "patch_size", 16) ** 2 * 3
 
         image_position_ids = torch.full((bs, max_patches, 2), -1, dtype=torch.int64)
@@ -1367,42 +1379,3 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         if kv_offload:
             return {"vision": vision_inputs, "lang": lang_inputs}
         return {**vision_inputs, **lang_inputs}
-
-    def remove_fp16clip_transform_if_disabled(self, effective_fp16clip: bool):
-        """
-        Remove FP16ClipTransform from ONNX transforms when FP16 clipping is disabled.
-        """
-        if not effective_fp16clip:
-            # ---- language model
-            if hasattr(self, "lang_model") and hasattr(self.lang_model, "_onnx_transforms"):
-                self.lang_model._onnx_transforms = [
-                    t for t in self.lang_model._onnx_transforms if t is not FP16ClipTransform
-                ]
-
-            # ---- vision model (optional)
-            if getattr(self, "vision_model", None) is not None:
-                if hasattr(self.vision_model, "_onnx_transforms"):
-                    self.vision_model._onnx_transforms = [
-                        t for t in self.vision_model._onnx_transforms if t is not FP16ClipTransform
-                    ]
-
-    def normalize_generated_ids(self, generated_ids):
-        array = np.asarray(generated_ids)
-        if array.dtype == object:
-            array = np.asarray([np.asarray(row).reshape(-1) for row in generated_ids], dtype=np.int64)
-        array = np.asarray(array)
-        if array.ndim == 1:
-            array = array.reshape(1, -1)
-        elif array.ndim > 2:
-            array = array.reshape(array.shape[0], -1)
-        return array.astype(np.int64, copy=False)
-
-    def effective_lens(
-        self, prefill_seq_len: int, ctx_len: int, prompt_len: int, generation_len: int, skip_vision: bool
-    ):
-        effective_ctx_len = max(ctx_len, prompt_len + generation_len)
-        if skip_vision:
-            effective_prefill_seq_len = prefill_seq_len
-        else:
-            effective_prefill_seq_len = max(prefill_seq_len, prompt_len)
-        return effective_prefill_seq_len, effective_ctx_len

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -415,6 +415,7 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
         position_ids: Optional[torch.LongTensor] = None,
         mm_token_type_ids: Optional[torch.Tensor] = None,
         batch_index: Optional[torch.LongTensor] = None,
+        comp_ctx_lengths: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         input_shape = hidden_states.shape[:-1]
@@ -451,6 +452,9 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
             token_key_states, token_value_states = key_states, value_states
 
         if past_key_values is not None:
+            if comp_ctx_lengths is not None and attention_mask is not None:
+                attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
+                cache_kwargs["CCL"] = attention_mask.shape[-1]
             if self.is_kv_shared_layer:
                 if token_key_states is not None and token_value_states is not None:
                     key_states, value_states = past_key_values.update(
@@ -515,6 +519,7 @@ class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
         past_key_values: Cache | None = None,
+        comp_ctx_lengths: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> torch.Tensor:
         hidden_states = _clamp_to_fp16_range(hidden_states)
@@ -527,6 +532,7 @@ class QEffGemma4TextDecoderLayer(Gemma4TextDecoderLayer):
             attention_mask=attention_mask,
             position_ids=position_ids,
             past_key_values=past_key_values,
+            comp_ctx_lengths=comp_ctx_lengths,
             **kwargs,
         )
         hidden_states = self.post_attention_layernorm(hidden_states)
@@ -572,6 +578,7 @@ class QEffGemma4TextModel(Gemma4TextModel):
         past_key_values: Optional[Cache] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
         per_layer_inputs: Optional[torch.Tensor] = None,
+        comp_ctx_lengths: Optional[torch.Tensor] = None,
         use_cache: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         **kwargs,
@@ -646,6 +653,7 @@ class QEffGemma4TextModel(Gemma4TextModel):
                 attention_mask=layer_attention_mask,
                 position_ids=position_ids,
                 past_key_values=past_key_values,
+                comp_ctx_lengths=comp_ctx_lengths,
                 **kwargs,
             )
 
@@ -869,9 +877,9 @@ class QEffGemma4ForCausalLM(Gemma4ForCausalLM):
                 spec["batch_size"] = kv_cache_batch_size
             return spec
 
-        if comp_ctx_lengths_prefill and comp_ctx_lengths_decode:
-            specializations = [build_prefill_spec(length) for length in comp_ctx_lengths_prefill]
-            specializations.extend(build_decode_spec(length) for length in comp_ctx_lengths_decode)
+        if comp_ctx_lengths_prefill or comp_ctx_lengths_decode:
+            specializations = [build_prefill_spec(length) for length in (comp_ctx_lengths_prefill or [])]
+            specializations.extend(build_decode_spec(length) for length in (comp_ctx_lengths_decode or []))
             return specializations
 
         return [build_prefill_spec(), build_decode_spec()]
@@ -1245,9 +1253,9 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
                 spec["batch_size"] = kv_cache_batch_size or batch_size
             return spec
 
-        if comp_ctx_lengths_prefill and comp_ctx_lengths_decode:
-            lang = [build_lang_prefill_spec(length) for length in comp_ctx_lengths_prefill]
-            lang.extend(build_lang_decode_spec(length) for length in comp_ctx_lengths_decode)
+        if comp_ctx_lengths_prefill or comp_ctx_lengths_decode:
+            lang = [build_lang_prefill_spec(length) for length in (comp_ctx_lengths_prefill or [])]
+            lang.extend(build_lang_decode_spec(length) for length in (comp_ctx_lengths_decode or []))
         else:
             lang = [build_lang_prefill_spec(), build_lang_decode_spec()]
         if kv_offload:
@@ -1375,7 +1383,7 @@ class QEffGemma4ForConditionalGeneration(Gemma4ForConditionalGeneration):
         if continuous_batching:
             lang_inputs["batch_index"] = torch.arange(bs).view(bs, 1)
         if comp_ctx_lengths is not None:
-            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int8)
+            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int64)
         if kv_offload:
             return {"vision": vision_inputs, "lang": lang_inputs}
         return {**vision_inputs, **lang_inputs}

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -649,7 +649,6 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
             mm_token_type_ids is not None
             and hidden_states.shape[1] != 1
             and getattr(self.config, "use_bidirectional_attention", None) == "vision"
-            and self.sliding_window is not None
         ):
             attention_mask = _build_bidirectional_vision_attention_mask(
                 position_ids=position_ids,

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -7,7 +7,7 @@
 
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Optional, Type, Union
+from typing import List, Optional, Tuple, Type, Union
 
 import onnx
 import torch
@@ -27,8 +27,14 @@ from transformers.models.gemma4.modeling_gemma4 import (
     Gemma4VisionAttention,
     apply_rotary_pos_emb,
     eager_attention_forward,
+    repeat_kv,
 )
 
+from QEfficient.customop.ctx_scatter_gather import (
+    CtxGatherFunc3DGeneralized,
+    CtxScatterFunc3DGeneralized,
+    CtxScatterFunc3DInt,
+)
 from QEfficient.customop.rms_norm import CustomRMSNormFunc
 from QEfficient.transformers.cache_utils import QEffGemma4DynamicCache
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
@@ -91,7 +97,7 @@ def _build_additive_attention_mask(
         target_length=target_length,
         sliding_window=sliding_window,
     )
-    return causal_mask.to(dtype=dtype) * _attention_mask_min(dtype, causal_mask.device)
+    return causal_mask
 
 
 def _build_bidirectional_vision_attention_mask(
@@ -112,7 +118,7 @@ def _build_bidirectional_vision_attention_mask(
         sliding_window=sliding_window,
     )
     if mm_token_type_ids is None:
-        return base_mask.to(dtype=dtype) * _attention_mask_min(dtype, base_mask.device)
+        return base_mask
 
     is_vision = (mm_token_type_ids == 1) | (mm_token_type_ids == 2)
     is_prev_vision = torch.roll(is_vision, shifts=1, dims=-1)
@@ -129,7 +135,7 @@ def _build_bidirectional_vision_attention_mask(
 
     same_group = (vision_group_ids.unsqueeze(-1) == kv_group_ids.unsqueeze(1)) & (vision_group_ids.unsqueeze(-1) >= 0)
     attention_mask = base_mask & ~same_group.unsqueeze(1)
-    return attention_mask.to(dtype=dtype) * _attention_mask_min(dtype, attention_mask.device)
+    return attention_mask
 
 
 def apply_multidimensional_rope(
@@ -188,6 +194,40 @@ def apply_multidimensional_rope(
         unsqueeze_dim=unsqueeze_dim,
     )
     return y_grouped.reshape(*x.shape[:-1], total_rotated_channels)
+
+
+def eager_attention_forward_text(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    dropout: float = 0.0,
+    scaling: Optional[float] = None,
+    softcap: Optional[float] = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if softcap is not None:
+        attn_weights = attn_weights / softcap
+        attn_weights = torch.tanh(attn_weights)
+        attn_weights = attn_weights * softcap
+
+    if attention_mask is not None:
+        attn_weights = torch.where(
+            attention_mask,
+            torch.tensor(constants.MIN_MASKED_ATTENTION_VALUE, dtype=module.config.torch_dtype),
+            attn_weights,
+        )
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+
+    return attn_output, attn_weights
 
 
 class QEffGemma4TextRouter(Gemma4TextRouter):
@@ -310,7 +350,117 @@ class QEffGemma4TextExperts(Gemma4TextExperts):
         return down
 
 
+def _build_matched_idx_from_cumsum(T2Ei: torch.Tensor) -> torch.Tensor:
+    """Build packed->original token index"""
+    batch_size, seq_len = T2Ei.shape
+    int32_max = torch.iinfo(torch.int32).max
+    int32_max_scalar = torch.tensor(int32_max, dtype=torch.int32, device=T2Ei.device)
+    token_idx = torch.arange(seq_len, dtype=torch.int32, device=T2Ei.device).unsqueeze(0).expand(batch_size, -1)
+    valid_prefix = torch.cumsum(T2Ei.to(torch.int32), dim=1)
+    valid_dest = valid_prefix - 1
+    scatter_pos = torch.where(T2Ei, valid_dest, int32_max_scalar)
+    matched_idx = torch.full_like(token_idx, int32_max)
+    matched_idx = CtxScatterFunc3DInt.apply(
+        matched_idx.unsqueeze(-1),
+        scatter_pos,
+        token_idx.unsqueeze(-1),
+    ).squeeze(-1)
+    return matched_idx
+
+
+def _cumsum_scatter_gather_update_expert_blocked(
+    x: torch.Tensor,
+    T2Ei: torch.Tensor,
+    W_g: torch.Tensor,
+    W_u: torch.Tensor,
+    W_d: torch.Tensor,
+    routing_weight: torch.Tensor,
+    expert_out: torch.Tensor,
+    act_fn,
+    num_packed_chunks: int,
+) -> torch.Tensor:
+    """Cumsum-scatter-gather-update expert helper for NSP-blocked dispatch.
+
+    Accumulates one local expert's contribution in-place onto ``expert_out``.
+    Uses a packed/cumsum layout so the MLP runs only over active rows, then
+    scatters the weighted output back to original token positions.
+    """
+    batch_size, seq_len = T2Ei.shape
+    num_packed_chunks = max(1, int(num_packed_chunks))
+    assert seq_len % num_packed_chunks == 0, (
+        f"seq_len={seq_len} must be divisible by num_packed_chunks={num_packed_chunks}"
+    )
+    packed_chunk_size = seq_len // num_packed_chunks
+    matched_idx = _build_matched_idx_from_cumsum(T2Ei)
+    valid_rows = torch.einsum("ij->i", T2Ei.to(torch.int32)).unsqueeze(1)
+    x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
+    for chunk_idx in range(num_packed_chunks):
+        packed_start = chunk_idx * packed_chunk_size
+        if chunk_idx == num_packed_chunks - 1:
+            packed_stop = seq_len
+        else:
+            packed_stop = packed_start + packed_chunk_size
+        chunk_rows = packed_stop - packed_start
+        row_range = torch.arange(chunk_rows, dtype=torch.int32, device=x.device).unsqueeze(0)
+        chunk_matched_idx = matched_idx[:, packed_start:packed_stop]
+        x_chunk = CtxGatherFunc3DGeneralized.apply(x_expanded, chunk_matched_idx)
+        gate_prime = x_chunk @ W_g
+        up_prime = x_chunk @ W_u
+        down_chunk = (up_prime * act_fn(gate_prime)) @ W_d
+
+        rw_chunk = CtxGatherFunc3DGeneralized.apply(routing_weight, chunk_matched_idx)
+        down_chunk = down_chunk * rw_chunk
+
+        expert_out_chunk = CtxGatherFunc3DGeneralized.apply(expert_out, chunk_matched_idx)
+        updated_chunk = expert_out_chunk + down_chunk
+
+        chunk_valid_rows = torch.clamp(
+            valid_rows - packed_start,
+            min=torch.zeros_like(valid_rows),
+            max=torch.full_like(valid_rows, packed_chunk_size),
+        )
+        updated_chunk = torch.where(
+            (row_range < chunk_valid_rows).unsqueeze(-1), updated_chunk, torch.zeros_like(updated_chunk)
+        )
+        expert_out = CtxScatterFunc3DGeneralized.apply(expert_out, chunk_matched_idx, updated_chunk)
+
+    return expert_out
+
+
 class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
+    supports_moe_prefill_blocking = True
+
+    def __qeff_init__(self):
+        H = self.hidden_dim
+        # Derive gather-friendly split projections from the checkpoint's fused
+        # gate_up_proj/down_proj, without changing on-disk checkpoint format.
+        gate_up_proj = self.gate_up_proj.detach()
+        down_proj = self.down_proj.detach()
+        self.gate_proj_t = gate_up_proj[:, : self.intermediate_dim, :].transpose(1, 2)
+        self.up_proj_t = gate_up_proj[:, self.intermediate_dim :, :].transpose(1, 2)
+        self.num_nsp = getattr(self, "expert_blocking_num_nsp", self.num_experts)
+        if self.num_experts % self.num_nsp != 0:
+            raise ValueError(
+                f"num_experts ({self.num_experts}) must be divisible by expert_blocking_num_nsp ({self.num_nsp})"
+            )
+        self.local_experts = self.num_experts // self.num_nsp
+        self.W_g = nn.Parameter(
+            self.gate_proj_t.view(self.local_experts, self.num_nsp, H, -1).transpose(0, 1).contiguous().clone(),
+            requires_grad=False,
+        )
+        self.W_u = nn.Parameter(
+            self.up_proj_t.view(self.local_experts, self.num_nsp, H, -1).transpose(0, 1).contiguous().clone(),
+            requires_grad=False,
+        )
+        self.W_d = nn.Parameter(
+            down_proj.transpose(1, 2)
+            .view(self.local_experts, self.num_nsp, -1, H)
+            .transpose(0, 1)
+            .contiguous()
+            .clone(),
+            requires_grad=False,
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -329,6 +479,8 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
 
         T = x.shape[0]
 
+        num_packed_chunks = getattr(self, "expert_blocking_packed_chunk_size", T)
+
         # Build dense routing weights [T, E] from top-k indices/weights
         expert_weights = torch.zeros(
             T,
@@ -338,21 +490,32 @@ class QEffPrefillChunkedGemma4TextExperts(Gemma4TextExperts):
         )
         expert_weights.scatter_add_(1, top_k_index, top_k_weights)
         expert_weights = expert_weights.to(x.dtype)
-        out = x.new_zeros((T, H))
-        for e in range(self.num_experts):
-            w = expert_weights[:, e].unsqueeze(-1)  # [T, 1]
-
-            # gate_up_proj[e]: [2I, H], down_proj[e]: [H, I] (matching your original matmuls)
-            gate_up = x @ self.gate_up_proj[e].transpose(0, 1)  # [T, 2I]
-            gate, up = gate_up.chunk(2, dim=-1)  # [T, I], [T, I]
-            activated = self.act_fn(gate) * up  # [T, I]
-            down = activated @ self.down_proj[e].transpose(0, 1)  # [T, H]
-
-            out += down * w
-
+        expert_out = x.new_zeros((self.num_nsp, T, H))
+        rw = (
+            expert_weights.transpose(0, 1)
+            .contiguous()
+            .view(self.local_experts, self.num_nsp, T)
+            .transpose(0, 1)
+            .contiguous()
+        )
+        routing_weights_unsqueezed = rw.unsqueeze(-1)
+        for slot in range(self.local_experts):
+            T2Ei = rw[:, slot, :] > 0
+            expert_out = _cumsum_scatter_gather_update_expert_blocked(
+                x=x,
+                T2Ei=T2Ei,
+                W_g=self.W_g[:, slot],
+                W_u=self.W_u[:, slot],
+                W_d=self.W_d[:, slot],
+                routing_weight=routing_weights_unsqueezed[:, slot],
+                expert_out=expert_out,
+                act_fn=self.act_fn,
+                num_packed_chunks=num_packed_chunks,
+            )
+        expert_output = torch.einsum("ijk->jk", expert_out)
         if reshape_back:
-            return out.view(B, S, H)
-        return out
+            return expert_output.view(B, S, H)
+        return expert_output
 
 
 class QEffGemma4VisionAttention(Gemma4VisionAttention):
@@ -452,9 +615,12 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
             token_key_states, token_value_states = key_states, value_states
 
         if past_key_values is not None:
-            if comp_ctx_lengths is not None and attention_mask is not None:
-                attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
-                cache_kwargs["CCL"] = attention_mask.shape[-1]
+            if comp_ctx_lengths is not None:
+                if attention_mask is not None:
+                    attention_mask = attention_mask[:, :, :, : comp_ctx_lengths.shape[-1]]
+                    cache_kwargs["CCL"] = attention_mask.shape[-1]
+                elif self.sliding_window is None:
+                    cache_kwargs["CCL"] = comp_ctx_lengths.shape[-1]
             if self.is_kv_shared_layer:
                 if token_key_states is not None and token_value_states is not None:
                     key_states, value_states = past_key_values.update(
@@ -493,7 +659,7 @@ class QEffGemma4TextAttention(Gemma4TextAttention):
                 sliding_window=self.sliding_window,
             )
 
-        attn_output, attn_weights = eager_attention_forward(
+        attn_output, attn_weights = eager_attention_forward_text(
             self,
             query_states,
             key_states,

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -42,6 +42,7 @@ from QEfficient.generation.text_generation_inference import (
 )
 from QEfficient.generation.vlm_generation import VisionLanguageGeneration
 from QEfficient.transformers.modeling_utils import (
+    DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH,
     DYNAMIC_SEQ_LEN_SUPPORTED_MODEL_ARCH,
     SPECIALIZED_DISAGG_SERVING_MODEL_ARCH,
     _configure_proxy_for_model,
@@ -1503,6 +1504,24 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         """
         return [self.vision_model.onnx_path, self.lang_model.onnx_path]
 
+    def __update_prefill_transform(
+        self,
+        enable: Optional[bool] = True,
+        enable_chunking: Optional[bool] = False,
+        retain_full_kv: Optional[bool] = False,
+    ):
+        if enable:
+            if enable_chunking:
+                self.model, tf = PrefillOnlyChunkedTransform.apply(self.model)
+            else:
+                self.model, tf = PrefillOnlyTransform.apply(self.model)
+
+        else:
+            if retain_full_kv:
+                self.model, tf = RevertPrefillKeepAttentionTransform.apply(self.model)
+            else:
+                self.model, tf = RevertPrefillOnlyTransform.apply(self.model)
+
     def export(
         self,
         export_dir: Optional[str] = None,
@@ -1512,6 +1531,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         prefill_seq_len: Optional[int] = None,
         prefill_only: bool = False,
         enable_chunking: bool = False,
+        num_cores: int = constants.DEFAULT_AIC_NUM_CORES,
+        moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
         layerwise: bool = False,
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
@@ -1552,13 +1573,37 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 kv_cache_prefix=kv_cache_prefix,
                 **kwargs,
             )
-
+        bs: int = constants.ONNX_EXPORT_EXAMPLE_BATCH_SIZE
+        seq_len: int = constants.ONNX_EXPORT_EXAMPLE_SEQ_LEN
+        # TODO: move this to a DA Serving utility class
+        if self.model.config.model_type in SPECIALIZED_DISAGG_SERVING_MODEL_ARCH:
+            if prefill_only and enable_chunking:
+                self.__update_prefill_transform(enable=True, enable_chunking=enable_chunking)
+                for module in self.model.modules():
+                    if getattr(module, "supports_moe_prefill_blocking", False):
+                        module.expert_blocking_num_nsp = num_cores
+                        if prefill_seq_len % moe_prefill_packed_chunk_size == 0:
+                            module.expert_blocking_packed_chunk_size = prefill_seq_len // moe_prefill_packed_chunk_size
+                        else:
+                            raise ValueError("Prefill_seq_len must be divisible by moe_prefill_packed_chunk_size")
+                        if hasattr(module, "__qeff_init__"):
+                            module.__qeff_init__()
+                if self.model.config.model_type in DYNAMIC_PREFILL_SEQ_LEN_SUPPORTED_MODEL_ARCH:
+                    seq_len = (
+                        seq_len
+                        if prefill_seq_len % moe_prefill_packed_chunk_size == 0
+                        else moe_prefill_packed_chunk_size
+                    )
+            else:
+                self.__update_prefill_transform(False, retain_full_kv=kwargs.get("retain_full_kv", False))
+        onnx_kwargs = {"prefill_seq_len": seq_len, "batch_size": bs}
         # TODO This is a temporary change as continous batching is enabled only for few models. Once support is added for all the models this exception handing can be removed.
         try:
             inputs = self.model.get_dummy_inputs(
                 kv_offload=True,
                 continuous_batching=self.continuous_batching,
                 comp_ctx_lengths=self.comp_ctx_lengths_decode,
+                **onnx_kwargs,
             )
             dynamic_axes = self.model.get_onnx_dynamic_axes(
                 kv_offload=True,
@@ -1567,8 +1612,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             )
         except TypeError:
             inputs = self.model.get_dummy_inputs(
-                kv_offload=True,
-                comp_ctx_lengths=self.comp_ctx_lengths_decode,
+                kv_offload=True, comp_ctx_lengths=self.comp_ctx_lengths_decode, **onnx_kwargs
             )
             dynamic_axes = self.model.get_onnx_dynamic_axes(
                 kv_offload=True, comp_ctx_lengths=self.comp_ctx_lengths_decode
@@ -1627,6 +1671,8 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 use_onnx_subfunctions=use_onnx_subfunctions,
                 prefill_only=prefill_only,
                 enable_chunking=enable_chunking,
+                num_cores=num_cores,
+                moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
                 prefill_seq_len=prefill_seq_len,
                 _layerwise_cache_probe=layerwise_cache_probe,
                 kv_cache_prefix=kv_cache_prefix,
@@ -1814,6 +1860,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         layerwise: bool = False,
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
+        moe_prefill_packed_chunk_size: int = constants.MOE_PREFILL_PACKED_CHUNK_SIZE,
         **compiler_options,
     ) -> str:
         """
@@ -1899,6 +1946,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                     offload_pt_weights=offload_pt_weights,
                     enable_chunking=enable_chunking,
                     qaic_config=qaic_config,
+                    moe_prefill_packed_chunk_size=moe_prefill_packed_chunk_size,
                     kv_cache_prefix=kv_cache_prefix,
                     **compiler_options,
                 )

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -2086,14 +2086,26 @@ class _QEffAutoModelForImageTextToTextDualQPC:
 
             custom_io_lang = _filter_custom_io_for_onnx(custom_io_lang, self.lang_model.onnx_path)
 
+            # get_specializations lays the language specs out as
+            # [prefill specs..., decode specs...], with one spec per CCL value when
+            # CCL is enabled. The disagg prefill/decode QPCs must therefore keep the
+            # whole prefill/decode slice (not just the first/last spec), otherwise all
+            # but one CCL value is silently dropped.
+            lang_specs = specializations["lang"]
             if prefill_only:
-                specializations = specializations["lang"][:1]
+                if self.comp_ctx_lengths_prefill is not None:
+                    specializations = lang_specs[: len(self.comp_ctx_lengths_prefill)]
+                else:
+                    specializations = lang_specs[:1]
                 qpc_key = "lang_prefill_qpc_path"
             elif prefill_seq_len == 1:
-                specializations = specializations["lang"][-1:]
+                if self.comp_ctx_lengths_decode is not None:
+                    specializations = lang_specs[-len(self.comp_ctx_lengths_decode) :]
+                else:
+                    specializations = lang_specs[-1:]
                 qpc_key = "lang_decode_qpc_path"
             else:
-                specializations = specializations["lang"]
+                specializations = lang_specs
                 qpc_key = "lang_qpc_path"
 
             lang_qpc_path = self.lang_model._compile(

--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -367,7 +367,7 @@ from QEfficient.transformers.models.gemma4.modeling_gemma4 import (
     QEffGemma4TextModel,
     QEffGemma4TextRouter,
     QEffGemma4VisionAttention,
-    QEffPrefillChunckedGemma4TextExperts,
+    QEffPrefillChunkedGemma4TextExperts,
 )
 from QEfficient.transformers.models.glm4_moe.modeling_glm4_moe import (
     QEffGlm4MoeAttention,
@@ -953,7 +953,7 @@ class PrefillOnlyChunkedTransform(ModuleMappingTransform):
         # Qwen3_5Moe
         QEffQwen3_5MoeSparseMoeBlock: QEffPrefillChunkedQwen3_5MoeSparseMoeBlock,
         # Gemma4_Moe
-        QEffGemma4TextExperts: QEffPrefillChunckedGemma4TextExperts,
+        QEffGemma4TextExperts: QEffPrefillChunkedGemma4TextExperts,
     }
 
 
@@ -974,7 +974,7 @@ class RevertPrefillKeepAttentionTransform(ModuleMappingTransform):
         # Qwen3_5Moe
         QEffPrefillChunkedQwen3_5MoeSparseMoeBlock: QEffQwen3_5MoeSparseMoeBlock,
         # Gemma4_Moe
-        QEffPrefillChunckedGemma4TextExperts: QEffGemma4TextExperts,
+        QEffPrefillChunkedGemma4TextExperts: QEffGemma4TextExperts,
     }
 
 

--- a/QEfficient/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/QEfficient/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -1712,8 +1712,8 @@ class QEffQwen3_5ForConditionalGeneration(Qwen3_5ForConditionalGeneration):
             return spec
 
         lang = []
-        if comp_ctx_lengths_prefill is not None:
-            for comp_ctx in comp_ctx_lengths_prefill:
+        if comp_ctx_lengths_prefill is not None or comp_ctx_lengths_decode is not None:
+            for comp_ctx in comp_ctx_lengths_prefill or []:
                 lang.append(_build_lang_spec(prefill_seq_len, comp_ctx_len=comp_ctx))
             for comp_ctx in comp_ctx_lengths_decode or []:
                 lang.append(_build_lang_spec(1, comp_ctx_len=comp_ctx))
@@ -1847,7 +1847,7 @@ class QEffQwen3_5ForConditionalGeneration(Qwen3_5ForConditionalGeneration):
             lang_inputs["batch_index"] = torch.arange(bs).view(bs, 1)
 
         if comp_ctx_lengths is not None:
-            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int8)
+            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int64)
 
         inputs = {}
         if kv_offload:

--- a/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -1268,6 +1268,8 @@ class QEffQwen3_5MoeModel(Qwen3_5MoeModel):
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
         past_key_values: Cache | None = None,
+        comp_ctx_lengths: torch.LongTensor | None = None,
+        batch_index: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         pixel_values: torch.Tensor | None = None,
         pixel_values_videos: torch.FloatTensor | None = None,
@@ -1316,6 +1318,8 @@ class QEffQwen3_5MoeModel(Qwen3_5MoeModel):
             position_ids=position_ids,
             attention_mask=attention_mask,
             past_key_values=past_key_values,
+            comp_ctx_lengths=comp_ctx_lengths,
+            batch_index=batch_index,
             inputs_embeds=inputs_embeds,
             cache_position=cache_position,
             **kwargs,
@@ -1677,6 +1681,8 @@ class QEffQwen3_5MoeForConditionalGeneration(Qwen3_5MoeForConditionalGeneration)
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
         past_key_values: Cache | None = None,
+        comp_ctx_lengths: torch.LongTensor | None = None,
+        batch_index: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
         pixel_values: torch.Tensor | None = None,
@@ -1746,6 +1752,8 @@ class QEffQwen3_5MoeForConditionalGeneration(Qwen3_5MoeForConditionalGeneration)
             position_ids=position_ids,
             attention_mask=attention_mask,
             past_key_values=past_key_values,
+            comp_ctx_lengths=comp_ctx_lengths,
+            batch_index=batch_index,
             inputs_embeds=inputs_embeds,
             cache_position=cache_position,
             mm_token_type_ids=mm_token_type_ids,
@@ -1876,8 +1884,8 @@ class QEffQwen3_5MoeForConditionalGeneration(Qwen3_5MoeForConditionalGeneration)
             return spec
 
         lang = []
-        if comp_ctx_lengths_prefill is not None:
-            for comp_ctx in comp_ctx_lengths_prefill:
+        if comp_ctx_lengths_prefill is not None or comp_ctx_lengths_decode is not None:
+            for comp_ctx in comp_ctx_lengths_prefill or []:
                 lang.append(_build_lang_spec(prefill_seq_len, comp_ctx_len=comp_ctx))
             for comp_ctx in comp_ctx_lengths_decode or []:
                 lang.append(_build_lang_spec(1, comp_ctx_len=comp_ctx))
@@ -2021,7 +2029,7 @@ class QEffQwen3_5MoeForConditionalGeneration(Qwen3_5MoeForConditionalGeneration)
             lang_inputs["batch_index"] = torch.arange(bs).view(bs, 1)
 
         if comp_ctx_lengths is not None:
-            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int8)
+            lang_inputs["comp_ctx_lengths"] = torch.randint(0, 100, (40,), dtype=torch.int64)
 
         inputs = {}
         if kv_offload:

--- a/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/QEfficient/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -1024,10 +1024,10 @@ class QEffQwen3VLForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 }
             )
 
-        if comp_ctx_lengths_prefill is not None:
+        if comp_ctx_lengths_prefill is not None or comp_ctx_lengths_decode is not None:
             lang = []
 
-            for i in range(0, len(comp_ctx_lengths_prefill)):
+            for i in range(0, len(comp_ctx_lengths_prefill or [])):
                 lang_prefill = {
                     "batch_size": 1 if continuous_batching else batch_size,
                     "seq_len": prefill_seq_len,
@@ -1047,7 +1047,7 @@ class QEffQwen3VLForConditionalGeneration(Qwen3VLForConditionalGeneration):
 
                 lang.append(lang_prefill)
 
-            for i in range(0, len(comp_ctx_lengths_decode)):
+            for i in range(0, len(comp_ctx_lengths_decode or [])):
                 lang_decode = {
                     "batch_size": full_batch_size if continuous_batching else batch_size,
                     "seq_len": "1",

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -1171,10 +1171,10 @@ class QEffQwen3VLMoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration)
                 }
             )
 
-        if comp_ctx_lengths_prefill is not None:
+        if comp_ctx_lengths_prefill is not None or comp_ctx_lengths_decode is not None:
             lang = []
 
-            for i in range(0, len(comp_ctx_lengths_prefill)):
+            for i in range(0, len(comp_ctx_lengths_prefill or [])):
                 lang_prefill = {
                     "batch_size": 1 if continuous_batching else batch_size,
                     "seq_len": prefill_seq_len,
@@ -1194,7 +1194,7 @@ class QEffQwen3VLMoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration)
 
                 lang.append(lang_prefill)
 
-            for i in range(0, len(comp_ctx_lengths_decode)):
+            for i in range(0, len(comp_ctx_lengths_decode or [])):
                 lang_decode = {
                     "batch_size": full_batch_size if continuous_batching else batch_size,
                     "seq_len": "1",

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
@@ -40,7 +40,7 @@ processor = AutoProcessor.from_pretrained(model_id)
 
 ENABLE_FP16_CLIP = True
 remove_fp16clip_transform_if_disabled(qeff_model, ENABLE_FP16_CLIP)
-PREFILL_SEQ_LEN = 296
+PREFILL_SEQ_LEN = 256
 CTX_LEN = 4096
 BS = 1
 gemma_vision_dir = Path(__file__).resolve().parent.parent
@@ -57,6 +57,7 @@ if not skip_vision:
         num_devices=1,
         mos=1,
         mxfp6_matmul=True,
+        mxint8_kv_cache=True,
         aic_enable_depth_first=True,
         skip_vision=skip_vision,
         split_model_io=True,
@@ -77,6 +78,8 @@ prefill_qpc_path = qeff_model.compile(
     node_precision_info=True,
     prefill_only=True,
     enable_chunking=True,
+    moe_prefill_packed_chunk_size=256,
+    use_onnx_subfunctions=True,
     skip_vision=True,
 )
 
@@ -93,6 +96,7 @@ decode_qpc_path = qeff_model.compile(
     aic_enable_depth_first=True,
     node_precision_info=True,
     prefill_only=False,
+    use_onnx_subfunctions=True,
     skip_vision=True,
 )
 

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_diss.py
@@ -79,7 +79,7 @@ prefill_qpc_path = qeff_model.compile(
     prefill_only=True,
     enable_chunking=True,
     moe_prefill_packed_chunk_size=256,
-    use_onnx_subfunctions=True,
+    use_onnx_subfunctions=False,
     skip_vision=True,
 )
 
@@ -96,7 +96,7 @@ decode_qpc_path = qeff_model.compile(
     aic_enable_depth_first=True,
     node_precision_info=True,
     prefill_only=False,
-    use_onnx_subfunctions=True,
+    use_onnx_subfunctions=False,
     skip_vision=True,
 )
 

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
@@ -31,7 +31,9 @@ CTX_LEN = 2048
 GENERATION_LEN = 1920
 NUM_LANG_HIDDEN_LAYER = 2
 NUM_VISION_HIDDEN_LAYER = 2
-
+# For CCL activation
+# comp_ctx_lengths_prefill=[2048]
+# comp_ctx_lengths_decode=[4096,65536]
 # NODE_PRECISION_INFO:Optional argument
 # If set to True, the NPI file will be generated automatically.
 # If a file path is provided, that file will be used for compilation.
@@ -53,6 +55,9 @@ compiler_kwargs = {
     "split_model_io": True,
     "BATCH_SIZE": BS,
     "node_precision_info": NODE_PRECISION_INFO,
+    ## For CCL activation
+    # "comp_ctx_lengths_prefill": comp_ctx_lengths_prefill,
+    # "comp_ctx_lengths_decode": comp_ctx_lengths_decode,
 }
 
 
@@ -92,6 +97,10 @@ def main():
         dtype="float32",
         kv_offload=True,
         ignore_mismatched_sizes=True,
+        ## For CCL activation
+        # qaic_config={
+        #     "ccl_enabled": True,
+        # },
     )
     remove_fp16clip_transform_if_disabled(qeff_model, True)
 
@@ -121,6 +130,7 @@ def main():
             skip_vision=SKIP_VISION,
             **compiler_kwargs,
         )
+        # print("compile_kwargs:", compile_kwargs)
         qeff_model.compile(**compile_kwargs)
 
         output = qeff_model.generate(inputs=text_inputs, generation_len=GENERATION_LEN)
@@ -160,6 +170,7 @@ def main():
         skip_model_io=True,
         **compiler_kwargs,
     )
+    # print("compile_kwargs:", compile_kwargs)
 
     qeff_model.compile(**compile_kwargs)
 

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_example.py
@@ -51,7 +51,7 @@ compiler_kwargs = {
     "MXINT8_KV_CACHE": True,
     "AIC_ENABLE_DEPTH_FIRST": True,
     "MOS": 1,
-    "USE_ONNX_SUBFUNCTIONS": True,
+    "USE_ONNX_SUBFUNCTIONS": False,
     "split_model_io": True,
     "BATCH_SIZE": BS,
     "node_precision_info": NODE_PRECISION_INFO,

--- a/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_utils.py
+++ b/examples/image_text_to_text/models/gemma_vision/gemma4/gemma4_utils.py
@@ -66,7 +66,7 @@ def build_messages(system_prompt: str, user_prompt: str, use_image: bool):
 
 
 def build_compile_kwargs(*, effective_prefill_seq_len: int, effective_ctx_len: int, skip_vision: bool, **kwargs):
-    kwargs = {
+    compile_kwargs = {
         "prefill_seq_len": effective_prefill_seq_len,
         "ctx_len": effective_ctx_len,
         "num_cores": kwargs["NUM_CORES"],
@@ -80,13 +80,15 @@ def build_compile_kwargs(*, effective_prefill_seq_len: int, effective_ctx_len: i
         "batch_size": kwargs.get("BATCH_SIZE", 1),
         "node_precision_info": kwargs.get("node_precision_info", None),
     }
+    # Carry the Compute-Context-Length lists through to compile() when provided.
+    for key in ("comp_ctx_lengths_prefill", "comp_ctx_lengths_decode"):
+        if kwargs.get(key) is not None:
+            compile_kwargs[key] = kwargs[key]
     if skip_vision:
-        kwargs["skip_vision"] = True
-    if kwargs["node_precision_info"] is None:
-        kwargs["node_precision_info"] = False
-    return kwargs
-
-    return kwargs
+        compile_kwargs["skip_vision"] = True
+    if compile_kwargs["node_precision_info"] is None:
+        compile_kwargs["node_precision_info"] = False
+    return compile_kwargs
 
 
 def remove_fp16clip_transform_if_disabled(model, effective_fp16clip: bool):

--- a/examples/image_text_to_text/models/qwen3_5/qwen3_5.py
+++ b/examples/image_text_to_text/models/qwen3_5/qwen3_5.py
@@ -22,7 +22,14 @@ config = AutoConfig.from_pretrained(model_id)
 config.torch_dtype = "float32"
 
 qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
-    model_id, attn_implementation="eager", kv_offload=True, config=config
+    model_id,
+    attn_implementation="eager",
+    kv_offload=True,
+    config=config,
+    # # For CCL activation
+    # qaic_config={
+    #     "ccl_enabled": True,
+    # },
 )
 
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
@@ -41,6 +48,11 @@ BS = 1
 PREFILL_SEQ_LEN = 64
 CTX_LEN = 4096
 
+# Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
+# ccl_enabled=True, they are auto-generated from CTX_LEN.
+# comp_ctx_lengths_prefill = [2048]
+# comp_ctx_lengths_decode = [4096, 65536]
+
 if skip_vision:
     ## Only Text ##
 
@@ -49,7 +61,7 @@ if skip_vision:
         prefill_seq_len=PREFILL_SEQ_LEN,
         ctx_len=CTX_LEN,
         num_cores=16,
-        num_devices=1,
+        num_devices=4,
         mxfp6_matmul=True,
         mxint8_kv_cache=True,
         aic_enable_depth_first=False,
@@ -57,6 +69,8 @@ if skip_vision:
         mos=1,
         split_model_io=True,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
         # qaic_config=qaic_config,  # Enable KV blocking - comment out to disable
     )
 
@@ -128,6 +142,8 @@ else:
         mos=1,
         split_model_io=True,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
         # qaic_config=qaic_config,  # Enable KV blocking - comment out to disable
     )
 

--- a/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe.py
+++ b/examples/image_text_to_text/models/qwen3_5_moe/qwen3_5_moe.py
@@ -13,7 +13,7 @@ from transformers import AutoConfig, AutoProcessor, TextStreamer
 
 from QEfficient import QEFFAutoModelForImageTextToText
 
-model_id = "Qwen/Qwen3.6-35B-A3B"
+model_id = "Qwen/Qwen3.5-35B-A3B"
 config = AutoConfig.from_pretrained(model_id)
 
 # For faster execution user can run with lesser layers, For Testing Purpose Only
@@ -22,7 +22,14 @@ config.text_config.num_hidden_layers = 4
 config.torch_dtype = "float32"
 
 qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
-    model_id, attn_implementation="eager", kv_offload=True, config=config
+    model_id,
+    attn_implementation="eager",
+    kv_offload=True,
+    config=config,
+    # # For CCL activation
+    # qaic_config={
+    #     "ccl_enabled": True,
+    # },
 )
 
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
@@ -41,6 +48,11 @@ BS = 1
 PREFILL_SEQ_LEN = 64
 CTX_LEN = 4096
 
+# Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
+# ccl_enabled=True, they are auto-generated from CTX_LEN.
+# comp_ctx_lengths_prefill = [2048]
+# comp_ctx_lengths_decode = [4096,65536]
+
 if skip_vision:
     ## Only Text ##
 
@@ -58,6 +70,8 @@ if skip_vision:
         skip_vision=True,
         mos=1,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
         # qaic_config=qaic_config,  # Enable KV blocking - comment out to disable
     )
 
@@ -130,6 +144,8 @@ else:
         mxint8_kv_cache=False,
         aic_enable_depth_first=True,
         mos=1,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
         # qaic_config=qaic_config,  # Enable KV blocking - comment out to disable
     )
 

--- a/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -22,13 +22,25 @@ config = AutoConfig.from_pretrained(model_id)
 # config.vision_config.deepstack_visual_indexes = [8]
 
 qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
-    model_id, attn_implementation="eager", kv_offload=True, config=config
+    model_id,
+    attn_implementation="eager",
+    kv_offload=True,
+    config=config,
+    # For CCL activation
+    # qaic_config={
+    #     "ccl_enabled": True,
+    # },
 )
 
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
 processor = AutoProcessor.from_pretrained(model_id)
 ### use skip_vision=Ture, if want to run only text, or false ###
 skip_vision = False
+
+# Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
+# ccl_enabled=True, they are auto-generated from ctx_len.
+# comp_ctx_lengths_prefill = [2048]
+# comp_ctx_lengths_decode = [4096,65536]
 
 if skip_vision:
     ## Only Text ##
@@ -47,6 +59,8 @@ if skip_vision:
         skip_vision=True,
         mos=1,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
 
     messages = [
@@ -91,6 +105,8 @@ else:
         aic_enable_depth_first=True,
         mos=1,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
 
     ### IMAGE + TEXT ###

--- a/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
+++ b/examples/image_text_to_text/models/qwen3vl/qwen3_vl.py
@@ -21,12 +21,24 @@ config = AutoConfig.from_pretrained(model_id)
 # config.vision_config.deepstack_visual_indexes = [8]
 
 qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
-    model_id, attn_implementation="eager", kv_offload=True, config=config
+    model_id,
+    attn_implementation="eager",
+    kv_offload=True,
+    config=config,
+    # # For CCL activation
+    # qaic_config={
+    #     "ccl_enabled": True,
+    # },
 )
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
 processor = AutoProcessor.from_pretrained(model_id)
 ### use skip_vision=Ture, if want to run only text, else false ###
-skip_vision = False
+skip_vision = True
+
+# Compute-Context-Length (CCL) lists for prefill and decode. When both are None and
+# ccl_enabled=True, they are auto-generated from ctx_len.
+# comp_ctx_lengths_prefill = [2048]
+# comp_ctx_lengths_decode = [65536]
 
 if skip_vision:
     ## Only Text ##
@@ -46,6 +58,8 @@ if skip_vision:
         skip_vision=True,
         mos=1,
         use_onnx_subfunctions=True,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
 
     messages = [
@@ -90,6 +104,8 @@ else:
         aic_enable_depth_first=True,
         mos=1,
         use_onnx_subfunctions=False,
+        # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
+        # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
 
     ### IMAGE + TEXT ###


### PR DESCRIPTION
Optimized the moe MLP block by processing only the top-K selected experts for each token. The implementation gathers expert-specific projection weights (gate, up, and down), performs batched matrix multiplications across all (token, expert) pairs, applies the gated activation (act_fn(gate) * up), and combines expert outputs using router-provided top-K weights.

NSP-parallel expert-blocked dispatch to the chunked prefill MoE path, replacing the sequential per-expert loop with a batched packed-prefix approach.