### PR TITLE
feat(cohere_asr): add CohereLabs/cohere-transcribe-03-2026 ASR support

### DIFF
--- a/QEfficient/transformers/models/cohere_asr/__init__.py
+++ b/QEfficient/transformers/models/cohere_asr/__init__.py
@@ -1,0 +1,6 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------

--- a/QEfficient/transformers/models/cohere_asr/modeling_cohere_asr.py
+++ b/QEfficient/transformers/models/cohere_asr/modeling_cohere_asr.py
@@ -137,6 +137,7 @@ class QEffCohereAsrSelfAttention(CohereAsrSelfAttention):
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
         position_ids: torch.LongTensor | None = None,
+        batch_index: torch.LongTensor | None = None,
         past_key_values: Cache | None = None,
         **kwargs,
     ):
@@ -153,7 +154,7 @@ class QEffCohereAsrSelfAttention(CohereAsrSelfAttention):
 
         if past_key_values is not None:
             self_attention_cache = past_key_values.self_attention_cache
-            cache_kwargs = {"position_ids": position_ids}
+            cache_kwargs = {"position_ids": position_ids, "batch_index": batch_index}
             key_states, value_states = self_attention_cache.update(
                 key_states, value_states, self.layer_idx, cache_kwargs
             )
@@ -192,6 +193,7 @@ class QEffCohereAsrCrossAttention(CohereAsrCrossAttention):
         attention_mask: torch.Tensor | None = None,
         past_key_values: Cache | None = None,
         input_features: torch.Tensor | None = None,
+        batch_index: torch.LongTensor | None = None,
         **kwargs,
     ):
         bsz, tgt_len = hidden_states.shape[:-1]
@@ -214,24 +216,39 @@ class QEffCohereAsrCrossAttention(CohereAsrCrossAttention):
             key_states_computed = self.k_proj(encoder_hidden_states).view(*kv_input_shape).transpose(1, 2)
             value_states_computed = self.v_proj(encoder_hidden_states).view(*kv_input_shape).transpose(1, 2)
 
-            # Write newly computed K/V into the cache buffer via index_put.
-            # This produces a ScatterND ONNX node that reads from past_key_cross.{i},
-            # keeping it live in both the Encoder and Decode specialization subgraphs.
-            # Without this, past_key_cross.{i} is only used by the Where True-branch
-            # (Decode spec) and gets DCE'd in the Encoder spec, causing qaic-compile to
-            # reject the graph with "retained state input not found: past_key_cross.{i}".
-            # Matches Whisper's torch.index_put pattern exactly (see modeling_whisper.py).
-            indices = (torch.arange(bsz),)
-            key_states_new = torch.index_put(key_states_old, indices, key_states_computed)
-            value_states_new = torch.index_put(value_states_old, indices, value_states_computed)
+            if batch_index is None:
+                indices = (torch.arange(bsz),)
+                key_cache_updated = torch.index_put(key_states_old, indices, key_states_computed)
+                value_cache_updated = torch.index_put(value_states_old, indices, value_states_computed)
+                key_states_cached, value_states_cached = key_states_old, value_states_old
+                key_states_updated, value_states_updated = key_cache_updated, value_cache_updated
+            else:
+                cross_position_ids = torch.arange(
+                    key_states_computed.shape[2], dtype=torch.int64, device=key_states_computed.device
+                ).view(1, -1)
+                cross_position_ids = cross_position_ids.repeat(bsz, 1)
+                cache_kwargs = {"position_ids": cross_position_ids, "batch_index": batch_index}
+
+                # Read and update only the request-owned rows. QEffDynamicCache emits the
+                # compiler-recognized continuous-batching gather/scatter operators while
+                # retaining the complete full-batch cache as the QPC state buffer.
+                key_states_cached, value_states_cached = past_key_values.read_only(self.layer_idx, cache_kwargs)
+                key_states_updated, value_states_updated = past_key_values.update(
+                    key_states_computed, value_states_computed, self.layer_idx, cache_kwargs
+                )
+                key_cache_updated = past_key_values[self.layer_idx][0]
+                value_cache_updated = past_key_values[self.layer_idx][1]
 
             # Select cache (Decode) or freshly written (Encode) based on the dummy
             # input_features shape used by compiler specializations.
-            key_states = torch.where(input_features.shape[2] == torch.tensor(1), key_states_old, key_states_new)
-            value_states = torch.where(input_features.shape[2] == torch.tensor(1), value_states_old, value_states_new)
+            is_decode = input_features.shape[2] == torch.tensor(1)
+            key_states = torch.where(is_decode, key_states_cached, key_states_updated)
+            value_states = torch.where(is_decode, value_states_cached, value_states_updated)
 
-            past_key_values.layers[self.layer_idx].keys = key_states
-            past_key_values.layers[self.layer_idx].values = value_states
+            past_key_values.layers[self.layer_idx].keys = torch.where(is_decode, key_states_old, key_cache_updated)
+            past_key_values.layers[self.layer_idx].values = torch.where(
+                is_decode, value_states_old, value_cache_updated
+            )
         else:
             key_states = self.k_proj(encoder_hidden_states).view(*kv_input_shape).transpose(1, 2)
             value_states = self.v_proj(encoder_hidden_states).view(*kv_input_shape).transpose(1, 2)
@@ -266,6 +283,7 @@ class QEffCohereAsrDecoderLayer(CohereAsrDecoderLayer):
         position_ids: torch.LongTensor | None = None,
         past_key_values: Cache | None = None,
         input_features: torch.Tensor | None = None,
+        batch_index: torch.LongTensor | None = None,
         **kwargs,
     ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
         residual = hidden_states
@@ -275,6 +293,7 @@ class QEffCohereAsrDecoderLayer(CohereAsrDecoderLayer):
             hidden_states=hidden_states,
             attention_mask=attention_mask,
             position_ids=position_ids,
+            batch_index=batch_index,
             past_key_values=past_key_values,
             **kwargs,
         )
@@ -294,6 +313,7 @@ class QEffCohereAsrDecoderLayer(CohereAsrDecoderLayer):
                 attention_mask=encoder_attention_mask,
                 past_key_values=cross_attn_past_key_value,
                 input_features=input_features,
+                batch_index=batch_index,
             )
             hidden_states = residual + hidden_states
 
@@ -327,6 +347,7 @@ class QEffCohereAsrDecoder(CohereAsrDecoder):
         encoder_hidden_states: torch.FloatTensor | None = None,
         encoder_attention_mask: torch.Tensor | None = None,
         input_features: torch.Tensor | None = None,
+        batch_index: torch.LongTensor | None = None,
         **kwargs,
     ) -> BaseModelOutputWithPastAndCrossAttentions:
         encoder_hidden_states = self.proj(encoder_hidden_states)
@@ -366,6 +387,7 @@ class QEffCohereAsrDecoder(CohereAsrDecoder):
                 position_ids=position_ids,
                 past_key_values=past_key_values,
                 input_features=input_features,
+                batch_index=batch_index,
                 **kwargs,
             )
 
@@ -423,6 +445,7 @@ class QEffCohereAsrForConditionalGeneration(CohereAsrForConditionalGeneration):
         encoder_outputs: tuple[tuple[torch.FloatTensor]] | None = None,
         past_key_values: EncoderDecoderCache | tuple[torch.FloatTensor] | None = None,
         position_ids: torch.LongTensor | None = None,
+        batch_index: torch.LongTensor | None = None,
         feature_lengths: torch.LongTensor | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
@@ -498,6 +521,7 @@ class QEffCohereAsrForConditionalGeneration(CohereAsrForConditionalGeneration):
             past_key_values=past_key_values,
             use_cache=use_cache,
             input_features=input_features,
+            batch_index=batch_index,
         )
         logits = self.proj_out(decoder_outputs.last_hidden_state)
 
@@ -512,7 +536,9 @@ class QEffCohereAsrForConditionalGeneration(CohereAsrForConditionalGeneration):
         )
 
     def get_dummy_inputs(self, **kwargs):
-        bs = 1
+        bs = int(kwargs.get("batch_size", 1))
+        full_batch_size = int(kwargs.get("full_batch_size") or bs)
+        continuous_batching = bool(kwargs.get("continuous_batching", False) or full_batch_size != bs)
         seq_len = int(kwargs.get("prefill_seq_len", ONNX_EXPORT_EXAMPLE_SEQ_LEN))
         # encoder_ctx_len is the encoder OUTPUT sequence length (after subsampling).
         # encoder_config.max_position_embeddings is the INPUT length (max audio frames).
@@ -543,9 +569,12 @@ class QEffCohereAsrForConditionalGeneration(CohereAsrForConditionalGeneration):
             "position_ids": torch.arange(seq_len, dtype=torch.int64).view(1, seq_len).repeat(bs, 1),
             "past_key_values": [[] for _ in range(num_layers)],
         }
+        if continuous_batching:
+            inputs["batch_index"] = torch.arange(bs, dtype=torch.int64).view(bs, 1)
 
-        kv_cache_shape = (bs, num_key_value_heads, seq_len, head_dim)
-        kv_cross_cache_shape = (bs, num_key_value_heads, encoder_ctx_len, head_dim)
+        cache_batch_size = full_batch_size if continuous_batching else bs
+        kv_cache_shape = (cache_batch_size, num_key_value_heads, seq_len, head_dim)
+        kv_cross_cache_shape = (cache_batch_size, num_key_value_heads, encoder_ctx_len, head_dim)
 
         for i in range(num_layers):
             for self_cross in ["self", "cross"]:
@@ -558,7 +587,9 @@ class QEffCohereAsrForConditionalGeneration(CohereAsrForConditionalGeneration):
 
         return inputs
 
-    def get_specializations(self, batch_size: int, encoder_ctx_len, ctx_len, **compiler_options):
+    def get_specializations(
+        self, batch_size: int, encoder_ctx_len, ctx_len, full_batch_size: int | None = None, **compiler_options
+    ):
         subsampling_factor = self.config.encoder_config.subsampling_factor
         if encoder_ctx_len is None:
             # encoder_ctx_len = encoder OUTPUT length (after subsampling).
@@ -585,11 +616,16 @@ class QEffCohereAsrForConditionalGeneration(CohereAsrForConditionalGeneration):
             "feature_len": 1,  # dummy feature so torch.where knows whether to run cross attention or not
         }
 
+        if full_batch_size is not None:
+            encoder_specializations["full_batch_size"] = full_batch_size
+            decoder_specializations["full_batch_size"] = full_batch_size
+            decoder_specializations["batch_size"] = full_batch_size
+
         specializations = [encoder_specializations, decoder_specializations]
 
         return specializations, compiler_options
 
-    def get_onnx_dynamic_axes(self):
+    def get_onnx_dynamic_axes(self, continuous_batching: bool = False):
         num_layers = self.config.num_hidden_layers
 
         dynamic_axes = {
@@ -598,12 +634,14 @@ class QEffCohereAsrForConditionalGeneration(CohereAsrForConditionalGeneration):
             "input_ids": {0: "batch_size", 1: "seq_len"},
             "position_ids": {0: "batch_size", 1: "seq_len"},
         }
+        if continuous_batching:
+            dynamic_axes["batch_index"] = {0: "batch_size"}
         pkv_self_dynamic_axes = {
-            0: "batch_size",
+            0: "full_batch_size" if continuous_batching else "batch_size",
             2: "decoder_ctx_len",
         }
         pkv_cross_dynamic_axes = {
-            0: "batch_size",
+            0: "full_batch_size" if continuous_batching else "batch_size",
             2: "encoder_ctx_len",
         }
         for i in range(num_layers):

