### PR TITLE
Prevent mdp generator from unrolling onnx subfunctions

### DIFF
--- a/QEfficient/compile/mdp_generator.py
+++ b/QEfficient/compile/mdp_generator.py
@@ -321,13 +321,7 @@ def generate_disagg_mdp_partition_config(
         else:
             partition_idx = 0 if not seen_first_layer else current_layer_partition
 
-        if node.op_type in inlined_functions:
-            # Expand the call-site inline: emit sub-nodes at this topological position.
-            func = local_functions[node.op_type]
-            sub_nodes = [f"{node.name}/{fn.name}" for fn in func.node if fn.name]
-            partitions[partition_idx].extend(sub_nodes)
-        else:
-            partitions[partition_idx].append(node.name)
+        partitions[partition_idx].append(node.name)
 
     for i, partition in enumerate(partitions):
         logger.info(f"Partition {i}: {len(partition)} nodes")

--- a/QEfficient/compile/mdp_generator.py
+++ b/QEfficient/compile/mdp_generator.py
@@ -296,10 +296,6 @@ def generate_disagg_mdp_partition_config(
     folded_nodes = _get_compiler_folded_nodes(model.graph)
     logger.info(f"Found {len(folded_nodes)} compiler-folded nodes (excluded from nodeList)")
 
-    _, non_inlined_functions = _get_inlined_node_map(model)
-    inlined_functions = {f.name for f in model.functions} - non_inlined_functions
-    local_functions = {f.name: f for f in model.functions}
-
     # Single pass: assign main-graph nodes by layer index.  Inlined call-sites
     # are expanded in topological position so nodeList order matches the ONNX
     # topsort — required by the compiler's SplitPlanMerge.


### PR DESCRIPTION
Changed mdp generator that VLLM uses to avoid unrolling onnx subfunctions into all nodes within