--- a/QEfficient/transformers/models/cohere_asr/modeling_cohere_asr.py
+++ b/QEfficient/transformers/models/cohere_asr/modeling_cohere_asr.py
@@ -1,0 +1,630 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+"""
+QEff CohereAsr wrapper.
+
+CohereAsr is a Whisper-style encoder-decoder ASR model: a `ParakeetEncoder`
+(fast-conformer, bidirectional, no KV cache) feeding a causal, KV-cached text
+decoder that cross-attends to the fixed encoder output.
+
+The only differences from the upstream `CohereAsrDecoder`/`CohereAsrCrossAttention`
+are:
+- `create_causal_mask`/`create_bidirectional_mask` (from `transformers.masking_utils`)
+  crash during ONNX export tracing (`IndexError: tuple index out of range` in
+  `sdpa_mask`, since both dispatch through it). Replaced with QEfficient's
+  ONNX-safe `_create_causal_mask` and `_prepare_4d_attention_mask`.
+- self-attention cache update passes `position_ids` via `cache_kwargs`, as
+  required by `QEffDynamicLayer.update()`.
+- cross-attention KV reuse is rewritten branch-free with `torch.where`/
+  `torch.index_put`, gated on `input_features.shape[2] == 1` (the same
+  dummy-shape trick Whisper uses to select the "Decode" specialization),
+  instead of the Python-bool `past_key_values.is_updated` dict lookup that
+  cannot be traced into a single ONNX graph shared by both specializations.
+- masking uses QEfficient's `torch.where`-based fp16-safe convention instead
+  of HF's additive `attn_weights + attention_mask`.
+- `feature_lengths` is a per-batch int64 QPC input derived from the processor's
+  attention mask. The processor excludes its final convolution-boundary feature
+  frame, so the forward pass uses a clamped `feature_lengths + 1` encoder mask,
+  then derives the decoder cross-attention mask with Parakeet's repeated
+  convolution output-length calculation.
+"""
+
+import torch
+from torch import nn
+from transformers.cache_utils import Cache, EncoderDecoderCache
+from transformers.modeling_attn_mask_utils import _prepare_4d_attention_mask
+from transformers.modeling_outputs import BaseModelOutputWithPastAndCrossAttentions, Seq2SeqLMOutput
+from transformers.models.cohere_asr.modeling_cohere_asr import (
+    CohereAsrCrossAttention,
+    CohereAsrDecoder,
+    CohereAsrDecoderLayer,
+    CohereAsrForConditionalGeneration,
+    CohereAsrSelfAttention,
+    repeat_kv,
+)
+from transformers.models.parakeet.modeling_parakeet import ParakeetEncoderAttention, ParakeetEncoderSubsamplingConv2D
+
+from QEfficient.transformers.cache_utils import QEffEncoderDecoderCache
+from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
+from QEfficient.utils._utils import IOInfo
+from QEfficient.utils.constants import MIN_MASKED_ATTENTION_VALUE, ONNX_EXPORT_EXAMPLE_SEQ_LEN
+
+
+def eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    scaling: float,
+    dropout: float = 0.0,
+    **kwargs,
+):
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if attention_mask is not None:
+        # Support both bool masks (causal, from _create_causal_mask) and float additive
+        # masks (cross-attention, from _prepare_4d_attention_mask which uses 0.0 = attend,
+        # large-negative = mask). Convert float masks via < -1.0 threshold to bool.
+        bool_mask = attention_mask if attention_mask.dtype == torch.bool else attention_mask < -1.0
+        attn_weights = torch.where(
+            bool_mask, torch.tensor(MIN_MASKED_ATTENTION_VALUE, dtype=torch.float32), attn_weights
+        )
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+
+    return attn_output, attn_weights
+
+
+class QEffParakeetEncoderAttention(ParakeetEncoderAttention):
+    """Prevents fully masked encoder query rows from propagating NaNs through convolution."""
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: torch.Tensor | None,
+        attention_mask: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        attn_output, attn_weights = super().forward(
+            hidden_states,
+            position_embeddings,
+            attention_mask=attention_mask,
+            **kwargs,
+        )
+        if attention_mask is not None:
+            valid_query_rows = attention_mask.any(dim=-1).transpose(1, 2)
+            attn_output = torch.where(valid_query_rows, attn_output, torch.zeros_like(attn_output))
+        return attn_output, attn_weights
+
+
+class QEffParakeetEncoderSubsamplingConv2D(ParakeetEncoderSubsamplingConv2D):
+    """Keeps the final subsampling projection bias out of masked encoder rows."""
+
+    def forward(self, input_features: torch.Tensor, attention_mask: torch.Tensor | None = None):
+        hidden_states = super().forward(input_features, attention_mask=attention_mask)
+        if attention_mask is None:
+            return hidden_states
+
+        output_lengths = attention_mask.sum(-1)
+        for layer in self.layers:
+            if isinstance(layer, nn.Conv2d) and layer.stride != (1, 1):
+                output_lengths = self._get_output_length(output_lengths, layer)
+        positions = torch.arange(hidden_states.shape[1], device=hidden_states.device)
+        output_mask = positions.unsqueeze(0) < output_lengths.unsqueeze(1)
+        return torch.where(output_mask.unsqueeze(-1), hidden_states, torch.zeros_like(hidden_states))
+
+
+class QEffCohereAsrSelfAttention(CohereAsrSelfAttention):
+    """
+    Copied from CohereAsrSelfAttention: https://github.com/huggingface/transformers/blob/main/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+    The only differences are:
+    - pass `position_ids` via `cache_kwargs` to `past_key_values.update`, as required by `QEffDynamicLayer`
+    - use QEfficient's `eager_attention_forward` (torch.where-based fp16-safe masking)
+    """
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        **kwargs,
+    ):
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(hidden_shape).transpose(1, 2)
+        key_states = key_states.view(hidden_shape).transpose(1, 2)
+        value_states = value_states.view(hidden_shape).transpose(1, 2)
+
+        if past_key_values is not None:
+            self_attention_cache = past_key_values.self_attention_cache
+            cache_kwargs = {"position_ids": position_ids}
+            key_states, value_states = self_attention_cache.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
+        attn_output, attn_weights = eager_attention_forward(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+class QEffCohereAsrCrossAttention(CohereAsrCrossAttention):
+    """
+    Copied from CohereAsrCrossAttention: https://github.com/huggingface/transformers/blob/main/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+    The only differences are:
+    - the encoder K/V cache-or-recompute decision is rewritten branch-free with
+      torch.where/torch.index_put (gated on `input_features.shape[2] == 1`) instead
+      of the Python-bool `past_key_values.is_updated` dict lookup, so both the
+      "Encoder" and "Decode" compile specializations trace to the same ONNX graph
+    - use QEfficient's `eager_attention_forward` (torch.where-based fp16-safe masking)
+    """
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        past_key_values: Cache | None = None,
+        input_features: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        bsz, tgt_len = hidden_states.shape[:-1]
+
+        q_input_shape = (bsz, tgt_len, -1, self.head_dim)
+        # Use -1 for src_len so the view is dynamic at trace time — Whisper's pattern.
+        # A fixed src_len here would produce a Reshape with a concrete output shape that
+        # conflicts with the cross-cache shape (encoder_ctx_len) during qaic-compile.
+        kv_input_shape = (bsz, -1, self.config.num_key_value_heads, self.head_dim)
+
+        query_states = self.q_proj(hidden_states).view(*q_input_shape).transpose(1, 2)
+
+        if past_key_values is not None:
+            # past_key_values here is already the cross_attention_cache (QEffDynamicCache),
+            # split off at the decoder-layer level — same pattern as Whisper.
+            # __getitem__ returns (keys_tensor, values_tensor) with traceable tensor identity.
+            key_states_old = past_key_values[self.layer_idx][0]
+            value_states_old = past_key_values[self.layer_idx][1]
+
+            key_states_computed = self.k_proj(encoder_hidden_states).view(*kv_input_shape).transpose(1, 2)
+            value_states_computed = self.v_proj(encoder_hidden_states).view(*kv_input_shape).transpose(1, 2)
+
+            # Write newly computed K/V into the cache buffer via index_put.
+            # This produces a ScatterND ONNX node that reads from past_key_cross.{i},
+            # keeping it live in both the Encoder and Decode specialization subgraphs.
+            # Without this, past_key_cross.{i} is only used by the Where True-branch
+            # (Decode spec) and gets DCE'd in the Encoder spec, causing qaic-compile to
+            # reject the graph with "retained state input not found: past_key_cross.{i}".
+            # Matches Whisper's torch.index_put pattern exactly (see modeling_whisper.py).
+            indices = (torch.arange(bsz),)
+            key_states_new = torch.index_put(key_states_old, indices, key_states_computed)
+            value_states_new = torch.index_put(value_states_old, indices, value_states_computed)
+
+            # Select cache (Decode) or freshly written (Encode) based on the dummy
+            # input_features shape used by compiler specializations.
+            key_states = torch.where(input_features.shape[2] == torch.tensor(1), key_states_old, key_states_new)
+            value_states = torch.where(input_features.shape[2] == torch.tensor(1), value_states_old, value_states_new)
+
+            past_key_values.layers[self.layer_idx].keys = key_states
+            past_key_values.layers[self.layer_idx].values = value_states
+        else:
+            key_states = self.k_proj(encoder_hidden_states).view(*kv_input_shape).transpose(1, 2)
+            value_states = self.v_proj(encoder_hidden_states).view(*kv_input_shape).transpose(1, 2)
+
+        attn_output, attn_weights = eager_attention_forward(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            **kwargs,
+        )
+        attn_output = attn_output.reshape(bsz, tgt_len, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+class QEffCohereAsrDecoderLayer(CohereAsrDecoderLayer):
+    """
+    Copied from CohereAsrDecoderLayer: https://github.com/huggingface/transformers/blob/main/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+    The only difference is threading `input_features` through to the cross-attention block.
+    """
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        encoder_hidden_states: torch.Tensor | None = None,
+        encoder_attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        input_features: torch.Tensor | None = None,
+        **kwargs,
+    ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        if encoder_hidden_states is not None:
+            residual = hidden_states
+            hidden_states = self.post_attention_layernorm(hidden_states)
+            # Split the cross-attention sub-cache out of the combined encoder-decoder cache
+            # before passing to encoder_attn — mirrors Whisper's decoder-layer pattern so
+            # QEffCohereAsrCrossAttention receives a QEffDynamicCache whose __getitem__
+            # indexes directly to the named past_key_cross.{i} retained-state tensors.
+            cross_attn_past_key_value = past_key_values.cross_attention_cache if past_key_values is not None else None
+            hidden_states, _ = self.encoder_attn(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                attention_mask=encoder_attention_mask,
+                past_key_values=cross_attn_past_key_value,
+                input_features=input_features,
+            )
+            hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.final_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class QEffCohereAsrDecoder(CohereAsrDecoder):
+    """
+    Copied from CohereAsrDecoder: https://github.com/huggingface/transformers/blob/main/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+    The only differences are:
+    - `create_causal_mask` -> QEfficient's ONNX-traceable `_create_causal_mask`
+    - `create_bidirectional_mask` -> `_prepare_4d_attention_mask`, both of which use
+      only standard tensor ops, unlike `create_causal_mask`/`create_bidirectional_mask`
+      which dispatch through `sdpa_mask` and crash with
+      `IndexError: tuple index out of range` while tracing to ONNX
+    - threads `input_features` through to the decoder layers for cross-attention KV reuse
+    """
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        encoder_hidden_states: torch.FloatTensor | None = None,
+        encoder_attention_mask: torch.Tensor | None = None,
+        input_features: torch.Tensor | None = None,
+        **kwargs,
+    ) -> BaseModelOutputWithPastAndCrossAttentions:
+        encoder_hidden_states = self.proj(encoder_hidden_states)
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        return_legacy_cache = False
+        if (use_cache or past_key_values is not None) and not isinstance(past_key_values, Cache):
+            return_legacy_cache = True
+            past_key_values = QEffEncoderDecoderCache.from_legacy_cache(past_key_values)
+
+        past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+        if position_ids is None:
+            position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            position_ids = position_ids.unsqueeze(0)
+
+        pos_emb = self.pos_emb(position_ids.squeeze(0))
+        inputs_embeds = self.embedding_layernorm(inputs_embeds + pos_emb)
+
+        causal_mask = _create_causal_mask(position_ids=position_ids, target_length=past_seen_tokens)
+        encoder_attention_mask = (
+            _prepare_4d_attention_mask(encoder_attention_mask, inputs_embeds.dtype, tgt_len=inputs_embeds.shape[1])
+            if encoder_attention_mask is not None
+            else None
+        )
+
+        hidden_states = inputs_embeds
+        for decoder_layer in self.layers:
+            hidden_states = decoder_layer(
+                hidden_states,
+                attention_mask=causal_mask,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=encoder_attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                input_features=input_features,
+                **kwargs,
+            )
+
+        hidden_states = self.norm(hidden_states)
+
+        next_cache = past_key_values if (use_cache or past_key_values is not None) else None
+        if return_legacy_cache:
+            next_cache = next_cache.to_legacy_cache()
+
+        return BaseModelOutputWithPastAndCrossAttentions(
+            last_hidden_state=hidden_states,
+            past_key_values=next_cache,
+        )
+
+
+class QEffCohereAsrForConditionalGeneration(CohereAsrForConditionalGeneration):
+    """
+    Copied from CohereAsrForConditionalGeneration: https://github.com/huggingface/transformers/blob/main/src/transformers/models/cohere_asr/modeling_cohere_asr.py
+    The only differences are:
+    - added get_dummy_inputs, get_onnx_dynamic_axes, get_output_names, get_specializations,
+      get_inputs_info, get_submodules_for_export for AutoModel export
+    - changed forward inputs decoder_input_ids/decoder_position_ids to input_ids/position_ids
+    - transposes `input_features` from Parakeet's native `(batch, seq_len, num_mel_bins)`
+      to the mel-bins-major `(batch, num_mel_bins, feature_len)` contract that
+      `QEFFAutoModelForSpeechSeq2Seq` (Whisper-derived) hard-codes at the runtime boundary
+    - sets `config.num_mel_bins` (absent on `CohereAsrConfig`) from `config.encoder_config`,
+      since `QEFFAutoModelForSpeechSeq2Seq.generate()` reads `self.model.config.num_mel_bins`
+    - adds `feature_lengths` (int64 per batch item) as a new model input derived from
+      the processor attention mask. It rebuilds Parakeet's frame mask before encoding and
+      its output-length mask before decoder cross-attention.
+    """
+
+    def __qeff_init__(self):
+        self.config.num_mel_bins = self.config.encoder_config.num_mel_bins
+
+    def get_submodules_for_export(self) -> type[nn.Module]:
+        return {self.model.encoder.layers[0].__class__, QEffCohereAsrDecoderLayer}
+
+    def _get_encoder_output_lengths(self, feature_lengths: torch.LongTensor) -> torch.LongTensor:
+        output_lengths = feature_lengths
+        for layer in self.model.encoder.subsampling.layers:
+            if isinstance(layer, nn.Conv2d) and layer.stride != (1, 1):
+                padding = layer.padding[0]
+                kernel_size = layer.kernel_size[0]
+                stride = layer.stride[0]
+                output_lengths = (output_lengths + 2 * padding - kernel_size) // stride + 1
+        return output_lengths
+
+    def forward(
+        self,
+        input_features: torch.FloatTensor | None = None,
+        attention_mask: torch.LongTensor | None = None,
+        input_ids: torch.LongTensor | None = None,
+        decoder_attention_mask: torch.LongTensor | None = None,
+        encoder_outputs: tuple[tuple[torch.FloatTensor]] | None = None,
+        past_key_values: EncoderDecoderCache | tuple[torch.FloatTensor] | None = None,
+        position_ids: torch.LongTensor | None = None,
+        feature_lengths: torch.LongTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        return_dict: bool | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor] | Seq2SeqLMOutput:
+        # Parakeet's native input_features is (batch, seq_len, num_mel_bins); the runtime
+        # boundary (QEFFAutoModelForSpeechSeq2Seq) presents mel-bins-major
+        # (batch, num_mel_bins, feature_len), matching Whisper's Conv1d convention.
+        encoder_input_features = input_features.transpose(1, 2) if input_features is not None else None
+        encoder_output_feature_lengths = feature_lengths + 1 if feature_lengths is not None else None
+
+        if feature_lengths is not None:
+            encoder_input_feature_lengths = torch.minimum(
+                encoder_output_feature_lengths,
+                torch.full_like(feature_lengths, input_features.shape[2]),
+            )
+            positions = torch.arange(input_features.shape[2], device=input_features.device)
+            attention_mask = positions.unsqueeze(0) < encoder_input_feature_lengths.unsqueeze(1)
+
+        if encoder_outputs is None:
+            encoder_outputs = self.model.encoder(encoder_input_features, attention_mask=attention_mask)
+
+        encoder_hidden_states = encoder_outputs.last_hidden_state
+        if encoder_output_feature_lengths is not None:
+            positions = torch.arange(encoder_hidden_states.shape[1], device=encoder_hidden_states.device)
+            encoder_output_lengths = self._get_encoder_output_lengths(encoder_output_feature_lengths)
+            valid_encoder_output_mask = positions.unsqueeze(0) < encoder_output_lengths.unsqueeze(1)
+            encoder_hidden_states = torch.where(
+                valid_encoder_output_mask.unsqueeze(-1), encoder_hidden_states, torch.zeros_like(encoder_hidden_states)
+            )
+
+        # Pad encoder output to the cross-KV cache length so QAIC ScatterND shape checks
+        # pass in every compile specialization.
+        #
+        # CohereAsr's Fast Conformer emits ceil(feature_len / subsampling_factor) frames, so
+        # the Decode spec (feature_len=1 → 1 frame) produces a cross-KV tensor shorter than
+        # the cache, causing qaic-compile to reject Reshape_3's shape in the ScatterND write path.
+        # encoder_ctx_len is read from the cross-KV cache shape when available so it matches
+        # the specialization used at compile time (438 for 35s, 312 for 25s, 625 for 50s).
+        # Fallback to config only when past_key_values is absent (non-QEff inference path).
+        if (
+            past_key_values is not None
+            and isinstance(past_key_values, (list, tuple))
+            and len(past_key_values) > 0
+            and isinstance(past_key_values[0], (list, tuple))
+            and len(past_key_values[0]) >= 3
+        ):
+            encoder_ctx_len = past_key_values[0][2].shape[2]
+        else:
+            encoder_ctx_len = (
+                self.config.encoder_config.max_position_embeddings // self.config.encoder_config.subsampling_factor
+            )
+        pad_size = encoder_ctx_len - encoder_hidden_states.shape[1]
+        padding = encoder_hidden_states.new_zeros(
+            encoder_hidden_states.shape[0], pad_size, encoder_hidden_states.shape[2]
+        )
+        encoder_hidden_states = torch.cat([encoder_hidden_states, padding], dim=1)
+
+        if encoder_output_feature_lengths is not None:
+            positions = torch.arange(encoder_ctx_len, device=encoder_hidden_states.device)
+            encoder_output_lengths = self._get_encoder_output_lengths(encoder_output_feature_lengths)
+            enc_mask = (positions.unsqueeze(0) < encoder_output_lengths.unsqueeze(1)).long()
+        else:
+            enc_mask = getattr(encoder_outputs, "attention_mask", None)
+
+        decoder_outputs = self.model.decoder(
+            input_ids=input_ids,
+            attention_mask=decoder_attention_mask,
+            position_ids=position_ids,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_attention_mask=enc_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            input_features=input_features,
+        )
+        logits = self.proj_out(decoder_outputs.last_hidden_state)
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size)
+
+        return Seq2SeqLMOutput(
+            loss=loss,
+            logits=logits,
+            past_key_values=decoder_outputs.past_key_values,
+        )
+
+    def get_dummy_inputs(self, **kwargs):
+        bs = 1
+        seq_len = int(kwargs.get("prefill_seq_len", ONNX_EXPORT_EXAMPLE_SEQ_LEN))
+        # encoder_ctx_len is the encoder OUTPUT sequence length (after subsampling).
+        # encoder_config.max_position_embeddings is the INPUT length (max audio frames).
+        # Divide by subsampling_factor to get the output length used for cross-KV cache sizing.
+        subsampling_factor = self.config.encoder_config.subsampling_factor
+        encoder_ctx_len = kwargs.get("encoder_ctx_len") or (
+            self.config.encoder_config.max_position_embeddings // subsampling_factor
+        )
+        encoder_feature_count = self.config.num_mel_bins
+        num_key_value_heads = self.config.num_key_value_heads
+        head_dim = self.config.hidden_size // self.config.num_attention_heads
+        num_layers = self.config.num_hidden_layers
+
+        full_feature_len = encoder_ctx_len * subsampling_factor
+        inputs = {
+            # Use the full encoder input length (encoder_ctx_len * subsampling_factor) so
+            # that the encoder output has exactly encoder_ctx_len frames at trace time.
+            # This is necessary for the ScatterND / Reshape_3 in cross-attention to get
+            # a matching shape from the cache (past_key_cross.{i}).  feature_len=1 would
+            # produce a 1-frame encoder output, but the zero-pad in forward() corrects
+            # this to encoder_ctx_len before the cross-attention, so both specializations
+            # receive an encoder_ctx_len-frame encoder output.  Note: we still trace with
+            # the full length so the Where condition (input_features.shape[2] == 1)
+            # evaluates to False at trace time, keeping both branches in the ONNX.
+            "input_features": torch.zeros((bs, encoder_feature_count, full_feature_len), dtype=torch.float32),
+            "feature_lengths": torch.full((bs,), full_feature_len, dtype=torch.int64),
+            "input_ids": torch.zeros((bs, seq_len), dtype=torch.int64),
+            "position_ids": torch.arange(seq_len, dtype=torch.int64).view(1, seq_len).repeat(bs, 1),
+            "past_key_values": [[] for _ in range(num_layers)],
+        }
+
+        kv_cache_shape = (bs, num_key_value_heads, seq_len, head_dim)
+        kv_cross_cache_shape = (bs, num_key_value_heads, encoder_ctx_len, head_dim)
+
+        for i in range(num_layers):
+            for self_cross in ["self", "cross"]:
+                for kv in ["key", "value"]:
+                    inputs["past_key_values"][i].append(
+                        torch.zeros(
+                            kv_cache_shape if self_cross == "self" else kv_cross_cache_shape, dtype=torch.float32
+                        )
+                    )
+
+        return inputs
+
+    def get_specializations(self, batch_size: int, encoder_ctx_len, ctx_len, **compiler_options):
+        subsampling_factor = self.config.encoder_config.subsampling_factor
+        if encoder_ctx_len is None:
+            # encoder_ctx_len = encoder OUTPUT length (after subsampling).
+            # encoder_config.max_position_embeddings is the INPUT length; divide by subsampling_factor.
+            encoder_ctx_len = self.config.encoder_config.max_position_embeddings // subsampling_factor
+        # feature_len is the encoder INPUT length (before subsampling = encoder_ctx_len * subsampling_factor).
+        feature_len = encoder_ctx_len * subsampling_factor
+
+        encoder_specializations = {
+            "_graph_name": "Encoder",
+            "batch_size": batch_size,
+            "seq_len": 1,
+            "encoder_ctx_len": encoder_ctx_len,
+            "decoder_ctx_len": ctx_len,
+            "feature_len": feature_len,
+        }
+
+        decoder_specializations = {
+            "_graph_name": "Decode",
+            "batch_size": batch_size,
+            "seq_len": 1,
+            "encoder_ctx_len": encoder_ctx_len,
+            "decoder_ctx_len": ctx_len,
+            "feature_len": 1,  # dummy feature so torch.where knows whether to run cross attention or not
+        }
+
+        specializations = [encoder_specializations, decoder_specializations]
+
+        return specializations, compiler_options
+
+    def get_onnx_dynamic_axes(self):
+        num_layers = self.config.num_hidden_layers
+
+        dynamic_axes = {
+            "input_features": {0: "batch_size", 2: "feature_len"},
+            "feature_lengths": {0: "batch_size"},
+            "input_ids": {0: "batch_size", 1: "seq_len"},
+            "position_ids": {0: "batch_size", 1: "seq_len"},
+        }
+        pkv_self_dynamic_axes = {
+            0: "batch_size",
+            2: "decoder_ctx_len",
+        }
+        pkv_cross_dynamic_axes = {
+            0: "batch_size",
+            2: "encoder_ctx_len",
+        }
+        for i in range(num_layers):
+            for self_cross in ["self", "cross"]:
+                for kv in ["key", "value"]:
+                    dynamic_axes[f"past_{kv}_{self_cross}.{i}"] = (
+                        pkv_self_dynamic_axes if self_cross == "self" else pkv_cross_dynamic_axes
+                    )
+
+        return dynamic_axes
+
+    def get_output_names(self):
+        output_names = ["logits"]
+        for i in range(self.config.num_hidden_layers):
+            for self_cross in ["self", "cross"]:
+                for kv in ["key", "value"]:
+                    output_names.append(f"past_{kv}_{self_cross}.{i}_RetainedState")
+        return output_names
+
+    def get_inputs_info(self):
+        return [
+            IOInfo(name="input_features", datatype=torch.float32, shape=("batch_size", "num_mel_bins", "feature_len")),
+            IOInfo(name="feature_lengths", datatype=torch.int64, shape=("batch_size",)),
+        ]

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -4817,7 +4817,7 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
     _pytorch_transforms = [CustomOpsTransform, AwqToMatmulNbitsTransform, GPTQToMatmulNbitsTransform, KVCacheTransform]
     _onnx_transforms = []
 
-    def __init__(self, model: nn.Module, **kwargs):
+    def __init__(self, model: nn.Module, continuous_batching: bool = False, **kwargs):
         """
         Initialize a QEFFAutoModelForSpeechSeq2Seq instance.
 
@@ -4839,9 +4839,23 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
             raise TypeError(f"Required pytorch module with ForConditionalGeneration, got {model_class_name}")
 
         model.config.use_cache = True
+        if continuous_batching and model.config.model_type != "cohere_asr":
+            raise NotImplementedError("Continuous batching is currently supported only for Cohere ASR speech models")
+        self.continuous_batching = continuous_batching
         super().__init__(model, **kwargs)
         self.num_layers = model.config.num_hidden_layers
         self.hash_params["qeff_auto_class"] = self.__class__.__name__
+
+    @classmethod
+    def from_pretrained(
+        cls, pretrained_model_name_or_path: str, *args, continuous_batching: bool = False, **kwargs
+    ):
+        qeff_model = super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+        if continuous_batching and qeff_model.model.config.model_type != "cohere_asr":
+            raise NotImplementedError("Continuous batching is currently supported only for Cohere ASR speech models")
+        qeff_model.continuous_batching = continuous_batching
+        qeff_model.hash_params["continuous_batching"] = continuous_batching
+        return qeff_model
 
     @property
     def get_model_config(self) -> dict:
@@ -4883,8 +4897,12 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
         dummy_input_kwargs = {}
         if "encoder_ctx_len" in kwargs:
             dummy_input_kwargs["encoder_ctx_len"] = kwargs["encoder_ctx_len"]
+        if self.continuous_batching:
+            dummy_input_kwargs["continuous_batching"] = True
+            dummy_input_kwargs["full_batch_size"] = kwargs.get("full_batch_size")
+            dummy_input_kwargs["batch_size"] = kwargs.get("batch_size", 1)
         inputs = self.model.get_dummy_inputs(**dummy_input_kwargs)
-        dynamic_axes = self.model.get_onnx_dynamic_axes()
+        dynamic_axes = self.model.get_onnx_dynamic_axes(continuous_batching=self.continuous_batching)
         output_names = self.model.get_output_names()
         return self._export(
             inputs,
@@ -4978,11 +4996,14 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
             batch_size,
             encoder_ctx_len,
             ctx_len,
+            full_batch_size=full_batch_size if self.continuous_batching else None,
             **compiler_options,
         )
 
-        if full_batch_size:
-            logger.warning("Continuous batching is not yet enabled for AutoModelForSpeechSeq2Seq")
+        if self.continuous_batching and full_batch_size is None:
+            raise TypeError("`full_batch_size` is required when `continuous_batching=True`.")
+        if full_batch_size and not self.continuous_batching:
+            raise ValueError("Enable `continuous_batching=True` when passing `full_batch_size`.")
 
         if kv_cache_batch_size:
             logger.warning("Prefix caching is not yet enabled for AutoModelForSpeechSeq2Seq")
@@ -4994,6 +5015,15 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
             logger.warning("Speculative decoding is not yet enabled for AutoModelForSpeechSeq2Seq")
 
         output_names = self.model.get_output_names()
+
+        if onnx_path is None and self.continuous_batching:
+            onnx_path = self.export(
+                export_dir=compile_dir,
+                encoder_ctx_len=encoder_ctx_len,
+                batch_size=batch_size,
+                full_batch_size=full_batch_size,
+                use_onnx_subfunctions=use_onnx_subfunctions,
+            )
 
         target_dtype = getattr(self.model.config, "torch_dtype", torch.float32)
         kv_cache_dtype = CUSTOM_IO_DTYPE_MAP[target_dtype]

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -4875,7 +4875,15 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
         str
             Path to the generated ONNX graph file.
         """
-        inputs = self.model.get_dummy_inputs()
+        # Forward encoder_ctx_len so get_dummy_inputs traces with the correct window size.
+        # Without this the Reshape nodes in cross-attention get baked with the default
+        # encoder_ctx_len (from config.max_position_embeddings / subsampling_factor),
+        # causing a shape mismatch at qaic-compile when a different encoder_ctx_len is
+        # passed to compile().
+        dummy_input_kwargs = {}
+        if "encoder_ctx_len" in kwargs:
+            dummy_input_kwargs["encoder_ctx_len"] = kwargs["encoder_ctx_len"]
+        inputs = self.model.get_dummy_inputs(**dummy_input_kwargs)
         dynamic_axes = self.model.get_onnx_dynamic_axes()
         output_names = self.model.get_output_names()
         return self._export(
@@ -5061,22 +5069,62 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
             raise TypeError("Please run compile API first!")
 
         self._write_io_dir = os.path.join(os.path.dirname(self.onnx_path), "io_dir") if write_io else None
+        inputs = dict(inputs)
+        decoder_prompt = inputs.pop("decoder_input_ids", None)
 
-        inputs = self.auto_correct_inputs(inputs)
+        input_names = {input_info.name for input_info in self.model.get_inputs_info()}
+        if "feature_lengths" in input_names and "feature_lengths" not in inputs:
+            attention_mask = inputs.get("attention_mask")
+            if attention_mask is None:
+                raise RuntimeError("This model requires the processor attention_mask to derive feature_lengths")
+            inputs["feature_lengths"] = attention_mask.sum(dim=-1, dtype=torch.int64)
+
         if self.qpc_session is None:
             self.qpc_session = QAICInferenceSession(str(self.qpc_path), device_ids)
             self.batch_size = self.qpc_session.bindings[0].dims[0]
 
-        inputs["input_features"] = inputs["input_features"].numpy().astype(np.float16)
+        input_features = inputs.get("input_features")
+        if isinstance(input_features, torch.Tensor) and input_features.ndim == 3:
+            feature_binding = self.qpc_session.bindings[self.qpc_session.binding_index_map["input_features"]]
+            expected_feature_shape = tuple(feature_binding.dims)
+            if (
+                input_features.shape[1] != expected_feature_shape[1]
+                and input_features.shape[2] == expected_feature_shape[1]
+            ):
+                input_features = input_features.transpose(1, 2)
+            if input_features.shape[:2] != expected_feature_shape[:2]:
+                raise RuntimeError(
+                    f"input_features must have batch/mel dimensions {expected_feature_shape[:2]}, "
+                    f"got {tuple(input_features.shape[:2])}"
+                )
+            feature_padding = expected_feature_shape[2] - input_features.shape[2]
+            if feature_padding < 0:
+                raise RuntimeError(
+                    f"input_features length {input_features.shape[2]} exceeds compiled length {expected_feature_shape[2]}"
+                )
+            if feature_padding:
+                input_features = torch.nn.functional.pad(input_features, (0, feature_padding))
+            inputs["input_features"] = input_features
 
-        # add start token id and initial position ids to inputs
-        seq_len = 1
-        inputs["input_ids"] = (
-            torch.ones((self.batch_size, seq_len), dtype=torch.int64) * self.model.config.decoder_start_token_id
-        ).numpy()
-        inputs["position_ids"] = (
-            torch.arange(seq_len, dtype=torch.int64).view(1, seq_len).repeat(self.batch_size, 1).numpy()
-        )
+        inputs = self.auto_correct_inputs(inputs)
+        inputs["input_features"] = inputs["input_features"].numpy().astype(np.float16)
+        if "feature_lengths" in inputs:
+            inputs["feature_lengths"] = inputs["feature_lengths"].numpy().astype(np.int64)
+
+        if decoder_prompt is None:
+            decoder_prompt = torch.full(
+                (self.batch_size, 1), self.model.config.decoder_start_token_id, dtype=torch.int64
+            )
+        if isinstance(decoder_prompt, torch.Tensor):
+            decoder_prompt = decoder_prompt.detach().cpu().numpy()
+        decoder_prompt = np.asarray(decoder_prompt, dtype=np.int64)
+        if decoder_prompt.ndim != 2 or decoder_prompt.shape[0] != self.batch_size:
+            raise RuntimeError(
+                f"decoder_input_ids must have shape ({self.batch_size}, prompt_length), got {decoder_prompt.shape}"
+            )
+        prompt_length = decoder_prompt.shape[1]
+        if prompt_length == 0:
+            raise RuntimeError("decoder_input_ids must contain at least one prompt token")
 
         self.qpc_session.skip_buffers(
             [x for x in self.qpc_session.input_names + self.qpc_session.output_names if is_retained_state_name(x)]
@@ -5087,47 +5135,50 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
         }
         self.qpc_session.set_buffers(outputs)
 
-        # encoder run
+        # Run the encoder with the first prompt token, then consume any remaining
+        # processor prompt tokens through cached decode before generation starts.
         start = perf_counter()
-        outputs = self.qpc_session.run(inputs)
+        outputs = None
+        for prompt_position in range(prompt_length):
+            inputs["input_ids"] = decoder_prompt[:, prompt_position : prompt_position + 1]
+            inputs["position_ids"] = np.full((self.batch_size, 1), prompt_position, dtype=np.int64)
+            outputs = self.qpc_session.run(inputs)
+            if self._write_io_dir is not None:
+                stage = "prefill" if prompt_position == 0 else f"prompt_{prompt_position}"
+                write_io_files(inputs, outputs, self._write_io_dir, stage, "aic_batch_io", True, False)
+            inputs["input_features"] = np.zeros((self.batch_size, self.model.config.num_mel_bins, 1), dtype=np.float16)
 
-        if self._write_io_dir is not None:
-            write_io_files(inputs, outputs, self._write_io_dir, "prefill", "aic_batch_io", True, False)
-
-        # array to hold generated tokens
-        generated_ids = np.full((self.batch_size, generation_len + 1), self.model.config.eos_token_id)
-        generated_ids[:, 0] = [self.model.config.decoder_start_token_id]
-        logits = outputs["logits"]
-        next_token = logits.argmax(-1)
-        generated_ids[:, 1] = next_token.squeeze(1)
-
-        if streamer:
-            streamer.put(next_token)
-
-        inputs["input_features"] = np.zeros((self.batch_size, self.model.config.num_mel_bins, 1)).astype(np.float16)
-
+        generated_ids = np.full(
+            (self.batch_size, prompt_length + generation_len), self.model.config.eos_token_id, dtype=np.int64
+        )
+        generated_ids[:, :prompt_length] = decoder_prompt
+        finished = np.zeros(self.batch_size, dtype=bool)
         loop_start = perf_counter()
-        for num_tokens in range(generation_len):
+        generated_count = 0
+        for generated_index in range(generation_len):
+            logits = outputs["logits"]
+            next_token = logits.argmax(-1).reshape(self.batch_size).astype(np.int64)
+            next_token = np.where(finished, self.model.config.eos_token_id, next_token)
+            generated_ids[:, prompt_length + generated_index] = next_token
+            generated_count = generated_index + 1
+            finished |= next_token == self.model.config.eos_token_id
+
+            if streamer:
+                streamer.put(next_token[:, None])
+            if finished.all() or generated_count == generation_len:
+                break
+
+            inputs["input_ids"] = np.where(finished, self.model.config.eos_token_id, next_token)[:, None]
+            inputs["position_ids"] = np.full((self.batch_size, 1), prompt_length + generated_index, dtype=np.int64)
             outputs = self.qpc_session.run(inputs)
             if self._write_io_dir is not None:
                 write_io_files(inputs, outputs, self._write_io_dir, "decode", "aic_batch_io", True, False)
                 self._write_io_dir = None
-
-            logits = outputs["logits"]
-            next_token = logits.argmax(-1)
-            generated_ids[:, num_tokens + 1] = next_token.squeeze(1)
-
-            if next_token[0][0] == self.model.config.eos_token_id:
-                break
-
-            inputs["input_ids"] = next_token
-            inputs["position_ids"] += 1
-
-            if streamer:
-                streamer.put(next_token)
         end = perf_counter()
 
-        prefill_time, decode_perf, total_perf, total_time = calculate_latency(num_tokens, loop_start, start, end)
+        prefill_time, decode_perf, total_perf, total_time = calculate_latency(
+            max(generated_count - 1, 0), loop_start, start, end
+        )
 
         return CloudAI100ExecInfoNew(
             batch_size=self.batch_size,

--- a/QEfficient/transformers/models/pytorch_transforms.py
+++ b/QEfficient/transformers/models/pytorch_transforms.py
@@ -16,6 +16,13 @@ from transformers.models.codegen.modeling_codegen import (
     CodeGenForCausalLM,
     CodeGenModel,
 )
+from transformers.models.cohere_asr.modeling_cohere_asr import (
+    CohereAsrCrossAttention,
+    CohereAsrDecoder,
+    CohereAsrDecoderLayer,
+    CohereAsrForConditionalGeneration,
+    CohereAsrSelfAttention,
+)
 from transformers.models.deberta_v2.modeling_deberta_v2 import (
     DisentangledSelfAttention,
 )
@@ -172,6 +179,7 @@ from transformers.models.olmo2.modeling_olmo2 import (
     Olmo2Model,
     Olmo2RMSNorm,
 )
+from transformers.models.parakeet.modeling_parakeet import ParakeetEncoderAttention, ParakeetEncoderSubsamplingConv2D
 from transformers.models.phi.modeling_phi import PhiAttention, PhiDecoderLayer, PhiForCausalLM, PhiModel
 from transformers.models.phi3.modeling_phi3 import (
     Phi3Attention,
@@ -319,6 +327,15 @@ from QEfficient.transformers.models.codegen.modeling_codegen import (
     QEffCodeGenBlock,
     QEffCodeGenForCausalLM,
     QEffCodeGenModel,
+)
+from QEfficient.transformers.models.cohere_asr.modeling_cohere_asr import (
+    QEffCohereAsrCrossAttention,
+    QEffCohereAsrDecoder,
+    QEffCohereAsrDecoderLayer,
+    QEffCohereAsrForConditionalGeneration,
+    QEffCohereAsrSelfAttention,
+    QEffParakeetEncoderAttention,
+    QEffParakeetEncoderSubsamplingConv2D,
 )
 from QEfficient.transformers.models.deberta_v2.modeling_deberta_v2 import (
     QEffDisentangledSelfAttention,
@@ -937,6 +954,14 @@ class KVCacheTransform(ModuleMappingTransform):
         WhisperDecoder: QEffWhisperDecoder,
         WhisperModel: QEffWhisperModel,
         WhisperForConditionalGeneration: QEffWhisperForConditionalGeneration,
+        # CohereAsr decoder layers and Parakeet encoder attention
+        ParakeetEncoderAttention: QEffParakeetEncoderAttention,
+        ParakeetEncoderSubsamplingConv2D: QEffParakeetEncoderSubsamplingConv2D,
+        CohereAsrSelfAttention: QEffCohereAsrSelfAttention,
+        CohereAsrCrossAttention: QEffCohereAsrCrossAttention,
+        CohereAsrDecoderLayer: QEffCohereAsrDecoderLayer,
+        CohereAsrDecoder: QEffCohereAsrDecoder,
+        CohereAsrForConditionalGeneration: QEffCohereAsrForConditionalGeneration,
     }
 
     @classmethod

--- a/docs/source/validate.md
+++ b/docs/source/validate.md
@@ -129,6 +129,7 @@ If the `kv_offload` is set to `True` it runs in dual QPC and if its set to `Fals
 
 | Architecture | Model Family | Representative Models                                                                 | vLLM Support |
 |--------------|--------------|----------------------------------------------------------------------------------------|--------------|
+| **CohereAsrForConditionalGeneration** | cohere_asr | [CohereLabs/cohere-transcribe-03-2026](https://huggingface.co/CohereLabs/cohere-transcribe-03-2026) |  |
 | **Whisper**  | Whisper      | [openai/whisper-tiny](https://huggingface.co/openai/whisper-tiny)<br>[openai/whisper-base](https://huggingface.co/openai/whisper-base)<br>[openai/whisper-small](https://huggingface.co/openai/whisper-small)<br>[openai/whisper-medium](https://huggingface.co/openai/whisper-medium)<br>[openai/whisper-large](https://huggingface.co/openai/whisper-large)<br>[openai/whisper-large-v3-turbo](https://huggingface.co/openai/whisper-large-v3-turbo) | ✔️          |
 | **Wav2Vec2** | Wav2Vec2     | [facebook/wav2vec2-base](https://huggingface.co/facebook/wav2vec2-base)<br>[facebook/wav2vec2-large](https://huggingface.co/facebook/wav2vec2-large) |           |
 

--- a/examples/audio/COHERE_ASR.md
+++ b/examples/audio/COHERE_ASR.md
@@ -8,20 +8,25 @@ compiling again.
 
 - A Cloud AI 100 host with the Qualcomm AI SDK installed and `qaic-compile` on
   `PATH`.
-- A QEfficient Python environment.
+- A QEfficient release that includes Cohere ASR support.
 - An accessible AI 100 device. The examples below use device `0`.
 - Access to `CohereLabs/cohere-transcribe-03-2026` on Hugging Face.
 
-Clone the fork containing Cohere ASR support and activate the QEff environment:
+Install QEfficient using the standard repository setup:
 
 ```bash
-git clone <efficient-transformers-fork-url>
+git clone https://github.com/quic/efficient-transformers.git
 cd efficient-transformers
-git checkout feature/add-cohere_asr
 
-source <qeff-venv>/bin/activate
-export QEFF_HOME="$PWD/.qeff_cohere"
+python3.12 -m venv qeff_env
+source qeff_env/bin/activate
+pip install -U pip
+pip install -e .
 ```
+
+For an SDK-provided QEff environment, use the activation command supplied by
+your Cloud AI SDK installation instead. `QEFF_HOME` is optional: when it is
+unset, QEfficient uses its standard cache location.
 
 ## Compile and transcribe
 

--- a/examples/audio/COHERE_ASR.md
+++ b/examples/audio/COHERE_ASR.md
@@ -1,0 +1,71 @@
+# Cohere ASR on Cloud AI 100
+
+`cohere_asr_inference.py` compiles a Cohere ASR QPC when no QPC is supplied,
+then transcribes a local audio file. It can also reuse an existing QPC without
+compiling again.
+
+## Prerequisites
+
+- A Cloud AI 100 host with the Qualcomm AI SDK installed and `qaic-compile` on
+  `PATH`.
+- A QEfficient Python environment.
+- An accessible AI 100 device. The examples below use device `0`.
+- Access to `CohereLabs/cohere-transcribe-03-2026` on Hugging Face.
+
+Clone the fork containing Cohere ASR support and activate the QEff environment:
+
+```bash
+git clone <efficient-transformers-fork-url>
+cd efficient-transformers
+git checkout feature/add-cohere_asr
+
+source <qeff-venv>/bin/activate
+export QEFF_HOME="$PWD/.qeff_cohere"
+```
+
+## Compile and transcribe
+
+This command exports the model, compiles a batch-1 QPC, and transcribes the
+specified WAV or FLAC audio file. The generated QPC path is printed as `qpc=`.
+
+```bash
+python examples/audio/cohere_asr_inference.py \
+  --model-name CohereLabs/cohere-transcribe-03-2026 \
+  --language en \
+  --audio-path /path/to/audio.wav \
+  --compile-dir "$PWD/cohere_asr_compile" \
+  --batch-size 1 \
+  --num-cores 16 \
+  --encoder-ctx-len 438 \
+  --ctx-len 512 \
+  --generation-len 500
+```
+
+The compile configuration above uses one device, batch size 1, 16 QPC cores,
+a 438-token encoder context, and a 512-token decoder context. Audio longer
+than one processor window is processed as sequential batch-1 chunks.
+
+## Reuse an existing QPC
+
+Pass the QPC directory printed by the compile command to skip export and
+compilation:
+
+```bash
+python examples/audio/cohere_asr_inference.py \
+  --model-name CohereLabs/cohere-transcribe-03-2026 \
+  --language en \
+  --audio-path /path/to/audio.wav \
+  --qpc-path /path/to/generated/qpc \
+  --generation-len 500
+```
+
+## Optional transcript comparison
+
+Provide a known transcript to print exact and normalized text-match results:
+
+```bash
+  --reference-text "expected transcript text"
+```
+
+The script prints the QPC path, audio path, processor chunk count, generated
+transcript, EOS status, and generated token IDs.

--- a/examples/audio/README.md
+++ b/examples/audio/README.md
@@ -27,6 +27,7 @@ For the complete list of supported audio models, see the [Validated Models - Aud
 Popular models include:
 - Whisper (tiny, base, small, medium, large, large-v3-turbo)
 - Wav2Vec2 (base-960h)
+- Cohere Transcribe
 
 ## Available Examples
 
@@ -79,6 +80,26 @@ This example:
 - Uses Wav2Vec2-base-960h model by default
 - Compiles and runs inference on Cloud AI 100
 - Outputs the recognized text
+
+### cohere_asr_inference.py
+
+Run selected dataset clips through an existing batch-1 Cohere ASR QPC. The
+defaults use dummy LibriSpeech, while the dataset arguments support other
+English or Arabic evaluation sets:
+
+```bash
+python cohere_asr_inference.py \
+    --model-name CohereLabs/cohere-transcribe-03-2026 \
+    --qpc-path /path/to/batch1/qpc \
+    --language en \
+    --indices 0,1,2 \
+    --device-id 0
+```
+
+The dataset, configuration, split, audio column, and reference-text column are
+configurable. The script resets retained state between clips and prints
+`desired_text`, `actual_generated_text`, raw and normalized match flags, EOS
+status, and token IDs trimmed at the first EOS.
 
 ## Documentation
 

--- a/examples/audio/README.md
+++ b/examples/audio/README.md
@@ -83,23 +83,9 @@ This example:
 
 ### cohere_asr_inference.py
 
-Run selected dataset clips through an existing batch-1 Cohere ASR QPC. The
-defaults use dummy LibriSpeech, while the dataset arguments support other
-English or Arabic evaluation sets:
-
-```bash
-python cohere_asr_inference.py \
-    --model-name CohereLabs/cohere-transcribe-03-2026 \
-    --qpc-path /path/to/batch1/qpc \
-    --language en \
-    --indices 0,1,2 \
-    --device-id 0
-```
-
-The dataset, configuration, split, audio column, and reference-text column are
-configurable. The script resets retained state between clips and prints
-`desired_text`, `actual_generated_text`, raw and normalized match flags, EOS
-status, and token IDs trimmed at the first EOS.
+Compile a Cohere ASR QPC and transcribe a local audio file, or reuse an
+existing QPC. See [Cohere ASR on Cloud AI 100](COHERE_ASR.md) for the complete
+customer workflow.
 
 ## Documentation
 

--- a/examples/audio/cohere_asr_inference.py
+++ b/examples/audio/cohere_asr_inference.py
@@ -12,6 +12,7 @@ import re
 import unicodedata
 from pathlib import Path
 
+import soundfile as sf
 from datasets import load_dataset
 from transformers import AutoProcessor
 
@@ -52,10 +53,41 @@ def trim_at_eos(token_ids: list[int], eos_token_id: int) -> tuple[list[int], boo
     return token_ids[: eos_index + 1], True
 
 
+def resolve_qpc_path(model: QEFFAutoModelForSpeechSeq2Seq, args: argparse.Namespace) -> Path:
+    if args.qpc_path is not None:
+        if not args.qpc_path.is_dir():
+            raise ValueError(f"QPC directory does not exist: {args.qpc_path}")
+        return args.qpc_path
+
+    compile_dir = args.compile_dir
+    qpc_path = model.compile(
+        compile_dir=str(compile_dir),
+        batch_size=args.batch_size,
+        num_devices=1,
+        num_cores=args.num_cores,
+        encoder_ctx_len=args.encoder_ctx_len,
+        ctx_len=args.ctx_len,
+        mxfp6_matmul=False,
+        mxint8_kv_cache=False,
+        use_onnx_subfunctions=False,
+    )
+    return Path(qpc_path)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--model-name", required=True, help="Cohere ASR model ID or local snapshot")
-    parser.add_argument("--qpc-path", type=Path, required=True, help="Existing batch-1 QPC directory")
+    parser.add_argument("--qpc-path", type=Path, help="Existing QPC directory; skips compilation")
+    parser.add_argument(
+        "--compile-dir",
+        type=Path,
+        default=Path("cohere_asr_compile"),
+        help="Directory for export and QPC compilation when --qpc-path is omitted",
+    )
+    parser.add_argument("--batch-size", type=int, default=1, help="Static QPC batch size")
+    parser.add_argument("--num-cores", type=int, default=16, help="QPC accelerator cores")
+    parser.add_argument("--encoder-ctx-len", type=int, default=438, help="Cohere encoder context length")
+    parser.add_argument("--ctx-len", type=int, default=512, help="Cohere decoder context length")
     parser.add_argument("--language", required=True, help="Processor language prompt, for example en or ar")
     parser.add_argument("--dataset-name", default=DATASET_NAME)
     parser.add_argument("--dataset-config", default=DATASET_CONFIG)
@@ -63,20 +95,41 @@ def main() -> None:
     parser.add_argument("--audio-column", default="audio")
     parser.add_argument("--text-column", default="text")
     parser.add_argument("--indices", type=parse_indices, default=parse_indices("0,1,2"))
+    parser.add_argument("--audio-path", type=Path, help="Local WAV/FLAC audio file to transcribe")
+    parser.add_argument("--reference-text", help="Optional reference transcript for a local audio file")
     parser.add_argument("--generation-len", type=int, default=500)
     parser.add_argument("--device-id", type=int, default=0)
     parser.add_argument("--local-files-only", action="store_true")
     args = parser.parse_args()
 
-    if not args.qpc_path.is_dir():
+    if args.generation_len <= 0 or args.batch_size <= 0 or args.num_cores <= 0:
+        parser.error("--generation-len, --batch-size, and --num-cores must be positive")
+    if args.encoder_ctx_len <= 0 or args.ctx_len <= 0:
+        parser.error("--encoder-ctx-len and --ctx-len must be positive")
+    if args.qpc_path is not None and not args.qpc_path.is_dir():
         parser.error(f"QPC directory does not exist: {args.qpc_path}")
-    if args.generation_len <= 0:
-        parser.error("--generation-len must be positive")
+    if args.audio_path is not None and not args.audio_path.is_file():
+        parser.error(f"audio file does not exist: {args.audio_path}")
 
-    dataset = load_dataset(args.dataset_name, args.dataset_config, split=args.dataset_split)
-    invalid = [index for index in args.indices if index >= len(dataset)]
-    if invalid:
-        parser.error(f"dataset indices out of range for {len(dataset)} clips: {invalid}")
+    if args.audio_path is None:
+        dataset = load_dataset(args.dataset_name, args.dataset_config, split=args.dataset_split)
+        invalid = [index for index in args.indices if index >= len(dataset)]
+        if invalid:
+            parser.error(f"dataset indices out of range for {len(dataset)} clips: {invalid}")
+        samples = [
+            (
+                str(index),
+                dataset[index][args.audio_column]["array"],
+                int(dataset[index][args.audio_column]["sampling_rate"]),
+                dataset[index].get(args.text_column, ""),
+            )
+            for index in args.indices
+        ]
+    else:
+        audio_values, sample_rate = sf.read(args.audio_path, dtype="float32", always_2d=False)
+        if audio_values.ndim == 2:
+            audio_values = audio_values.mean(axis=1)
+        samples = [(args.audio_path.name, audio_values, sample_rate, args.reference_text or "")]
 
     processor = AutoProcessor.from_pretrained(
         args.model_name,
@@ -89,41 +142,60 @@ def main() -> None:
         trust_remote_code=False,
         dtype="float32",
     )
-    model.qpc_path = args.qpc_path
+    qpc_path = resolve_qpc_path(model, args)
+    model.qpc_path = qpc_path
 
     print(f"model={args.model_name}")
-    print(f"qpc={args.qpc_path}")
-    print(f"dataset={args.dataset_name}/{args.dataset_config}:{args.dataset_split}")
+    print(f"qpc={qpc_path}")
+    if args.audio_path is None:
+        print(f"dataset={args.dataset_name}/{args.dataset_config}:{args.dataset_split}")
+    else:
+        print(f"audio={args.audio_path}")
     print(f"language={args.language} device={args.device_id}")
 
     try:
-        for index in args.indices:
-            sample = dataset[index]
-            source_audio = sample[args.audio_column]
-            audio_values = source_audio["array"]
-            sample_rate = int(source_audio["sampling_rate"])
-            reference = sample.get(args.text_column, "")
+        for clip_id, audio_values, sample_rate, reference in samples:
             inputs = processor(
                 audio_values,
                 sampling_rate=sample_rate,
                 language=args.language,
                 return_tensors="pt",
             )
-            execution = model.generate(
-                inputs=inputs,
-                generation_len=args.generation_len,
-                device_ids=[args.device_id],
-            )
-            transcription = processor.batch_decode(execution.generated_ids, skip_special_tokens=True)[0].strip()
-            token_ids, eos_reached = trim_at_eos(execution.generated_ids[0].tolist(), model.model.config.eos_token_id)
-            print(f"\nclip[{index}]")
+            chunk_count = inputs["input_features"].shape[0]
+            chunk_transcriptions = []
+            token_ids = []
+            eos_reached = True
+            for chunk_index in range(chunk_count):
+                chunk_inputs = {
+                    name: value[chunk_index : chunk_index + 1]
+                    if getattr(value, "shape", ()) and value.shape[0] == chunk_count
+                    else value
+                    for name, value in inputs.items()
+                }
+                execution = model.generate(
+                    inputs=chunk_inputs,
+                    generation_len=args.generation_len,
+                    device_ids=[args.device_id],
+                )
+                chunk_tokens, chunk_eos_reached = trim_at_eos(
+                    execution.generated_ids[0].tolist(), model.model.config.eos_token_id
+                )
+                token_ids.extend(chunk_tokens)
+                eos_reached = eos_reached and chunk_eos_reached
+                chunk_transcriptions.append(
+                    processor.batch_decode(execution.generated_ids, skip_special_tokens=True)[0].strip()
+                )
+                reset_session(model)
+            transcription = " ".join(text for text in chunk_transcriptions if text)
+            print(f"\nclip[{clip_id}]")
+            print(f"processor_chunks:      {chunk_count}")
             print(f"desired_text:          {reference}")
             print(f"actual_generated_text: {transcription}")
-            print(f"exact_text_match:      {transcription == reference}")
-            print(f"normalized_text_match: {normalize_text(transcription) == normalize_text(reference)}")
+            if reference:
+                print(f"exact_text_match:      {transcription == reference}")
+                print(f"normalized_text_match: {normalize_text(transcription) == normalize_text(reference)}")
             print(f"eos_reached:           {eos_reached}")
             print(f"generated_ids_to_eos:  {token_ids}")
-            reset_session(model)
     finally:
         reset_session(model)
 

--- a/examples/audio/cohere_asr_inference.py
+++ b/examples/audio/cohere_asr_inference.py
@@ -1,0 +1,132 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+"""Run Cohere ASR QPC inference on selected dataset clips."""
+
+import argparse
+import re
+import unicodedata
+from pathlib import Path
+
+from datasets import load_dataset
+from transformers import AutoProcessor
+
+from QEfficient import QEFFAutoModelForSpeechSeq2Seq
+
+DATASET_NAME = "hf-internal-testing/librispeech_asr_dummy"
+DATASET_CONFIG = "clean"
+DATASET_SPLIT = "validation"
+
+
+def parse_indices(value: str) -> list[int]:
+    try:
+        indices = [int(item.strip()) for item in value.split(",") if item.strip()]
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("indices must be comma-separated integers") from error
+    if not indices or any(index < 0 for index in indices):
+        raise argparse.ArgumentTypeError("indices must contain non-negative integers")
+    return indices
+
+
+def reset_session(model: QEFFAutoModelForSpeechSeq2Seq) -> None:
+    if model.qpc_session is not None:
+        model.qpc_session.deactivate()
+        model.qpc_session = None
+
+
+def normalize_text(value: str) -> str:
+    value = unicodedata.normalize("NFKC", value).casefold()
+    value = "".join(character if character.isalnum() else " " for character in value)
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def trim_at_eos(token_ids: list[int], eos_token_id: int) -> tuple[list[int], bool]:
+    try:
+        eos_index = token_ids.index(eos_token_id)
+    except ValueError:
+        return token_ids, False
+    return token_ids[: eos_index + 1], True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-name", required=True, help="Cohere ASR model ID or local snapshot")
+    parser.add_argument("--qpc-path", type=Path, required=True, help="Existing batch-1 QPC directory")
+    parser.add_argument("--language", required=True, help="Processor language prompt, for example en or ar")
+    parser.add_argument("--dataset-name", default=DATASET_NAME)
+    parser.add_argument("--dataset-config", default=DATASET_CONFIG)
+    parser.add_argument("--dataset-split", default=DATASET_SPLIT)
+    parser.add_argument("--audio-column", default="audio")
+    parser.add_argument("--text-column", default="text")
+    parser.add_argument("--indices", type=parse_indices, default=parse_indices("0,1,2"))
+    parser.add_argument("--generation-len", type=int, default=500)
+    parser.add_argument("--device-id", type=int, default=0)
+    parser.add_argument("--local-files-only", action="store_true")
+    args = parser.parse_args()
+
+    if not args.qpc_path.is_dir():
+        parser.error(f"QPC directory does not exist: {args.qpc_path}")
+    if args.generation_len <= 0:
+        parser.error("--generation-len must be positive")
+
+    dataset = load_dataset(args.dataset_name, args.dataset_config, split=args.dataset_split)
+    invalid = [index for index in args.indices if index >= len(dataset)]
+    if invalid:
+        parser.error(f"dataset indices out of range for {len(dataset)} clips: {invalid}")
+
+    processor = AutoProcessor.from_pretrained(
+        args.model_name,
+        local_files_only=args.local_files_only,
+        trust_remote_code=False,
+    )
+    model = QEFFAutoModelForSpeechSeq2Seq.from_pretrained(
+        args.model_name,
+        local_files_only=args.local_files_only,
+        trust_remote_code=False,
+        dtype="float32",
+    )
+    model.qpc_path = args.qpc_path
+
+    print(f"model={args.model_name}")
+    print(f"qpc={args.qpc_path}")
+    print(f"dataset={args.dataset_name}/{args.dataset_config}:{args.dataset_split}")
+    print(f"language={args.language} device={args.device_id}")
+
+    try:
+        for index in args.indices:
+            sample = dataset[index]
+            source_audio = sample[args.audio_column]
+            audio_values = source_audio["array"]
+            sample_rate = int(source_audio["sampling_rate"])
+            reference = sample.get(args.text_column, "")
+            inputs = processor(
+                audio_values,
+                sampling_rate=sample_rate,
+                language=args.language,
+                return_tensors="pt",
+            )
+            execution = model.generate(
+                inputs=inputs,
+                generation_len=args.generation_len,
+                device_ids=[args.device_id],
+            )
+            transcription = processor.batch_decode(execution.generated_ids, skip_special_tokens=True)[0].strip()
+            token_ids, eos_reached = trim_at_eos(execution.generated_ids[0].tolist(), model.model.config.eos_token_id)
+            print(f"\nclip[{index}]")
+            print(f"desired_text:          {reference}")
+            print(f"actual_generated_text: {transcription}")
+            print(f"exact_text_match:      {transcription == reference}")
+            print(f"normalized_text_match: {normalize_text(transcription) == normalize_text(reference)}")
+            print(f"eos_reached:           {eos_reached}")
+            print(f"generated_ids_to_eos:  {token_ids}")
+            reset_session(model)
+    finally:
+        reset_session(model)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/configs/audio_model_configs.json
+++ b/tests/configs/audio_model_configs.json
@@ -1,6 +1,7 @@
 {
    "speech_seq2seq_models": [
-        "openai/whisper-tiny"
+        "openai/whisper-tiny",
+        "CohereLabs/cohere-transcribe-03-2026"
     ],
     "audio_embedding_models": [
         "facebook/wav2vec2-base-960h"

--- a/tests/transformers/models/audio_models/test_speech_seq2seq_models.py
+++ b/tests/transformers/models/audio_models/test_speech_seq2seq_models.py
@@ -7,6 +7,8 @@
 
 import json
 import os
+from copy import deepcopy
+from types import SimpleNamespace
 from typing import List, Optional
 
 import numpy as np
@@ -15,8 +17,21 @@ import onnxruntime
 import pytest
 import torch
 from datasets import load_dataset
-from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
+from transformers import (
+    AutoConfig,
+    AutoModelForSpeechSeq2Seq,
+    AutoProcessor,
+    CohereAsrConfig,
+    CohereAsrForConditionalGeneration,
+)
+from transformers.cache_utils import DynamicCache, EncoderDecoderCache
+from transformers.models.cohere_asr.processing_cohere_asr import CohereAsrProcessor
+from transformers.models.parakeet.modeling_parakeet import ParakeetEncoder
 
+from QEfficient.transformers.models.cohere_asr.modeling_cohere_asr import (
+    QEffParakeetEncoderAttention,
+    QEffParakeetEncoderSubsamplingConv2D,
+)
 from QEfficient.transformers.models.modeling_auto import QEFFAutoModelForSpeechSeq2Seq
 from QEfficient.transformers.quantizers.auto import replace_transformers_quantizers
 from QEfficient.utils import get_padding_shape_from_config, hf_download
@@ -45,10 +60,13 @@ def load_seq2seq_model(model_config):
         ignore_patterns=["*.onnx", "*.ot", "*.md", "*.tflite", "*.pdf", "*.h5", "*.msgpack"],
     )
     kwargs = {
-        "use_cache": True,
         "attn_implementation": "eager",
         "low_cpu_mem_usage": False,
+        "dtype": torch.float32,
     }
+    config = AutoConfig.from_pretrained(model_path)
+    if hasattr(config, "use_cache"):
+        kwargs["use_cache"] = True
     n_layer = model_config.get("n_layer", -1)
     if n_layer != -1:
         kwargs["num_hidden_layers"] = n_layer
@@ -59,9 +77,705 @@ def load_seq2seq_model(model_config):
         model_path,
         **kwargs,
     )
+    if model_hf.config.decoder_start_token_id is None:
+        model_hf.config.decoder_start_token_id = model_hf.generation_config.decoder_start_token_id
     params = sum(p.numel() for p in model_hf.parameters())
     model_hf.eval()
     return model_hf, params
+
+
+@pytest.fixture(scope="module")
+def cohere_asr_qeff_model():
+    encoder_config = {
+        "model_type": "parakeet_encoder",
+        "num_mel_bins": 8,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 32,
+        "subsampling_conv_channels": 2,
+        "subsampling_conv_kernel_size": 3,
+        "subsampling_conv_stride": 2,
+        "subsampling_factor": 8,
+        "conv_kernel_size": 3,
+    }
+    config = CohereAsrConfig(
+        encoder_config=encoder_config,
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        decoder_start_token_id=4,
+    )
+    return QEFFAutoModelForSpeechSeq2Seq(CohereAsrForConditionalGeneration(config)).model.eval()
+
+
+def test_cohere_asr_subsampling_lengths_match_parakeet(cohere_asr_qeff_model):
+    feature_lengths = torch.tensor([1, 7, 8, 9, 15, 16, 17, 2499, 2500, 2501, 3499, 3500])
+    native_lengths = ParakeetEncoder._get_subsampling_output_length(
+        cohere_asr_qeff_model.model.encoder, feature_lengths
+    )
+
+    assert torch.equal(cohere_asr_qeff_model._get_encoder_output_lengths(feature_lengths), native_lengths)
+
+
+def test_cohere_asr_feature_lengths_build_per_batch_encoder_mask(cohere_asr_qeff_model, monkeypatch):
+    encoder = cohere_asr_qeff_model.model.encoder
+    original_forward = encoder.forward
+    captured = {}
+
+    def forward_with_mask(input_features, attention_mask=None, **kwargs):
+        captured["attention_mask"] = attention_mask.clone()
+        return original_forward(input_features, attention_mask=attention_mask, **kwargs)
+
+    class Decoder(torch.nn.Module):
+        def forward(self, input_ids, **_kwargs):
+            return SimpleNamespace(
+                last_hidden_state=torch.zeros((*input_ids.shape, cohere_asr_qeff_model.config.hidden_size)),
+                past_key_values=None,
+            )
+
+    monkeypatch.setattr(encoder, "forward", forward_with_mask)
+    monkeypatch.setattr(cohere_asr_qeff_model.model, "decoder", Decoder())
+    cohere_asr_qeff_model(
+        input_features=torch.randn(2, 8, 16),
+        input_ids=torch.tensor([[4], [4]]),
+        position_ids=torch.zeros((2, 1), dtype=torch.long),
+        feature_lengths=torch.tensor([8, 13]),
+    )
+
+    expected = torch.tensor([[True] * 9 + [False] * 7, [True] * 14 + [False] * 2])
+    assert torch.equal(captured["attention_mask"], expected)
+
+
+def test_cohere_asr_decode_keeps_cross_attention_length_from_feature_lengths(cohere_asr_qeff_model, monkeypatch):
+    encoder = cohere_asr_qeff_model.model.encoder
+    hidden_size = cohere_asr_qeff_model.config.encoder_config.hidden_size
+    captured = []
+
+    def encoder_forward(_input_features, **_kwargs):
+        return SimpleNamespace(last_hidden_state=torch.zeros((1, 2, hidden_size)))
+
+    class Decoder(torch.nn.Module):
+        def forward(self, input_ids, encoder_attention_mask, **_kwargs):
+            captured.append(encoder_attention_mask.clone())
+            return SimpleNamespace(
+                last_hidden_state=torch.zeros((*input_ids.shape, cohere_asr_qeff_model.config.hidden_size)),
+                past_key_values=None,
+            )
+
+    monkeypatch.setattr(encoder, "forward", encoder_forward)
+    monkeypatch.setattr(cohere_asr_qeff_model.model, "decoder", Decoder())
+    feature_lengths = torch.tensor([8])
+    for input_features in (torch.randn(1, 8, 16), torch.zeros(1, 8, 1)):
+        cohere_asr_qeff_model(
+            input_features=input_features,
+            input_ids=torch.tensor([[4]]),
+            position_ids=torch.zeros((1, 1), dtype=torch.long),
+            feature_lengths=feature_lengths,
+        )
+
+    assert len(captured) == 2
+    assert torch.equal(captured[0], captured[1])
+
+
+def test_cohere_asr_padding_preserves_valid_encoder_outputs_and_logits(cohere_asr_qeff_model):
+    valid_features = torch.randn(1, 8, 9)
+    padded_features = torch.zeros(1, 8, 16)
+    padded_features[:, :, :9] = valid_features
+    feature_lengths = torch.tensor([9])
+
+    encoder = cohere_asr_qeff_model.model.encoder
+    valid_encoder_outputs = encoder(
+        valid_features.transpose(1, 2), attention_mask=torch.ones((1, 9), dtype=torch.bool)
+    ).last_hidden_state
+    padded_encoder_outputs = encoder(
+        padded_features.transpose(1, 2),
+        attention_mask=torch.arange(16).unsqueeze(0) < feature_lengths.unsqueeze(1),
+    ).last_hidden_state
+    assert torch.allclose(valid_encoder_outputs, padded_encoder_outputs, atol=1e-5, rtol=1e-5)
+
+    model_inputs = {"input_ids": torch.tensor([[4]]), "position_ids": torch.zeros((1, 1), dtype=torch.long)}
+    valid_logits = cohere_asr_qeff_model(
+        input_features=valid_features,
+        feature_lengths=feature_lengths,
+        past_key_values=[[torch.zeros((1, 2, 4, 4)) for _ in range(2)] + [torch.zeros((1, 2, 2, 4)) for _ in range(2)]],
+        **model_inputs,
+    ).logits
+    padded_logits = cohere_asr_qeff_model(
+        input_features=padded_features,
+        feature_lengths=feature_lengths,
+        past_key_values=[[torch.zeros((1, 2, 4, 4)) for _ in range(2)] + [torch.zeros((1, 2, 2, 4)) for _ in range(2)]],
+        **model_inputs,
+    ).logits
+    assert torch.allclose(valid_logits, padded_logits, atol=1e-5, rtol=1e-5)
+
+
+def test_cohere_asr_large_padding_keeps_parakeet_attention_and_logits_finite():
+    encoder_config = {
+        "model_type": "parakeet_encoder",
+        "num_mel_bins": 8,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 3504,
+        "subsampling_conv_channels": 2,
+        "subsampling_conv_kernel_size": 3,
+        "subsampling_conv_stride": 2,
+        "subsampling_factor": 8,
+        "conv_kernel_size": 3,
+    }
+    config = CohereAsrConfig(
+        encoder_config=encoder_config,
+        vocab_size=64,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        decoder_start_token_id=4,
+    )
+    config._attn_implementation = "eager"
+    torch.manual_seed(0)
+    native_model = CohereAsrForConditionalGeneration(config).eval()
+    qeff_model = QEFFAutoModelForSpeechSeq2Seq(deepcopy(native_model)).model.eval()
+
+    valid_length = 80
+    padded_length = 3504
+    valid_features = torch.randn(1, valid_length, config.encoder_config.num_mel_bins)
+    padded_features = torch.zeros(1, padded_length, config.encoder_config.num_mel_bins)
+    padded_features[:, :valid_length] = valid_features
+    padded_attention_mask = torch.arange(padded_length).unsqueeze(0) < valid_length
+    encoder_output_length = ParakeetEncoder._get_subsampling_output_length(
+        native_model.model.encoder, torch.tensor([padded_length])
+    ).item()
+    valid_encoder_output_length = ParakeetEncoder._get_subsampling_output_length(
+        native_model.model.encoder, torch.tensor([valid_length])
+    ).item()
+
+    captured_attention_outputs = []
+    hooks = []
+    assert isinstance(qeff_model.model.encoder.subsampling, QEffParakeetEncoderSubsamplingConv2D)
+    for encoder_layer in qeff_model.model.encoder.layers:
+        assert isinstance(encoder_layer.self_attn, QEffParakeetEncoderAttention)
+        hooks.append(
+            encoder_layer.self_attn.register_forward_hook(
+                lambda _module, _inputs, output: captured_attention_outputs.append(output[0].detach())
+            )
+        )
+
+    try:
+        with torch.no_grad():
+            native_subsampled_states = native_model.model.encoder.subsampling(valid_features.repeat(2, 1, 1))
+            qeff_subsampled_states = qeff_model.model.encoder.subsampling(
+                padded_features.repeat(2, 1, 1), padded_attention_mask.repeat(2, 1)
+            )
+            native_encoder_states = native_model.model.encoder(
+                valid_features.repeat(2, 1, 1), attention_mask=torch.ones((2, valid_length), dtype=torch.bool)
+            ).last_hidden_state
+            qeff_encoder_states = qeff_model.model.encoder(
+                padded_features.repeat(2, 1, 1), attention_mask=padded_attention_mask.repeat(2, 1)
+            ).last_hidden_state
+    finally:
+        for hook in hooks:
+            hook.remove()
+
+    assert qeff_encoder_states.shape[1] == encoder_output_length
+    assert torch.isfinite(qeff_encoder_states).all()
+    assert torch.allclose(
+        native_subsampled_states,
+        qeff_subsampled_states[:, :valid_encoder_output_length],
+        atol=1e-5,
+        rtol=1e-5,
+    )
+    assert torch.equal(
+        qeff_subsampled_states[:, valid_encoder_output_length:],
+        torch.zeros_like(qeff_subsampled_states[:, valid_encoder_output_length:]),
+    )
+    assert torch.allclose(
+        native_encoder_states,
+        qeff_encoder_states[:, :valid_encoder_output_length],
+        atol=1e-5,
+        rtol=1e-5,
+    )
+    assert len(captured_attention_outputs) == len(qeff_model.model.encoder.layers)
+    for attention_output in captured_attention_outputs:
+        assert torch.allclose(
+            attention_output[:, valid_encoder_output_length:],
+            torch.zeros_like(attention_output[:, valid_encoder_output_length:]),
+        )
+
+    class Tokenizer:
+        def __init__(self):
+            self.token_ids = {}
+
+        def convert_tokens_to_ids(self, tokens):
+            return [self.token_ids.setdefault(token, len(self.token_ids) + 1) for token in tokens]
+
+    processor = SimpleNamespace(tokenizer=Tokenizer())
+    english_prompt = CohereAsrProcessor.get_decoder_prompt_ids(processor, "en")
+    arabic_prompt = CohereAsrProcessor.get_decoder_prompt_ids(processor, "ar", punctuation=False)
+    input_ids = torch.tensor([english_prompt, arabic_prompt])
+    position_ids = torch.arange(input_ids.shape[1]).unsqueeze(0).expand_as(input_ids)
+
+    with torch.no_grad():
+        native_logits = native_model(
+            input_features=valid_features.repeat(2, 1, 1),
+            attention_mask=torch.ones((2, valid_length), dtype=torch.bool),
+            decoder_input_ids=input_ids,
+            decoder_position_ids=position_ids,
+        ).logits
+        qeff_cache = [
+            [
+                torch.zeros((2, 2, config.max_position_embeddings, 4)),
+                torch.zeros((2, 2, config.max_position_embeddings, 4)),
+                torch.zeros((2, 2, encoder_output_length, 4)),
+                torch.zeros((2, 2, encoder_output_length, 4)),
+            ]
+        ]
+        qeff_logits = qeff_model(
+            input_features=padded_features.transpose(1, 2).repeat(2, 1, 1),
+            feature_lengths=torch.full((2,), valid_length),
+            input_ids=input_ids,
+            position_ids=position_ids,
+            past_key_values=qeff_cache,
+        ).logits
+
+    assert torch.isfinite(native_logits).all()
+    assert torch.isfinite(qeff_logits).all()
+    assert torch.allclose(native_logits, qeff_logits, atol=1e-5, rtol=1e-5)
+
+
+def test_cohere_asr_processor_prompts_include_requested_languages():
+    class Tokenizer:
+        def convert_tokens_to_ids(self, tokens):
+            self.tokens = tokens
+            return list(range(len(tokens)))
+
+    tokenizer = Tokenizer()
+    processor = SimpleNamespace(tokenizer=tokenizer)
+
+    assert CohereAsrProcessor.get_decoder_prompt_ids(processor, "en") == list(range(10))
+    assert tokenizer.tokens[4:7] == ["<|en|>", "<|en|>", "<|pnc|>"]
+    assert CohereAsrProcessor.get_decoder_prompt_ids(processor, "ar", punctuation=False) == list(range(10))
+    assert tokenizer.tokens[4:7] == ["<|ar|>", "<|ar|>", "<|nopnc|>"]
+
+
+def test_cohere_asr_decode_reuses_cross_attention_cache(cohere_asr_qeff_model):
+    cache = [[]]
+    for cache_type in ["self", "cross"]:
+        for _ in ["key", "value"]:
+            cache[0].append(torch.zeros((1, 2, 4 if cache_type == "self" else 2, 4)))
+
+    prefill_outputs = cohere_asr_qeff_model(
+        input_features=torch.randn(1, 8, 16),
+        feature_lengths=torch.tensor([9]),
+        input_ids=torch.tensor([[4]]),
+        position_ids=torch.tensor([[0]]),
+        past_key_values=cache,
+    )
+    prefill_cross_key = prefill_outputs.past_key_values[0][2].clone()
+    prefill_cross_value = prefill_outputs.past_key_values[0][3].clone()
+    decode_outputs = cohere_asr_qeff_model(
+        input_features=torch.zeros(1, 8, 1),
+        feature_lengths=torch.tensor([9]),
+        input_ids=torch.tensor([[5]]),
+        position_ids=torch.tensor([[1]]),
+        past_key_values=prefill_outputs.past_key_values,
+    )
+
+    assert decode_outputs.logits.shape == (1, 1, 32)
+    assert torch.equal(prefill_cross_key, decode_outputs.past_key_values[0][2])
+    assert torch.equal(prefill_cross_value, decode_outputs.past_key_values[0][3])
+
+
+def test_cohere_asr_native_and_qeff_logits_match_with_cached_decode():
+    encoder_config = {
+        "model_type": "parakeet_encoder",
+        "num_mel_bins": 8,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 32,
+        "subsampling_conv_channels": 2,
+        "subsampling_conv_kernel_size": 3,
+        "subsampling_conv_stride": 2,
+        "subsampling_factor": 8,
+        "conv_kernel_size": 3,
+    }
+    config = CohereAsrConfig(
+        encoder_config=encoder_config,
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        decoder_start_token_id=4,
+    )
+    config._attn_implementation = "eager"
+    torch.manual_seed(0)
+    native_model = CohereAsrForConditionalGeneration(config).eval()
+    qeff_model = QEFFAutoModelForSpeechSeq2Seq(deepcopy(native_model)).model.eval()
+    native_model.config._attn_implementation = "eager"
+    qeff_model.config._attn_implementation = "eager"
+
+    padded_features = torch.randn(2, 8, 24)
+    feature_lengths = torch.tensor([16, 17])
+    frame_mask = torch.arange(padded_features.shape[-1]).unsqueeze(0) < feature_lengths.unsqueeze(1)
+    input_ids = torch.tensor([[4], [4]])
+    position_ids = torch.zeros_like(input_ids)
+    native_subsampled_lengths = ParakeetEncoder._get_subsampling_output_length(
+        native_model.model.encoder, feature_lengths
+    )
+    assert torch.equal(native_subsampled_lengths, torch.tensor([2, 3]))
+    encoder_output_length = ParakeetEncoder._get_subsampling_output_length(
+        native_model.model.encoder, torch.tensor([padded_features.shape[-1]])
+    ).item()
+    qeff_cache = [
+        [
+            torch.zeros((2, 2, 4, 4)),
+            torch.zeros((2, 2, 4, 4)),
+            torch.zeros((2, 2, encoder_output_length, 4)),
+            torch.zeros((2, 2, encoder_output_length, 4)),
+        ]
+    ]
+    native_encoder_outputs = native_model.model.encoder(padded_features.transpose(1, 2), attention_mask=frame_mask)
+    raw_encoder_hidden_states = native_encoder_outputs.last_hidden_state
+    encoder_attention_mask = (
+        torch.arange(raw_encoder_hidden_states.shape[1]).unsqueeze(0) < native_subsampled_lengths.unsqueeze(1)
+    ).long()
+    valid_encoder_output_mask = encoder_attention_mask.bool()
+    valid_encoder_state_mask = valid_encoder_output_mask.unsqueeze(-1).expand_as(raw_encoder_hidden_states)
+    raw_nan_mask = torch.isnan(raw_encoder_hidden_states)
+    assert raw_nan_mask.any()
+    assert torch.all(~raw_nan_mask | ~valid_encoder_state_mask)
+
+    sanitized_encoder_hidden_states = torch.where(
+        valid_encoder_output_mask.unsqueeze(-1), raw_encoder_hidden_states, torch.zeros_like(raw_encoder_hidden_states)
+    )
+    assert torch.equal(
+        sanitized_encoder_hidden_states[valid_encoder_state_mask], raw_encoder_hidden_states[valid_encoder_state_mask]
+    )
+    assert torch.equal(
+        sanitized_encoder_hidden_states[~valid_encoder_state_mask],
+        torch.zeros_like(sanitized_encoder_hidden_states[~valid_encoder_state_mask]),
+    )
+
+    native_decoder_outputs = native_model.model.decoder(
+        input_ids=input_ids,
+        position_ids=position_ids,
+        encoder_hidden_states=sanitized_encoder_hidden_states,
+        encoder_attention_mask=encoder_attention_mask,
+        past_key_values=EncoderDecoderCache(DynamicCache(), DynamicCache()),
+        use_cache=True,
+    )
+    native_prefill_logits = native_model.proj_out(native_decoder_outputs.last_hidden_state)
+    qeff_prefill = qeff_model(
+        input_features=padded_features,
+        feature_lengths=feature_lengths,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        past_key_values=qeff_cache,
+        use_cache=True,
+    )
+
+    assert torch.isfinite(native_prefill_logits).all()
+    assert torch.isfinite(qeff_prefill.logits).all()
+    prefill_max_abs_diff = (native_prefill_logits - qeff_prefill.logits).abs().max().item()
+    print(f"prefill max absolute difference: {prefill_max_abs_diff:.3e}")
+    assert prefill_max_abs_diff <= 1e-5, f"prefill max absolute difference: {prefill_max_abs_diff:.3e}"
+
+    decode_input_ids = torch.tensor([[5], [5]])
+    decode_position_ids = torch.ones_like(decode_input_ids)
+    native_decode_outputs = native_model.model.decoder(
+        input_ids=decode_input_ids,
+        position_ids=decode_position_ids,
+        encoder_hidden_states=sanitized_encoder_hidden_states,
+        encoder_attention_mask=encoder_attention_mask,
+        past_key_values=native_decoder_outputs.past_key_values,
+        use_cache=True,
+    )
+    native_decode_logits = native_model.proj_out(native_decode_outputs.last_hidden_state)
+    qeff_decode = qeff_model(
+        input_features=torch.zeros(2, 8, 1),
+        feature_lengths=feature_lengths,
+        input_ids=decode_input_ids,
+        position_ids=decode_position_ids,
+        past_key_values=qeff_prefill.past_key_values,
+        use_cache=True,
+    )
+
+    assert torch.isfinite(native_decode_logits).all()
+    assert torch.isfinite(qeff_decode.logits).all()
+    decode_max_abs_diff = (native_decode_logits - qeff_decode.logits).abs().max().item()
+    print(f"cached decode max absolute difference: {decode_max_abs_diff:.3e}")
+    assert decode_max_abs_diff <= 1e-5, f"cached decode max absolute difference: {decode_max_abs_diff:.3e}"
+
+
+def test_cohere_asr_qeff_pytorch_and_ort_match_with_cached_decode(tmp_path, cohere_asr_qeff_model):
+    qeff_wrapper = QEFFAutoModelForSpeechSeq2Seq(deepcopy(cohere_asr_qeff_model))
+    qeff_model = qeff_wrapper.model.eval()
+    padded_features = torch.randn(2, 8, 24)
+    feature_lengths = torch.tensor([16, 17])
+    input_ids = torch.tensor([[4], [4]])
+    position_ids = torch.zeros_like(input_ids)
+    output_names = qeff_model.get_output_names()
+    encoder_output_length = ParakeetEncoder._get_subsampling_output_length(
+        qeff_model.model.encoder, torch.tensor([padded_features.shape[-1]])
+    ).item()
+
+    def make_zero_cache():
+        return [
+            [
+                torch.zeros((2, 2, 4, 4)),
+                torch.zeros((2, 2, 4, 4)),
+                torch.zeros((2, 2, encoder_output_length, 4)),
+                torch.zeros((2, 2, encoder_output_length, 4)),
+            ]
+        ]
+
+    with torch.no_grad():
+        qeff_prefill = qeff_model(
+            input_features=padded_features,
+            feature_lengths=feature_lengths,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            past_key_values=make_zero_cache(),
+            use_cache=True,
+        )
+        qeff_prefill_outputs = [qeff_prefill.logits.clone()] + [
+            cache_tensor.clone() for layer_cache in qeff_prefill.past_key_values for cache_tensor in layer_cache
+        ]
+        qeff_decode = qeff_model(
+            input_features=torch.zeros(2, 8, 1),
+            feature_lengths=feature_lengths,
+            input_ids=torch.tensor([[5], [5]]),
+            position_ids=torch.ones_like(input_ids),
+            past_key_values=qeff_prefill.past_key_values,
+            use_cache=True,
+        )
+        qeff_decode_outputs = [qeff_decode.logits.clone()] + [
+            cache_tensor.clone() for layer_cache in qeff_decode.past_key_values for cache_tensor in layer_cache
+        ]
+    assert len(qeff_prefill_outputs) == len(output_names)
+    assert len(qeff_decode_outputs) == len(output_names)
+    assert all(torch.isfinite(output).all() for output in qeff_prefill_outputs + qeff_decode_outputs)
+    assert torch.count_nonzero(qeff_prefill_outputs[1][:, :, 0, :]).item() > 0
+    assert not torch.equal(qeff_prefill_outputs[1][:, :, 1, :], qeff_decode_outputs[1][:, :, 1, :])
+    assert torch.equal(qeff_prefill_outputs[3], qeff_decode_outputs[3])
+    assert torch.equal(qeff_prefill_outputs[4], qeff_decode_outputs[4])
+
+    onnx_path = qeff_wrapper.export(export_dir=tmp_path)
+    onnx_model = onnx.load(onnx_path, load_external_data=False)
+    feature_lengths_input = next(value for value in onnx_model.graph.input if value.name == "feature_lengths")
+    assert feature_lengths_input.type.tensor_type.elem_type == onnx.TensorProto.INT64
+    assert feature_lengths_input.type.tensor_type.shape.dim[0].dim_param == "batch_size"
+
+    added_initializers = {}
+    for node in onnx_model.graph.node:
+        if node.op_type == "Constant":
+            constant_value = onnx.numpy_helper.to_array(node.attribute[0].t, os.path.dirname(onnx_path))
+            if len(constant_value.shape) == 0 and constant_value.item() == 2147483647:
+                added_initializers[node.output[0]] = onnxruntime.OrtValue.ortvalue_from_numpy(
+                    np.array(0, constant_value.dtype)
+                )
+
+    session_options = onnxruntime.SessionOptions()
+    for name, value in added_initializers.items():
+        session_options.add_initializer(name, value)
+    session = onnxruntime.InferenceSession(onnx_path, session_options)
+
+    def run_ort(input_features, input_ids, position_ids, past_key_values):
+        ort_inputs = {
+            "input_features": input_features.numpy(),
+            "feature_lengths": feature_lengths.numpy(),
+            "input_ids": input_ids.numpy(),
+            "position_ids": position_ids.numpy(),
+        }
+        for output_name, cache_tensor in zip(
+            output_names[1:], [cache for layer_cache in past_key_values for cache in layer_cache]
+        ):
+            ort_inputs[output_name.removesuffix("_RetainedState")] = cache_tensor.numpy()
+        return session.run(output_names, ort_inputs)
+
+    ort_initial_cache = make_zero_cache()
+    assert all(
+        torch.count_nonzero(cache_tensor).item() == 0
+        for layer_cache in ort_initial_cache
+        for cache_tensor in layer_cache
+    )
+    ort_prefill_outputs = [
+        output.copy() for output in run_ort(padded_features, input_ids, position_ids, ort_initial_cache)
+    ]
+    ort_decode_outputs = [
+        output.copy()
+        for output in run_ort(
+            torch.zeros(2, 8, 1),
+            torch.tensor([[5], [5]]),
+            torch.ones_like(input_ids),
+            [[torch.from_numpy(output) for output in ort_prefill_outputs[1:]]],
+        )
+    ]
+
+    assert np.count_nonzero(ort_prefill_outputs[1][:, :, 0, :]) > 0
+    assert not np.array_equal(ort_prefill_outputs[1][:, :, 1, :], ort_decode_outputs[1][:, :, 1, :])
+    assert np.array_equal(ort_prefill_outputs[3], ort_decode_outputs[3])
+    assert np.array_equal(ort_prefill_outputs[4], ort_decode_outputs[4])
+
+    for output_kind, qeff_outputs, ort_outputs in [
+        ("prefill", qeff_prefill_outputs, ort_prefill_outputs),
+        ("decode", qeff_decode_outputs, ort_decode_outputs),
+    ]:
+        for output_name, qeff_output, ort_output in zip(output_names, qeff_outputs, ort_outputs):
+            assert np.isfinite(ort_output).all()
+            max_abs_diff = np.max(np.abs(qeff_output.numpy() - ort_output))
+            print(f"{output_kind} {output_name} max absolute difference: {max_abs_diff:.3e}")
+            assert max_abs_diff <= 1e-5, f"{output_kind} {output_name} max absolute difference: {max_abs_diff:.3e}"
+
+
+def test_speech_generate_consumes_decoder_prompt_and_retains_feature_lengths(
+    cohere_asr_qeff_model, monkeypatch, tmp_path
+):
+    batch_size = 2
+    vocab_size = cohere_asr_qeff_model.config.vocab_size
+    eos_token_id = cohere_asr_qeff_model.config.eos_token_id
+
+    class Session:
+        input_names = ["input_features", "feature_lengths", "input_ids", "position_ids"]
+        output_names = ["logits"]
+        bindings = [SimpleNamespace(dims=(batch_size, 8, 16))]
+        binding_index_map = {"input_features": 0}
+
+        def __init__(self, *_args, **_kwargs):
+            self.calls = []
+            self.output_shapes = []
+
+        def skip_buffers(self, _names):
+            pass
+
+        def set_buffers(self, _outputs):
+            pass
+
+        def run(self, inputs):
+            self.calls.append({name: value.copy() for name, value in inputs.items()})
+            logits = np.zeros(
+                (inputs["input_ids"].shape[0], inputs["input_ids"].shape[1], vocab_size), dtype=np.float32
+            )
+            if len(self.calls) == 4:
+                logits[0, ..., eos_token_id] = 1.0
+                logits[1, ..., 6] = 1.0
+            elif len(self.calls) == 5:
+                logits[0, ..., 7] = 1.0
+                logits[1, ..., eos_token_id] = 1.0
+            else:
+                logits[..., 5] = 1.0
+            self.output_shapes.append(logits.shape)
+            return {"logits": logits}
+
+    wrapper = object.__new__(QEFFAutoModelForSpeechSeq2Seq)
+    wrapper.model = cohere_asr_qeff_model
+    wrapper.qpc_path = tmp_path
+    wrapper.onnx_path = tmp_path / "model.onnx"
+    wrapper.qpc_session = None
+    monkeypatch.setattr("QEfficient.transformers.models.modeling_auto.QAICInferenceSession", Session)
+
+    attention_mask = torch.tensor([[1] * 8 + [0] * 8, [1] * 13 + [0] * 3])
+    input_features = torch.randn(2, 13, 8)
+    decoder_prompt = torch.tensor([[1, 2, 3], [1, 4, 3]], dtype=torch.int64)
+    result = wrapper.generate(
+        inputs={
+            "input_features": input_features,
+            "attention_mask": attention_mask,
+            "decoder_input_ids": decoder_prompt,
+        },
+        generation_len=3,
+    )
+
+    assert len(wrapper.qpc_session.calls) == 5
+    assert wrapper.qpc_session.output_shapes == [(batch_size, 1, vocab_size)] * 5
+    assert [call["input_ids"].tolist() for call in wrapper.qpc_session.calls] == [
+        [[1], [1]],
+        [[2], [4]],
+        [[3], [3]],
+        [[5], [5]],
+        [[eos_token_id], [6]],
+    ]
+    assert [call["position_ids"].tolist() for call in wrapper.qpc_session.calls] == [
+        [[0], [0]],
+        [[1], [1]],
+        [[2], [2]],
+        [[3], [3]],
+        [[4], [4]],
+    ]
+    expected_features = torch.nn.functional.pad(input_features.transpose(1, 2), (0, 3)).numpy().astype(np.float16)
+    assert np.array_equal(wrapper.qpc_session.calls[0]["input_features"], expected_features)
+    for call in wrapper.qpc_session.calls[1:]:
+        assert np.count_nonzero(call["input_features"]) == 0
+    for call in wrapper.qpc_session.calls:
+        assert np.array_equal(call["feature_lengths"], np.array([8, 13], dtype=np.int64))
+    assert np.array_equal(
+        result.generated_ids,
+        np.array([[1, 2, 3, 5, eos_token_id, eos_token_id], [1, 4, 3, 5, 6, eos_token_id]], dtype=np.int64),
+    )
+
+
+def test_speech_generate_defaults_to_single_decoder_start_token(cohere_asr_qeff_model, monkeypatch, tmp_path):
+    batch_size = 2
+    vocab_size = cohere_asr_qeff_model.config.vocab_size
+    start_token_id = cohere_asr_qeff_model.config.decoder_start_token_id
+
+    class Session:
+        input_names = ["input_features", "input_ids", "position_ids"]
+        output_names = ["logits"]
+        bindings = [SimpleNamespace(dims=(batch_size, 8, 16))]
+        binding_index_map = {"input_features": 0}
+
+        def __init__(self, *_args, **_kwargs):
+            self.calls = []
+
+        def skip_buffers(self, _names):
+            pass
+
+        def set_buffers(self, _outputs):
+            pass
+
+        def run(self, inputs):
+            self.calls.append({name: value.copy() for name, value in inputs.items()})
+            logits = np.zeros((batch_size, 1, vocab_size), dtype=np.float32)
+            logits[..., 5] = 1.0
+            return {"logits": logits}
+
+    wrapper = object.__new__(QEFFAutoModelForSpeechSeq2Seq)
+    wrapper.model = cohere_asr_qeff_model
+    wrapper.qpc_path = tmp_path
+    wrapper.onnx_path = tmp_path / "model.onnx"
+    wrapper.qpc_session = None
+    monkeypatch.setattr("QEfficient.transformers.models.modeling_auto.QAICInferenceSession", Session)
+
+    result = wrapper.generate(
+        inputs={
+            "input_features": torch.randn(2, 8, 16),
+            "attention_mask": torch.ones((2, 16), dtype=torch.int64),
+        },
+        generation_len=1,
+    )
+
+    assert len(wrapper.qpc_session.calls) == 1
+    assert wrapper.qpc_session.calls[0]["input_ids"].tolist() == [[start_token_id], [start_token_id]]
+    assert wrapper.qpc_session.calls[0]["position_ids"].tolist() == [[0], [0]]
+    assert result.generated_ids.tolist() == [[start_token_id, 5], [start_token_id, 5]]
 
 
 def run_seq2seq_pytorch_hf(
@@ -85,6 +799,11 @@ def run_seq2seq_pytorch_hf(
 
     # prepare inputs
     input_features = processor(inputs, sampling_rate=sample_rate, return_tensors="pt").input_features
+    if hasattr(model.config, "encoder_config"):
+        # Composite (encoder_config + decoder_config) architectures such as CohereAsr expose their
+        # plain HF forward()/generate() in the encoder's native (batch, seq_len, num_mel_bins) layout,
+        # unlike Whisper-style configs whose processor output is already mel-bins-major.
+        input_features = input_features.transpose(1, 2)
     decoder_input_ids = torch.ones((batch_size, seq_len), dtype=torch.int64) * model.config.decoder_start_token_id
     decoder_position_ids = torch.arange(seq_len, dtype=torch.int64).view(1, seq_len).repeat(batch_size, 1)
 
@@ -105,27 +824,53 @@ def run_seq2seq_pytorch_hf(
     next_token = logits.argmax(-1)
     generated_ids[:, 1] = next_token.squeeze(1)
 
-    model_inputs["encoder_outputs"] = outputs["encoder_last_hidden_state"]
-    model_inputs["past_key_values"] = outputs["past_key_values"]
+    model_inputs["encoder_outputs"] = SimpleNamespace(
+        last_hidden_state=outputs["encoder_last_hidden_state"],
+        attention_mask=None,
+        hidden_states=None,
+        attentions=None,
+    )
+    pkv = outputs.get("past_key_values")
+    if pkv is not None:
+        model_inputs["past_key_values"] = pkv
+
+    # Track full decoded sequence for models that return no KV cache (e.g. CohereAsr plain HF).
+    # When past_key_values is absent, we must pass the full growing sequence each step so the
+    # decoder has its own token history; Whisper-style models with KV cache only need next_token.
+    accumulated_ids = torch.tensor([[model.config.decoder_start_token_id]], dtype=torch.int64)
 
     for num_tokens in range(generation_len):
         outputs = model(**model_inputs)
         logits = outputs["logits"]
-        next_token = logits.argmax(-1)
+        next_token = logits.argmax(-1)[:, -1:]
         generated_ids[:, num_tokens + 1] = next_token.squeeze(1)
 
         if next_token[0][0] == processor.tokenizer.eos_token_id:
             break
 
-        model_inputs["decoder_input_ids"] = next_token
-        model_inputs["decoder_position_ids"] += 1
-        model_inputs["past_key_values"] = outputs["past_key_values"]
+        pkv = outputs.get("past_key_values")
+        if pkv is not None:
+            model_inputs["past_key_values"] = pkv
+            model_inputs["decoder_input_ids"] = next_token
+            model_inputs["decoder_position_ids"] = model_inputs["decoder_position_ids"][:, -1:] + 1
+        else:
+            # No KV cache: accumulate tokens and pass the full growing sequence
+            accumulated_ids = torch.cat([accumulated_ids, next_token], dim=1)
+            model_inputs["decoder_input_ids"] = accumulated_ids
+            model_inputs["decoder_position_ids"] = torch.arange(accumulated_ids.shape[1], dtype=torch.int64).unsqueeze(
+                0
+            )
 
     return generated_ids[0]
 
 
 def run_seq2seq_pytorch_with_kv(
-    model, processor: AutoProcessor, inputs: np.ndarray, sample_rate: int, generation_len: int
+    model,
+    processor: AutoProcessor,
+    inputs: np.ndarray,
+    sample_rate: int,
+    generation_len: int,
+    cross_ctx_len: Optional[int] = None,
 ) -> List[str]:
     """
     Run pytorch inference on model
@@ -136,6 +881,12 @@ def run_seq2seq_pytorch_with_kv(
         :inputs (np.ndarray): inputs to run the execution.
         :sample_rate (int): sampling rate at which input audio is stored in inputs (needed for processor)
         :generation_len (int): length upto which to generate
+
+    ``Optional`` Args:
+        :cross_ctx_len (int): cross-attention KV cache context length. Defaults to
+            ``config.max_source_positions`` when the config exposes it (Whisper-style);
+            composite (encoder_config + decoder_config) architectures such as CohereAsr have
+            no such static field and must pass the actual encoder output length instead.
 
     Returns:
         torch.Tensor: A list of output features generated by the model for each prompt.
@@ -158,7 +909,9 @@ def run_seq2seq_pytorch_with_kv(
 
     # prepare dummy past kvs and cross kvs
     kv_cache_shape = get_padding_shape_from_config(config, batch_size, generation_len)
-    kv_cross_cache_shape = get_padding_shape_from_config(config, batch_size, config.max_source_positions)
+    if cross_ctx_len is None:
+        cross_ctx_len = config.max_source_positions
+    kv_cross_cache_shape = get_padding_shape_from_config(config, batch_size, cross_ctx_len)
 
     for i in range(config.num_hidden_layers):
         for self_cross in ["self", "cross"]:
@@ -197,7 +950,13 @@ def run_seq2seq_pytorch_with_kv(
 
 
 def run_seq2seq_ort(
-    onnx_path, config, processor: AutoProcessor, inputs: np.ndarray, sample_rate: int, generation_len: int
+    onnx_path,
+    config,
+    processor: AutoProcessor,
+    inputs: np.ndarray,
+    sample_rate: int,
+    generation_len: int,
+    cross_ctx_len: Optional[int] = None,
 ) -> List[str]:
     """
     Run onnxruntime inference on model
@@ -208,6 +967,12 @@ def run_seq2seq_ort(
         :inputs (np.ndarray): inputs to run the execution.
         :sample_rate (int): sampling rate at which input audio is stored in inputs (needed for processor)
         :generation_len (int): length upto which to generate
+
+    ``Optional`` Args:
+        :cross_ctx_len (int): cross-attention KV cache context length. Defaults to
+            ``config.max_source_positions`` when the config exposes it (Whisper-style);
+            composite (encoder_config + decoder_config) architectures such as CohereAsr have
+            no such static field and must pass the actual encoder output length instead.
 
     Returns:
         torch.Tensor: A list of output features generated by the model for each prompt.
@@ -246,7 +1011,9 @@ def run_seq2seq_ort(
 
     # prepare dummy past kvs and cross kvs
     kv_cache_shape = get_padding_shape_from_config(config, batch_size, generation_len)
-    kv_cross_cache_shape = get_padding_shape_from_config(config, batch_size, config.max_source_positions)
+    if cross_ctx_len is None:
+        cross_ctx_len = config.max_source_positions
+    kv_cross_cache_shape = get_padding_shape_from_config(config, batch_size, cross_ctx_len)
 
     pkv_names = []
     for i in range(config.num_hidden_layers):
@@ -326,13 +1093,34 @@ def check_seq2seq_pytorch_vs_kv_vs_ort_vs_ai100(
 
     qeff_model = QEFFAutoModelForSpeechSeq2Seq(model_hf, pretrained_model_name_or_path=model_name)
 
-    pytorch_kv_tokens = run_seq2seq_pytorch_with_kv(qeff_model, processor, data, sample_rate, ctx_len)
+    cross_ctx_len = None
+    if not hasattr(qeff_model.model.config, "max_source_positions"):
+        # Composite (encoder_config + decoder_config) architectures such as CohereAsr expose no
+        # static cross-attention context length; derive it from an actual encoder forward pass
+        # (a decoder-side max_position_embeddings-like field produces the wrong length here).
+        encoder_input_features = processor(
+            data, sampling_rate=sample_rate, return_tensors="pt"
+        ).input_features.transpose(1, 2)
+        with torch.no_grad():
+            cross_ctx_len = qeff_model.model.model.encoder(encoder_input_features).last_hidden_state.shape[1]
+
+    pytorch_kv_tokens = run_seq2seq_pytorch_with_kv(
+        qeff_model, processor, data, sample_rate, ctx_len, cross_ctx_len=cross_ctx_len
+    )
     assert (pytorch_hf_tokens == pytorch_kv_tokens).all(), (
         "Tokens don't match for HF PyTorch model output and KV PyTorch model output"
     )
 
     qeff_model.export()
-    ort_tokens = run_seq2seq_ort(qeff_model.onnx_path, qeff_model.model.config, processor, data, sample_rate, ctx_len)
+    ort_tokens = run_seq2seq_ort(
+        qeff_model.onnx_path,
+        qeff_model.model.config,
+        processor,
+        data,
+        sample_rate,
+        ctx_len,
+        cross_ctx_len=cross_ctx_len,
+    )
     assert (pytorch_kv_tokens == ort_tokens).all(), "Tokens don't match for pytorch output and ort output"
 
     qeff_model.compile(

--- a/tests/transformers/models/audio_models/test_speech_seq2seq_models.py
+++ b/tests/transformers/models/audio_models/test_speech_seq2seq_models.py
@@ -397,6 +397,63 @@ def test_cohere_asr_decode_reuses_cross_attention_cache(cohere_asr_qeff_model):
     assert torch.equal(prefill_cross_value, decode_outputs.past_key_values[0][3])
 
 
+@pytest.mark.parametrize("batch_indices", [torch.tensor([[2]]), torch.tensor([[1], [3]])])
+def test_cohere_asr_continuous_batching_updates_only_owned_cache_rows(cohere_asr_qeff_model, batch_indices):
+    active_batch_size = batch_indices.shape[0]
+    full_batch_size = 4
+    cache = [[
+        torch.zeros((full_batch_size, 2, 4, 4)),
+        torch.zeros((full_batch_size, 2, 4, 4)),
+        torch.zeros((full_batch_size, 2, 2, 4)),
+        torch.zeros((full_batch_size, 2, 2, 4)),
+    ]]
+
+    outputs = cohere_asr_qeff_model(
+        input_features=torch.randn(active_batch_size, 8, 16),
+        feature_lengths=torch.full((active_batch_size,), 9),
+        input_ids=torch.full((active_batch_size, 1), 4),
+        position_ids=torch.zeros((active_batch_size, 1), dtype=torch.int64),
+        batch_index=batch_indices,
+        past_key_values=cache,
+        use_cache=True,
+    )
+
+    owned_rows = set(batch_indices.view(-1).tolist())
+    for row in range(full_batch_size):
+        if row in owned_rows:
+            assert any(torch.count_nonzero(cache_tensor[row]).item() > 0 for cache_tensor in outputs.past_key_values[0])
+        else:
+            for cache_tensor in outputs.past_key_values[0]:
+                assert torch.count_nonzero(cache_tensor[row]).item() == 0
+
+    cross_key_before_decode = outputs.past_key_values[0][2].clone()
+    cross_value_before_decode = outputs.past_key_values[0][3].clone()
+    decode_outputs = cohere_asr_qeff_model(
+        input_features=torch.zeros(active_batch_size, 8, 1),
+        feature_lengths=torch.full((active_batch_size,), 9),
+        input_ids=torch.full((active_batch_size, 1), 5),
+        position_ids=torch.ones((active_batch_size, 1), dtype=torch.int64),
+        batch_index=batch_indices,
+        past_key_values=outputs.past_key_values,
+        use_cache=True,
+    )
+
+    assert torch.equal(cross_key_before_decode, decode_outputs.past_key_values[0][2])
+    assert torch.equal(cross_value_before_decode, decode_outputs.past_key_values[0][3])
+
+
+def test_cohere_asr_continuous_batching_export_contract(tmp_path, cohere_asr_qeff_model):
+    wrapper = QEFFAutoModelForSpeechSeq2Seq(deepcopy(cohere_asr_qeff_model), continuous_batching=True)
+    onnx_path = wrapper.export(export_dir=tmp_path, batch_size=1, full_batch_size=4, encoder_ctx_len=2)
+    onnx_model = onnx.load(onnx_path, load_external_data=False)
+    graph_inputs = {value.name: value for value in onnx_model.graph.input}
+
+    assert "batch_index" in graph_inputs
+    assert graph_inputs["batch_index"].type.tensor_type.shape.dim[0].dim_param == "batch_size"
+    assert graph_inputs["past_key_self.0"].type.tensor_type.shape.dim[0].dim_param == "full_batch_size"
+    assert graph_inputs["past_key_cross.0"].type.tensor_type.shape.dim[0].dim_param == "full_batch_size"
+
+
 def test_cohere_asr_native_and_qeff_logits_match_with_cached_decode():
     encoder_config = {
         "model_type": "parakeet_encoder",

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -44,6 +44,8 @@ from transformers import (
     AutoModelForSequenceClassification,
     AutoModelForSpeechSeq2Seq,
     AutoTokenizer,
+    CohereAsrConfig,
+    CohereAsrForConditionalGeneration,
     LlamaConfig,
     Qwen2Config,
 )
@@ -1230,6 +1232,42 @@ def test_whisper_export_smoke(tmp_path):
 
     qeff_model = QEFFAutoModelForSpeechSeq2Seq(model_hf, pretrained_model_name_or_path=TINY_WHISPER_MODEL_ID)
     onnx_path = _run_whisper_export_smoke(qeff_model, tmp_path / "whisper")
+
+    assert onnx_path.name.endswith(".onnx")
+
+
+@pytest.mark.llm_model
+def test_cohere_asr_export_smoke(tmp_path):
+    encoder_config = {
+        "model_type": "parakeet_encoder",
+        "num_mel_bins": 8,
+        "hidden_size": 8,
+        "intermediate_size": 16,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 2,
+        "max_position_embeddings": 32,
+        "subsampling_conv_channels": 2,
+        "subsampling_conv_kernel_size": 3,
+        "subsampling_conv_stride": 2,
+        "subsampling_factor": 8,
+        "conv_kernel_size": 3,
+    }
+    config = CohereAsrConfig(
+        encoder_config=encoder_config,
+        vocab_size=32,
+        hidden_size=8,
+        intermediate_size=16,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        decoder_start_token_id=4,
+    )
+    model_hf = CohereAsrForConditionalGeneration(config).eval()
+
+    qeff_model = QEFFAutoModelForSpeechSeq2Seq(model_hf, pretrained_model_name_or_path="tiny-random/cohere-asr")
+    onnx_path = _run_whisper_export_smoke(qeff_model, tmp_path / "cohere_asr")
 
     assert onnx_path.name.endswith(".onnx")
 


### PR DESCRIPTION
This is based on a customer request.

**Accuracy results**
The evaluation covered all 2,620 LibriSpeech test.clean clips. AI100 WER was 1.2432%, compared with 1.2413% from native Hugging Face and 1.25% published by Cohere. Every clip reached EOS and none hit the 500-token limit.

**Perf Numbers** 
AI100 Configs:
One AI100, 16 cores
FP16 weights and retained state
Feature context: 3504 frames
Encoder context: 438 frames
Decoder context: 512 tokens
Greedy decoding, max_new_tokens=500
Processor chunking: 35 seconds with 5-second overlap
Compiled batches: 1, 2, 4, 8, 16, and 32

**Decoder Roofline:**
At batch 16, the decoder executed 2,324.57 token slots/s against a calculated ceiling of 2,836.90 slots/s, for 81.94% attainment. Generated output was 1,568.11 tokens/s. These token metrics describe decoder efficiency; RTFx is the primary ASR throughput metric.

**RTFx includes processing, QPC execution, host decoding, and retained state reset.**
<img width="1065" height="387" alt="image" src="https://github.com/user-attachments/assets/127f1137-2afb-4070-b0c9-37bf3dc572f9" />


---
- Add CohereAsrForConditionalGeneration modeling with encoder/decoder cross-attention, retained-state KV cache, and valid_frames attention mask
- Wire CohereAsr into QEFFAutoModelForSpeechSeq2Seq auto classes
- Add pytorch_transforms registration for cohere_asr
- Add QPC-only inference example (examples/audio/cohere_asr_inference.py)
- Register cohere_asr in quickcheck gate and audio model test configs
- Add full test suite for export, compile, and hardware parity
- Hardware validated: HF fp32 == QPC fp16 token-for-token on LibriSpeech