### PR TITLE
feat(0831): Localize constant ReduceSum axes inside ONNX subfunctions

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -25,6 +25,7 @@ from QEfficient.base.onnx_transforms import (
     BaseOnnxTransform,
     CustomOpTransform,
     FP16ClipTransform,
+    LocalizeFunctionReduceSumAxesTransform,
     OnnxTransformPipeline,
     RenameFunctionOutputsTransform,
     SplitTensorsTransform,
@@ -942,6 +943,8 @@ class QEFFBaseModel(ABC):
             "layer_idx": idx,
         }
         _onnx_transforms = [SplitTensorsTransform, CustomOpTransform, RenameFunctionOutputsTransform]
+        if export_kwargs.get("use_onnx_subfunctions", False):
+            _onnx_transforms.append(LocalizeFunctionReduceSumAxesTransform)
         onnx_transforms = OnnxTransformPipeline(transforms=_onnx_transforms)
         model, transformed = onnx_transforms.apply(model, **transform_kwargs)
 

--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -615,6 +615,226 @@ class RenameWsubNodesTransform(BaseOnnxTransform):
         return transformed
 
 
+class LocalizeFunctionReduceSumAxesTransform(BaseOnnxTransform):
+    """Move constant ReduceSum axes from ONNX function arguments into the function body.
+
+    ONNX subfunction export can lift a constant axes tensor out of a FunctionProto
+    and make it a formal argument. That is semantically valid ONNX, but downstream
+    compilation then sees ReduceSum axes as a runtime parameter. This transform is
+    intentionally narrow: it only rewrites ReduceSum input-1 when that value is a
+    function input and every top-level call site passes the same integer constant.
+    """
+
+    _INTEGER_TENSOR_TYPES = {
+        TensorProto.INT8,
+        TensorProto.INT16,
+        TensorProto.INT32,
+        TensorProto.INT64,
+        TensorProto.UINT8,
+        TensorProto.UINT16,
+        TensorProto.UINT32,
+        TensorProto.UINT64,
+    }
+
+    @classmethod
+    def apply(cls, model: ModelProto) -> bool:
+        """Localize eligible ReduceSum axes constants for all functions in ``model``.
+
+        Returns ``True`` only when a function signature and its call nodes were
+        rewritten. Unsupported cases, including dynamic axes, mismatched constants,
+        nested function call sites, and non-ReduceSum uses of the same formal input,
+        are left unchanged.
+        """
+        transformed = False
+        graph_constants = cls._collect_graph_constants(model.graph)
+
+        for function in model.functions:
+            function_inputs = list(function.input)
+            if not function_inputs or cls._has_nested_call_site(model, function):
+                continue
+
+            call_sites = cls._find_graph_call_sites(model, function)
+            if not call_sites:
+                continue
+
+            axes_inputs = cls._find_reduce_sum_axes_inputs(function, function_inputs)
+            for axes_name, reduce_nodes in sorted(
+                axes_inputs.items(), key=lambda item: function_inputs.index(item[0]), reverse=True
+            ):
+                formal_index = function_inputs.index(axes_name)
+                axes_tensor = cls._resolve_shared_axes_tensor(call_sites, graph_constants, formal_index)
+                if axes_tensor is None:
+                    continue
+
+                local_axes_name = cls._insert_axes_constant(function, axes_name, axes_tensor)
+                for reduce_node in reduce_nodes:
+                    reduce_node.input[1] = local_axes_name
+
+                del function.input[formal_index]
+                for call_node in call_sites:
+                    del call_node.input[formal_index]
+                transformed = True
+
+        return transformed
+
+    @classmethod
+    def _find_reduce_sum_axes_inputs(
+        cls, function: onnx.FunctionProto, function_inputs: List[str]
+    ) -> Dict[str, List[onnx.NodeProto]]:
+        """Return formal inputs used only as ReduceSum axes inside ``function``.
+
+        If a formal input is consumed by any other node or by any ReduceSum input
+        other than input 1, removing it from the function signature could change
+        graph semantics. Such inputs are excluded.
+        """
+        formal_inputs = set(function_inputs)
+        axes_inputs: Dict[str, List[onnx.NodeProto]] = {}
+        unsafe_inputs = set()
+
+        for node in function.node:
+            for input_index, input_name in enumerate(node.input):
+                if input_name not in formal_inputs:
+                    continue
+                if node.op_type == "ReduceSum" and input_index == 1:
+                    axes_inputs.setdefault(input_name, []).append(node)
+                else:
+                    unsafe_inputs.add(input_name)
+
+        for input_name in unsafe_inputs:
+            axes_inputs.pop(input_name, None)
+        return axes_inputs
+
+    @staticmethod
+    def _find_graph_call_sites(model: ModelProto, function: onnx.FunctionProto) -> List[onnx.NodeProto]:
+        """Find top-level graph nodes that call ``function``."""
+        return [node for node in model.graph.node if node.op_type == function.name and node.domain == function.domain]
+
+    @staticmethod
+    def _has_nested_call_site(model: ModelProto, function: onnx.FunctionProto) -> bool:
+        """Return whether ``function`` is called from another FunctionProto.
+
+        The pass intentionally resolves constants only in the main graph. If a
+        function is also called from another function, all call sites cannot be
+        proven to pass the same graph constant, so the function is skipped.
+        """
+        for caller_function in model.functions:
+            for node in caller_function.node:
+                if node.op_type == function.name and node.domain == function.domain:
+                    return True
+        return False
+
+    @classmethod
+    def _collect_graph_constants(cls, graph: onnx.GraphProto) -> Dict[str, TensorProto]:
+        """Collect graph-scope constants addressable by value name.
+
+        This supports the common exported ``Constant -> FunctionCall`` form and
+        small initializer-backed axes. It does not load external tensor data or
+        fold producer subgraphs.
+        """
+        constants_by_name = {initializer.name: initializer for initializer in graph.initializer}
+        for node in graph.node:
+            if node.op_type != "Constant" or len(node.output) != 1:
+                continue
+            for attr in node.attribute:
+                if attr.name == "value" and attr.HasField("t"):
+                    constants_by_name[node.output[0]] = attr.t
+                    break
+        return constants_by_name
+
+    @classmethod
+    def _resolve_shared_axes_tensor(
+        cls, call_sites: List[onnx.NodeProto], constants_by_name: Dict[str, TensorProto], formal_index: int
+    ) -> Optional[TensorProto]:
+        """Return the shared integer axes tensor passed by every call site.
+
+        ``None`` means at least one call site is dynamic, missing the argument,
+        passes a non-integer/non-vector tensor, or passes a different value.
+        """
+        shared_value = None
+        shared_tensor = None
+
+        for call_node in call_sites:
+            if len(call_node.input) <= formal_index:
+                return None
+
+            axes_tensor = constants_by_name.get(call_node.input[formal_index])
+            axes_value = cls._to_integer_axes_value(axes_tensor) if axes_tensor is not None else None
+            if axes_value is None:
+                return None
+
+            if shared_value is None:
+                shared_value = axes_value
+                shared_tensor = axes_tensor
+            elif not np.array_equal(shared_value, axes_value):
+                return None
+
+        return shared_tensor
+
+    @classmethod
+    def _to_integer_axes_value(cls, tensor: TensorProto) -> Optional[np.ndarray]:
+        """Convert a TensorProto to a valid ReduceSum axes value, or ``None``.
+
+        Valid axes are scalar or 1-D integer tensors. Empty tensors and non-integer
+        tensors are rejected because they do not represent an explicit static axes
+        list for this transform.
+        """
+        if tensor.data_type not in cls._INTEGER_TENSOR_TYPES:
+            return None
+        try:
+            value = numpy_helper.to_array(tensor)
+        except Exception:
+            return None
+        if value.ndim > 1 or value.size == 0 or not np.issubdtype(value.dtype, np.integer):
+            return None
+        return value.astype(np.int64, copy=False)
+
+    @classmethod
+    def _insert_axes_constant(cls, function: onnx.FunctionProto, axes_name: str, axes_tensor: TensorProto) -> str:
+        """Insert a local Constant node and return its output name."""
+        local_axes_name = cls._make_unique_value_name(function, f"{axes_name}_local")
+        constant_tensor = TensorProto()
+        constant_tensor.CopyFrom(axes_tensor)
+        constant_tensor.name = local_axes_name
+
+        function.node.insert(
+            0,
+            onnx.helper.make_node(
+                "Constant",
+                inputs=[],
+                outputs=[local_axes_name],
+                name=cls._make_unique_node_name(function, f"{local_axes_name}_Constant"),
+                value=constant_tensor,
+            ),
+        )
+        return local_axes_name
+
+    @staticmethod
+    def _make_unique_value_name(function: onnx.FunctionProto, base_name: str) -> str:
+        """Return a value name that does not collide with values in ``function``."""
+        used_names = set(function.input) | set(function.output)
+        for node in function.node:
+            used_names.update(node.input)
+            used_names.update(node.output)
+
+        candidate = base_name
+        suffix = 0
+        while candidate in used_names:
+            suffix += 1
+            candidate = f"{base_name}_{suffix}"
+        return candidate
+
+    @staticmethod
+    def _make_unique_node_name(function: onnx.FunctionProto, base_name: str) -> str:
+        """Return a node name that does not collide with named nodes in ``function``."""
+        used_names = {node.name for node in function.node if node.name}
+        candidate = base_name
+        suffix = 0
+        while candidate in used_names:
+            suffix += 1
+            candidate = f"{base_name}_{suffix}"
+        return candidate
+
+
 class OnnxTransformPipeline(BaseOnnxTransform):
     """Pipeline to apply multiple ONNX transformations in sequence."""
 
@@ -690,6 +910,9 @@ class OnnxTransformPipeline(BaseOnnxTransform):
 
         if RenameWsubNodesTransform in requested:
             applied[RenameWsubNodesTransform] = RenameWsubNodesTransform.apply(model)
+
+        if LocalizeFunctionReduceSumAxesTransform in requested:
+            applied[LocalizeFunctionReduceSumAxesTransform] = LocalizeFunctionReduceSumAxesTransform.apply(model)
 
         if PreserveNestedCacheRetainedStateTransform in requested:
             applied[PreserveNestedCacheRetainedStateTransform] = PreserveNestedCacheRetainedStateTransform.apply(model)

--- a/QEfficient/blocking/attention_blocking.py
+++ b/QEfficient/blocking/attention_blocking.py
@@ -243,6 +243,7 @@ def generic_blocked_attention_interface(
     prefill_only: bool = False,
     **kwargs,
 ):
+    prefill_only = prefill_only or blocking_config.mode.is_prefill
     strategy = _STRATEGIES[
         BlockingMode.get_final_mode(blocking_config, prefill_only=prefill_only, is_mla=is_mla, mla_kwargs=mla_kwargs)
     ]

--- a/QEfficient/blocking/blocked_attention_forwards.py
+++ b/QEfficient/blocking/blocked_attention_forwards.py
@@ -62,7 +62,7 @@ def update_running_softmax(
 
     # update running denominator
     prev_denominator = current_denominator
-    curr_exp_sum = torch.einsum("bhqk->bhq", current_exp)
+    curr_exp_sum = current_exp.sum(dim=-1)
     current_denominator_updated = prev_denominator * torch.exp(delta_max) + curr_exp_sum
 
     prob = current_exp / current_denominator_updated.unsqueeze(-1)
@@ -107,7 +107,7 @@ def update_running_softmax_prefill(
     delta_max = prev_max - current_max_updated
     current_exp = torch.exp(attn_weights_block - current_max_updated.unsqueeze(-1))
     prev_denominator = current_denominator
-    curr_exp_sum = torch.einsum("bhqk->bhq", current_exp)
+    curr_exp_sum = current_exp.sum(dim=-1)
     current_denominator_updated = prev_denominator * torch.exp(delta_max) + curr_exp_sum
     prev_output = output
     output_updated = prev_output * torch.exp(delta_max.unsqueeze(-1)) + torch.matmul(current_exp, v_block)
@@ -333,7 +333,7 @@ def blocked_kv_attention_forward_decode_headpar_batch(
         v_block = past_key_value.read_only_blocked_V_batch(
             start_index, end_index, layer_idx, cache_kwargs, folded_cache=value_cache_folded
         )
-        sum_block = torch.einsum("btdn->btd", exp_block)
+        sum_block = exp_block.sum(dim=-1)
         out_block = torch.matmul(exp_block, v_block)
         if skip_kv and (torch.onnx.is_in_onnx_export() or torch.jit.is_tracing()):
             sum_block = torch.where(skip_future, torch.zeros_like(sum_block), sum_block)
@@ -347,8 +347,8 @@ def blocked_kv_attention_forward_decode_headpar_batch(
     out_stacked = torch.stack(out_blocks)
     block_max = max_stacked.max(dim=0).values
     block_weight = torch.exp(max_stacked - block_max.unsqueeze(0))
-    block_sum = torch.einsum("nbtd->btd", (block_weight * sum_stacked))
-    block_out = torch.einsum("nbtdk->btdk", (block_weight.unsqueeze(4) * out_stacked))
+    block_sum = (block_weight * sum_stacked).sum(dim=0)
+    block_out = (block_weight.unsqueeze(4) * out_stacked).sum(dim=0)
     output = block_out / block_sum.unsqueeze(-1)  # [1, BH, num_kv_groups*seq_len, D]
     attn_output = output.reshape(batch_size, num_kv_heads, num_kv_groups, seq_len, head_dim).reshape(
         batch_size, num_heads, seq_len, head_dim
@@ -466,7 +466,7 @@ def blocked_kv_attention_forward_headpar_offline(
         if pad_len > 0:
             v_block = nn.functional.pad(v_block, (0, 0, 0, pad_len))
         value_5d = v_block.view(batch_size, num_kv_heads, split, split_block_len, head_dim)
-        sum_block = torch.einsum("bsgkn->bsgk", exp_block)
+        sum_block = exp_block.sum(dim=-1)
         out_block = torch.matmul(exp_block, value_5d)
         if skip_kv and (torch.onnx.is_in_onnx_export() or torch.jit.is_tracing()):
             sum_block = torch.where(skip_future, torch.zeros_like(sum_block), sum_block)
@@ -481,13 +481,13 @@ def blocked_kv_attention_forward_headpar_offline(
     out_stacked = torch.stack(out_blocks)
     block_max = max_stacked.max(dim=0).values
     block_weight = torch.exp(max_stacked - block_max.unsqueeze(0))
-    block_sum = torch.einsum("nbsgk->bsgk", (block_weight * sum_stacked))
-    block_out = torch.einsum("nbsgkv->bsgkv", (block_weight.unsqueeze(-1) * out_stacked))
+    block_sum = (block_weight * sum_stacked).sum(dim=0)
+    block_out = (block_weight.unsqueeze(-1) * out_stacked).sum(dim=0)
 
     split_max = block_max.max(dim=2).values
     split_weight = torch.exp(block_max - split_max.unsqueeze(2))
-    split_sum = torch.einsum("bsgk->bsk", (split_weight * block_sum))
-    split_out = torch.einsum("bsgkv->bskv", (split_weight.unsqueeze(-1) * block_out))
+    split_sum = (split_weight * block_sum).sum(dim=2)
+    split_out = (split_weight.unsqueeze(-1) * block_out).sum(dim=2)
 
     if sinks is not None:
         sinks_logits = sinks.reshape(1, -1, 1, 1).expand(batch_size, -1, seq_len, -1)
@@ -893,7 +893,7 @@ def blocked_kv_attention_forward_prefill_headpar_offline(
                 m_c = torch.where(skip_future, torch.full_like(m_c, float(MIN_MASKED_ATTENTION_VALUE)), m_c)
                 exp_c = torch.where(skip_future, torch.zeros_like(exp_c), exp_c)
 
-            sum_c = torch.einsum("bhsrqt->bhsrq", exp_c)
+            sum_c = exp_c.sum(dim=-1)
             out_c = torch.matmul(exp_c, V_5d.unsqueeze(3))  # [B, Hkv, split, chunk, QL, kv_lora_rank]
 
             if skip_kv and (torch.onnx.is_in_onnx_export() or torch.jit.is_tracing()):
@@ -919,14 +919,14 @@ def blocked_kv_attention_forward_prefill_headpar_offline(
     out_stk = torch.stack(out_buf)  # [nkvb, B, Hkv, split, n_rep, QL, kv_lora_rank]
     m1 = max_stk.max(dim=0).values
     w1 = torch.exp(max_stk - m1.unsqueeze(0))
-    s1 = torch.einsum("nbhsrq->bhsrq", w1 * sum_stk)
-    o1 = torch.einsum("nbhsrqv->bhsrqv", w1.unsqueeze(-1) * out_stk)
+    s1 = (w1 * sum_stk).sum(dim=0)
+    o1 = (w1.unsqueeze(-1) * out_stk).sum(dim=0)
 
     # ── Stage 2: merge across splits ─────────────────────────────────────────
     m2 = m1.max(dim=2).values  # [B, Hkv, n_rep, QL]
     w2 = torch.exp(m1 - m2.unsqueeze(2))
-    s2 = torch.einsum("bhsrq->bhrq", w2 * s1)
-    o2 = torch.einsum("bhsrqv->bhrqv", w2.unsqueeze(-1) * o1)
+    s2 = (w2 * s1).sum(dim=2)
+    o2 = (w2.unsqueeze(-1) * o1).sum(dim=2)
 
     if sinks is not None:
         # sinks: [NQH] → per-head logit, same for all query positions

--- a/QEfficient/diffusers/models/modeling_utils.py
+++ b/QEfficient/diffusers/models/modeling_utils.py
@@ -198,7 +198,7 @@ def apply_kv_blocking(
 
                 # Update running sum of exponentials
                 prev_exp_sum = running_exp_sum.clone()
-                curr_exp_sum = torch.einsum("bhqk->bhq", curr_exp)
+                curr_exp_sum = curr_exp.sum(dim=-1)
                 running_exp_sum = prev_exp_sum * torch.exp(delta_max) + curr_exp_sum
 
                 # Compute normalized attention weights
@@ -413,7 +413,7 @@ def apply_qkv_blocking(
 
                     # Online softmax: Update running sum of exponentials
                     prev_exp_sum = running_exp_sum.clone()
-                    curr_exp_sum = torch.einsum("bhqk->bhq", curr_exp)
+                    curr_exp_sum = curr_exp.sum(dim=-1)
                     running_exp_sum = prev_exp_sum * torch.exp(delta_max) + curr_exp_sum
 
                     # Compute normalized attention weights for this block

--- a/QEfficient/transformers/models/gemma4/modeling_gemma4.py
+++ b/QEfficient/transformers/models/gemma4/modeling_gemma4.py
@@ -261,7 +261,7 @@ class QEffGemma4TextRouter(Gemma4TextRouter):
             dim=-1,
         )
 
-        top_k_weights = top_k_weights / torch.einsum("bk->b", top_k_weights).unsqueeze(-1)
+        top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True)
         top_k_weights = top_k_weights * self.per_expert_scale[top_k_index]
 
         return router_probabilities, top_k_weights, top_k_index

--- a/QEfficient/transformers/models/glm4_moe/modeling_glm4_moe.py
+++ b/QEfficient/transformers/models/glm4_moe/modeling_glm4_moe.py
@@ -215,8 +215,7 @@ def eager_attention_forward_blocked_kv(
 
         # update running denominator
         prev_denominator = current_denominator
-        # Replace .sum() to fix the ReduceSum Issuse in subfunction
-        curr_exp_sum = torch.einsum("bhqk->bhq", current_exp)
+        curr_exp_sum = current_exp.sum(dim=-1)
         current_denominator = prev_denominator * torch.exp(delta_max) + curr_exp_sum
 
         prob = current_exp / current_denominator.unsqueeze(-1)
@@ -514,7 +513,7 @@ class QEffGlm4MoeTopkRouter(nn.Module):
         group_scores_top2 = scores_for_choice.view(-1, self.n_group, self.n_routed_experts // self.n_group).topk(
             2, dim=-1
         )[0]
-        group_scores = torch.einsum("bge->bg", group_scores_top2)
+        group_scores = group_scores_top2.sum(dim=-1)
         group_idx = torch.topk(group_scores, k=self.topk_group, dim=-1, sorted=False)[1]
         group_mask = torch.zeros_like(group_scores)
         group_mask.scatter_(1, group_idx, 1)
@@ -535,7 +534,7 @@ class QEffGlm4MoeTopkRouter(nn.Module):
         topk_weights = scores.gather(1, topk_indices)
         if self.norm_topk_prob:
             # denominator = topk_weights.sum(dim=-1, keepdim=True) + 1e-20
-            denominator = torch.einsum("ab->a", topk_weights).unsqueeze(-1) + 1e-20
+            denominator = topk_weights.sum(dim=-1, keepdim=True) + 1e-20
             topk_weights /= denominator
         topk_weights = topk_weights * self.routed_scaling_factor
         return topk_indices, topk_weights
@@ -562,7 +561,7 @@ class QEffGlm4MoeTopkRouter(nn.Module):
 
         if self.norm_topk_prob:
             # denominator = topk_weights.sum(dim=-1, keepdim=True) + 1e-20
-            denominator = torch.einsum("ab->a", topk_weights).unsqueeze(-1) + 1e-20
+            denominator = topk_weights.sum(dim=-1, keepdim=True) + 1e-20
             topk_weights /= denominator
 
         topk_weights = topk_weights * self.routed_scaling_factor  # *2.5

--- a/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/QEfficient/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -336,7 +336,7 @@ class QEffGptOssMLP(_QEffGptOssLegacyBlockedMixin, QEffMoEBlockMixin, GptOssMLP)
 
         # Apply routing weights AFTER expert computation (This is before on Llama4)
         experts_out = experts_out * router_top_value.unsqueeze(-1)
-        experts_out = torch.einsum("bnd->bd", experts_out)
+        experts_out = experts_out.sum(dim=1)
 
         return experts_out, router_logits
 

--- a/QEfficient/transformers/models/granitemoe/modeling_granitemoe.py
+++ b/QEfficient/transformers/models/granitemoe/modeling_granitemoe.py
@@ -553,7 +553,7 @@ class QEffGraniteMoeMoE(QEffMoEBlockMixin, GraniteMoeMoE):
 
     def route(self, x: torch.Tensor):
         topk_gates, expert_mask, router_logits, _ = self.router(x)
-        routing_weights = torch.einsum("bke,bk->be", expert_mask.permute(2, 1, 0).to(topk_gates.dtype), topk_gates)
+        routing_weights = (expert_mask.permute(2, 1, 0).to(topk_gates.dtype) * topk_gates.unsqueeze(-1)).sum(dim=1)
         return routing_weights.to(x.dtype), router_logits
 
 

--- a/QEfficient/transformers/models/mixtral_moe/modeling_mixtral.py
+++ b/QEfficient/transformers/models/mixtral_moe/modeling_mixtral.py
@@ -320,7 +320,7 @@ class QEffMixtralSparseMoeBlock(QEffMoEBlockMixin, MixtralSparseMoeBlock):
             router_logits = gate_out[0] if isinstance(gate_out, tuple) else gate_out
             routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
             routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
-            routing_weights = routing_weights / torch.einsum("bi->b", routing_weights)[:, None]
+            routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
             routing_weights = routing_weights.to(x.dtype)
         return (selected_experts, routing_weights), router_logits
 

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -2223,9 +2223,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 else:
                     specializations = lang_specs[:1]
                 qpc_key = "lang_prefill_qpc_path"
-            elif prefill_seq_len == 1 and not (
-                self.continuous_batching and full_batch_size is not None and full_batch_size != batch_size
-            ):
+            elif prefill_seq_len == 1:
                 if self.comp_ctx_lengths_decode is not None:
                     specializations = lang_specs[-len(self.comp_ctx_lengths_decode) :]
                 else:

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -2223,7 +2223,9 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 else:
                     specializations = lang_specs[:1]
                 qpc_key = "lang_prefill_qpc_path"
-            elif prefill_seq_len == 1:
+            elif prefill_seq_len == 1 and not (
+                self.continuous_batching and full_batch_size is not None and full_batch_size != batch_size
+            ):
                 if self.comp_ctx_lengths_decode is not None:
                     specializations = lang_specs[-len(self.comp_ctx_lengths_decode) :]
                 else:

--- a/QEfficient/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/QEfficient/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -549,8 +549,8 @@ class QEffQwen3_5GatedDeltaNet(Qwen3_5GatedDeltaNet):
         #     query = l2norm(query, dim=-1, eps=1e-6)
         #     key = l2norm(key, dim=-1, eps=1e-6)
         if use_qk_l2norm_in_kernel:
-            query = query * torch.rsqrt(torch.einsum("bthd,bthd->bth", query, query).unsqueeze(-1) + 1e-6)
-            key = key * torch.rsqrt(torch.einsum("bthd,bthd->bth", key, key).unsqueeze(-1) + 1e-6)
+            query = query * torch.rsqrt((query * query).sum(dim=-1, keepdim=True) + 1e-6)
+            key = key * torch.rsqrt((key * key).sum(dim=-1, keepdim=True) + 1e-6)
         query, key, value, beta, g = [
             x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
         ]
@@ -621,7 +621,7 @@ class QEffQwen3_5GatedDeltaNet(Qwen3_5GatedDeltaNet):
             row = attn[..., i, :i].clone()
             sub = attn[..., :i, :i].clone()
             # attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(-2)
-            attn[..., i, :i] = row + torch.einsum("bghi,bghij->bghj", row, sub)
+            attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(dim=-2)
         attn = attn + eye.to(dtype=attn.dtype, device=attn.device)
 
         ## Approximation code ##
@@ -707,10 +707,8 @@ class QEffQwen3_5GatedDeltaNet(Qwen3_5GatedDeltaNet):
         # L2 norm (matching chunk kernel behavior)
         q = query.float()
         k = key.float()
-        # q = q * torch.rsqrt((q * q).sum(dim=-1, keepdim=True) + 1e-6)
-        # k = k * torch.rsqrt((k * k).sum(dim=-1, keepdim=True) + 1e-6)
-        q = q * torch.rsqrt(torch.einsum("bthd,bthd->bth", q, q).unsqueeze(-1) + 1e-6)
-        k = k * torch.rsqrt(torch.einsum("bthd,bthd->bth", k, k).unsqueeze(-1) + 1e-6)
+        q = q * torch.rsqrt((q * q).sum(dim=-1, keepdim=True) + 1e-6)
+        k = k * torch.rsqrt((k * k).sum(dim=-1, keepdim=True) + 1e-6)
         v = value.float()
 
         scale = 1.0 / (q.shape[-1] ** 0.5)
@@ -730,12 +728,10 @@ class QEffQwen3_5GatedDeltaNet(Qwen3_5GatedDeltaNet):
         # Single step — no loop because T=1
         # S update
         S_decayed = S * decay[:, :, 0]  # (B, H, d_k, d_v)
-        # kv_mem = (S_decayed * k[:, :, 0].unsqueeze(-1)).sum(dim=-2)  # (B, H, d_v)
-        kv_mem = torch.einsum("bhkv,bhk->bhv", S_decayed, k[:, :, 0])  # (B, H, d_v)
+        kv_mem = (S_decayed * k[:, :, 0].unsqueeze(-1)).sum(dim=-2)  # (B, H, d_v)
         delta = (v[:, :, 0] - kv_mem) * b[:, :, 0]  # (B, H, d_v)
         S_new = S_decayed + k[:, :, 0].unsqueeze(-1) * delta.unsqueeze(-2)  # (B, H, d_k, d_v)
-        # out = (S_new * q[:, :, 0].unsqueeze(-1)).sum(dim=-2)  # (B, H, d_v)
-        out = torch.einsum("bhkv,bhk->bhv", S_new, q[:, :, 0])  # (B, H, d_v)
+        out = (S_new * q[:, :, 0].unsqueeze(-1)).sum(dim=-2)  # (B, H, d_v)
         out = out.unsqueeze(2).transpose(1, 2).to(dtype)  # (B, 1, H, d_v) → (B, T, H, d_v)
         return out, S_new.to(recurrent_state.dtype)
 

--- a/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -534,6 +534,7 @@ class QEffQwen3_5MoeAttention(Qwen3_5MoeAttention):
                 batch_index=batch_index,
                 position_ids=position_ids[0],
                 past_seen_tokens=past_seen_tokens,
+                prefill_only=blocking_config.mode.is_prefill,
             )
         else:
             if past_key_values is not None:

--- a/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/QEfficient/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -613,7 +613,7 @@ class QEffQwen3_5MoeGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         for i in range(1, chunk_size):
             row = attn[..., i, :i].clone()
             sub = attn[..., :i, :i].clone()
-            attn[..., i, :i] = row + torch.einsum("bghi,bghij->bghj", row, sub)
+            attn[..., i, :i] = row + (row.unsqueeze(-1) * sub).sum(dim=-2)
         return attn + eye.to(dtype=attn.dtype, device=attn.device)
 
     def _solve_chunk_attn_recursive_sns(
@@ -728,8 +728,8 @@ class QEffQwen3_5MoeGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         #     query = l2norm(query, dim=-1, eps=1e-6)
         #     key = l2norm(key, dim=-1, eps=1e-6)
         if use_qk_l2norm_in_kernel:
-            query = query * torch.rsqrt(torch.einsum("bthd,bthd->bth", query, query).unsqueeze(-1) + 1e-6)
-            key = key * torch.rsqrt(torch.einsum("bthd,bthd->bth", key, key).unsqueeze(-1) + 1e-6)
+            query = query * torch.rsqrt((query * query).sum(dim=-1, keepdim=True) + 1e-6)
+            key = key * torch.rsqrt((key * key).sum(dim=-1, keepdim=True) + 1e-6)
         query, key, value, beta, g = [
             x.transpose(1, 2).contiguous().to(torch.float32) for x in (query, key, value, beta, g)
         ]
@@ -842,10 +842,8 @@ class QEffQwen3_5MoeGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         # L2 norm (matching chunk kernel behavior)
         q = query.float()
         k = key.float()
-        # q = q * torch.rsqrt((q * q).sum(dim=-1, keepdim=True) + 1e-6)
-        # k = k * torch.rsqrt((k * k).sum(dim=-1, keepdim=True) + 1e-6)
-        q = q * torch.rsqrt(torch.einsum("bthd,bthd->bth", q, q).unsqueeze(-1) + 1e-6)
-        k = k * torch.rsqrt(torch.einsum("bthd,bthd->bth", k, k).unsqueeze(-1) + 1e-6)
+        q = q * torch.rsqrt((q * q).sum(dim=-1, keepdim=True) + 1e-6)
+        k = k * torch.rsqrt((k * k).sum(dim=-1, keepdim=True) + 1e-6)
 
         v = value.float()
 
@@ -866,12 +864,10 @@ class QEffQwen3_5MoeGatedDeltaNet(Qwen3_5MoeGatedDeltaNet):
         # Single step — no loop because T=1
         # S update
         S_decayed = S * decay[:, :, 0]  # (B, H, d_k, d_v)
-        # kv_mem = (S_decayed * k[:, :, 0].unsqueeze(-1)).sum(dim=-2)  # (B, H, d_v)
-        kv_mem = torch.einsum("bhkv,bhk->bhv", S_decayed, k[:, :, 0])  # (B, H, d_v)
+        kv_mem = (S_decayed * k[:, :, 0].unsqueeze(-1)).sum(dim=-2)  # (B, H, d_v)
         delta = (v[:, :, 0] - kv_mem) * b[:, :, 0]  # (B, H, d_v)
         S_new = S_decayed + k[:, :, 0].unsqueeze(-1) * delta.unsqueeze(-2)  # (B, H, d_k, d_v)
-        # out = (S_new * q[:, :, 0].unsqueeze(-1)).sum(dim=-2)  # (B, H, d_v)
-        out = torch.einsum("bhkv,bhk->bhv", S_new, q[:, :, 0])  # (B, H, d_v)
+        out = (S_new * q[:, :, 0].unsqueeze(-1)).sum(dim=-2)  # (B, H, d_v)
         out = out.unsqueeze(2).transpose(1, 2).to(dtype)  # (B, 1, H, d_v) → (B, T, H, d_v)
         return out, S_new.to(recurrent_state.dtype)
 
@@ -2249,7 +2245,7 @@ class QEffQwen3_5MoeTopKRouter(Qwen3_5MoeTopKRouter):
         router_logits = F.linear(hidden_states, self.weight)  # (seq_len, num_experts)
         router_logits = torch.nn.functional.softmax(router_logits, dtype=torch.float, dim=-1).to(router_logits.dtype)
         router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=-1)  # (seq_len, top_k)
-        router_top_value = router_top_value / torch.einsum("bk->b", router_top_value).unsqueeze(-1)
+        router_top_value = router_top_value / router_top_value.sum(dim=-1, keepdim=True)
         router_top_value = router_top_value.to(router_logits.dtype)
         router_scores = router_top_value
         return router_logits, router_scores, router_indices

--- a/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/QEfficient/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -121,7 +121,7 @@ class QEffQwen3MoeTopKRouter(Qwen3MoeTopKRouter):
         router_logits = torch.nn.functional.softmax(router_logits, dtype=torch.float, dim=-1).to(router_logits.dtype)
         router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=-1)
         if self.norm_topk_prob:
-            router_top_value = router_top_value / torch.einsum("bk->b", router_top_value).unsqueeze(-1)
+            router_top_value = router_top_value / router_top_value.sum(dim=-1, keepdim=True)
         router_top_value = router_top_value.to(router_logits.dtype)
         return router_logits, router_top_value, router_indices
 
@@ -178,7 +178,7 @@ class QEffQwen3MoeSparseMoeBlock(QEffMoEBlockMixin, Qwen3MoeSparseMoeBlock):
     def route(self, x: torch.Tensor):
         router_logits, top_w, top_i = self.gate(x)
         if self.norm_topk_prob:
-            top_w = top_w / torch.einsum("bk->b", top_w).unsqueeze(-1)
+            top_w = top_w / top_w.sum(dim=-1, keepdim=True)
         top_w = top_w.to(x.dtype)
         return (top_i, top_w), router_logits
 

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -790,7 +790,7 @@ class QEffQwen3VLMoeTextTopKRouter(Qwen3VLMoeTextTopKRouter):
         router_logits = F.linear(hidden_states, self.weight)  # (seq_len, num_experts)
         router_logits = torch.nn.functional.softmax(router_logits, dtype=torch.float, dim=-1)
         router_top_value, router_indices = torch.topk(router_logits, self.top_k, dim=-1)  # (seq_len, top_k)
-        router_top_value = router_top_value / torch.einsum("bk->b", router_top_value).unsqueeze(-1)
+        router_top_value = router_top_value / router_top_value.sum(dim=-1, keepdim=True)
         router_top_value = router_top_value.to(router_logits.dtype)
         router_scores = router_top_value
         return router_logits, router_scores, router_indices
@@ -1033,7 +1033,7 @@ class QEffQwen3VLMoeTextSparseMoeBlock(QEffMoEBlockMixin, Qwen3VLMoeTextSparseMo
     def route(self, x: torch.Tensor):
         router_logits, top_w, top_i = self.gate(x)
         if getattr(self, "norm_topk_prob", False):
-            top_w = top_w / torch.einsum("bk->b", top_w).unsqueeze(-1)
+            top_w = top_w / top_w.sum(dim=-1, keepdim=True)
         top_w = top_w.to(x.dtype)
         return (top_i, top_w), router_logits
 

--- a/QEfficient/transformers/moe/flavours.py
+++ b/QEfficient/transformers/moe/flavours.py
@@ -123,7 +123,7 @@ def cumsum_scatter_gather_update_expert_blocked(
     )
     packed_chunk_size = seq_len // num_packed_chunks
     matched_idx = build_matched_idx_from_cumsum(T2Ei)
-    valid_rows = torch.einsum("ij->i", T2Ei.to(torch.int32)).unsqueeze(1)
+    valid_rows = T2Ei.to(torch.int32).sum(dim=-1, keepdim=True)
     x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
     for chunk_idx in range(num_packed_chunks):
         packed_start = chunk_idx * packed_chunk_size
@@ -226,11 +226,11 @@ def moe_expert_parallel(
                 f"({num_devices})"
             )
         parallelized_experts_per_soc = num_parallelized_experts // num_devices
-        expert_out = torch.einsum("dpth->dth", expert_out.view(num_devices, parallelized_experts_per_soc, T, H))
+        expert_out = expert_out.view(num_devices, parallelized_experts_per_soc, T, H).sum(dim=1)
         if tree_reduce:
             return reduce_nsp_tree(expert_out, num_devices)
-        return torch.einsum("dth->th", expert_out)
-    return torch.einsum("nth->th", expert_out)
+        return expert_out.sum(dim=0)
+    return expert_out.sum(dim=0)
 
 
 # Backward-compatible helper name for one transition period.
@@ -290,7 +290,7 @@ def moe_decode_bmm(
     down = profile.expert_mlp(expert_in, gate_proj, up_proj, down_proj, b_g, b_u, b_d)
     experts_out = down.view(T, top_k, H)
     experts_out = experts_out * topk_weights.unsqueeze(-1)
-    return torch.einsum("bnd->bd", experts_out)
+    return experts_out.sum(dim=1)
 
 
 def select_moe_flavour(

--- a/QEfficient/transformers/moe/qflavours.py
+++ b/QEfficient/transformers/moe/qflavours.py
@@ -102,7 +102,7 @@ def moe_quantized_decode_bmm(
         1,
         topk_indices.unsqueeze(-1).expand(-1, topk_indices.shape[1], down_out.shape[-1]),
     )
-    return torch.einsum("abc,ab->ac", selected_out, topk_weights)
+    return (selected_out * topk_weights.unsqueeze(-1)).sum(dim=1)
 
 
 def _cumsum_scatter_gather_update_quantized_expert(
@@ -148,7 +148,7 @@ def _cumsum_scatter_gather_update_quantized_expert(
     packed_chunk_size = seq_len // num_packed_chunks
 
     matched_idx = _build_matched_idx_from_cumsum(token_to_expert)
-    valid_rows = torch.einsum("bi->b", token_to_expert.to(torch.int32)).unsqueeze(1)
+    valid_rows = token_to_expert.to(torch.int32).sum(dim=-1, keepdim=True)
     row_range = torch.arange(packed_chunk_size, dtype=torch.int32, device=x.device).unsqueeze(0)
     x_expanded = x.unsqueeze(0).expand(batch_size, -1, -1)
 
@@ -278,4 +278,4 @@ def moe_quantized_expert_parallel(
             group_size=weights.group_size,
             num_packed_chunks=num_packed_chunks,
         )
-    return torch.einsum("nth->th", expert_out)
+    return expert_out.sum(dim=0)

--- a/QEfficient/utils/export_utils.py
+++ b/QEfficient/utils/export_utils.py
@@ -20,6 +20,7 @@ from torch.export import Dim
 
 from QEfficient.base.onnx_transforms import (
     CustomOpTransform,
+    LocalizeFunctionReduceSumAxesTransform,
     PreserveNestedCacheRetainedStateTransform,
     RenameFunctionOutputsTransform,
     RenameRepeatedSubgraphTransform,
@@ -529,6 +530,9 @@ def _setup_onnx_subfunctions(qeff_model, args, kwargs, dynamo=False):
             qeff_model._onnx_transforms.append(CustomOpTransform)
         if RenameWsubNodesTransform not in qeff_model._onnx_transforms:
             qeff_model._onnx_transforms.append(RenameWsubNodesTransform)
+
+    if LocalizeFunctionReduceSumAxesTransform not in qeff_model._onnx_transforms:
+        qeff_model._onnx_transforms.append(LocalizeFunctionReduceSumAxesTransform)
 
     # TODO: Handle this in the modelling class QEFFTransformersBase, remove from here.
     decoder_layer_classes = get_decoder_layer_classes_for_export(qeff_model.model)

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -15,29 +15,52 @@ def testFilter(String profile) {
 }
 
 
-def impactStageEnabled(String stageKey, boolean requested) {
-    if (!requested) {
-        return false
-    }
-    return env.CI_IMPACT_MODE == 'full' || env["IMPACT_${stageKey.toUpperCase()}"] == 'true'
+def readImpactPlan() {
+    return new JsonSlurperClassic().parseText(readFile('.ci-impact-plan.json'))
 }
 
 
-def runImpactStage(String stageKey, boolean requested, Closure body) {
-    if (!impactStageEnabled(stageKey, requested)) {
+def impactRuntimeEnv(Map plan, String profile) {
+    def mode = plan.mode.toString()
+    def values = [
+        "CI_IMPACT_MODE=${mode}",
+        "IMPACT_TEST_FILTER=${mode == 'full' ? testFilter(profile) : noopMarkerFilter()}",
+        "CI_SELECTIVE_LAYER_FILTER=${mode == 'full' ? noopMarkerFilter() : '(not full_layers)'}",
+        "CI_QAIC_WORKERS=${qaicWorkerCount(mode, profile)}",
+    ]
+    plan.stages.each { currentStageKey, stagePlan ->
+        values << "IMPACT_${currentStageKey.toUpperCase()}=${stagePlan.enabled.toString()}"
+    }
+    return values
+}
+
+
+def planStageEnabled(Map plan, String stageKey, boolean requested) {
+    return requested && (plan.mode == 'full' || plan.stages[stageKey].enabled)
+}
+
+
+def runImpactStage(String stageKey, boolean requested, String profile, Closure body) {
+    def plan = readImpactPlan()
+    if (!planStageEnabled(plan, stageKey, requested)) {
         echo "Skipping ${stageKey}: not requested or not selected by CI impact plan"
         return
     }
-    body.call()
+    withEnv(impactRuntimeEnv(plan, profile)) {
+        body.call()
+    }
 }
 
 
-def runFullImpactStage(String stageName, boolean requested, Closure body) {
-    if (!requested || env.CI_IMPACT_MODE != 'full') {
-        echo "Skipping ${stageName}: not requested or CI impact mode is ${env.CI_IMPACT_MODE}"
+def runFullImpactStage(String stageName, boolean requested, String profile, Closure body) {
+    def plan = readImpactPlan()
+    if (!requested || plan.mode != 'full') {
+        echo "Skipping ${stageName}: not requested or CI impact mode is ${plan.mode}"
         return
     }
-    body.call()
+    withEnv(impactRuntimeEnv(plan, profile)) {
+        body.call()
+    }
 }
 
 
@@ -66,17 +89,6 @@ def pipelinePrNumber() {
         positiveIntegerOrEmpty(params.get('PR_NUMBER')) ?:
         positiveIntegerOrEmpty(env.PR_NUMBER) ?:
         positiveIntegerOrEmpty(env.CHANGE_ID)
-}
-
-
-def loadImpactEnvironment(Map plan, String profile) {
-    env.CI_IMPACT_MODE = plan.mode
-    env.IMPACT_TEST_FILTER = plan.mode == 'full' ? env.TEST_FILTER : noopMarkerFilter()
-    env.CI_SELECTIVE_LAYER_FILTER = plan.mode == 'full' ? noopMarkerFilter() : '(not full_layers)'
-    env.CI_QAIC_WORKERS = qaicWorkerCount(plan.mode, profile)
-    plan.stages.each { stageKey, stagePlan ->
-        env["IMPACT_${stageKey.toUpperCase()}"] = stagePlan.enabled.toString()
-    }
 }
 
 
@@ -316,7 +328,6 @@ pipeline {
                     }
                     def plan = new JsonSlurperClassic().parseText(readFile('.ci-impact-plan.json'))
                     def llmDecisionText = fileExists('.ci-impact-llm.json') ? readFile('.ci-impact-llm.json').trim() : '<missing>'
-                    loadImpactEnvironment(plan, params.TEST_PROFILE)
                     def prPrefix = env.CI_IMPACT_PR_NUMBER ? "PR-${env.CI_IMPACT_PR_NUMBER}; " : ''
                     currentBuild.description = "${prPrefix}${plan.mode}: ${plan.reasons.join('; ')}"
                     echo "Regression impact mode: ${plan.mode}\nReasons: ${plan.reasons.join('\n')}"
@@ -332,6 +343,7 @@ pipeline {
                         }
                         echo "Final selected tests:\n${selectedTests ? selectedTests.join('\n') : '<none>'}"
                     }
+                    echo "CI impact stage flags:\n${impactRuntimeEnv(plan, params.TEST_PROFILE).sort().join('\n')}"
                     archiveArtifacts artifacts: '.ci-impact-catalog.json,.ci-impact-deterministic-plan.json,.ci-impact-llm.json,.ci-impact-plan.json,.ci-impact-qgenie-audit.jsonl', fingerprint: true
                 }
             }
@@ -353,7 +365,7 @@ pipeline {
                 stage('Export & Compile') {
                     steps {
                         script {
-                            runImpactStage('export_compile', true) {
+                            runImpactStage('export_compile', true, params.TEST_PROFILE) {
                                 timeout(time: params.TEST_PROFILE == 'full_layers_model' ? 0 : 60, unit: params.TEST_PROFILE == 'full_layers_model' ? 'HOURS' : 'MINUTES') {
                                     sh '''
                                     sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/export_compile ${BUILD_TAG} bash -c "
@@ -375,7 +387,7 @@ pipeline {
                 stage('QAIC LLM') {
                     steps {
                         script {
-                            runImpactStage('qaic_llm', true) {
+                            runImpactStage('qaic_llm', true, params.TEST_PROFILE) {
                                 timeout(time: params.TEST_PROFILE == 'full_layers_model' ? 0 : 240, unit: params.TEST_PROFILE == 'full_layers_model' ? 'HOURS' : 'MINUTES') {
                                     sh '''
                                     sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/qaic_llm ${BUILD_TAG} bash -c "
@@ -400,7 +412,7 @@ pipeline {
         stage('QAIC FEATURE') {
             steps {
                 script {
-                    runImpactStage('qaic_feature', params.RUN_QAIC_FEATURE) {
+                    runImpactStage('qaic_feature', params.RUN_QAIC_FEATURE, params.TEST_PROFILE) {
                         timeout(time: params.TEST_PROFILE == 'full_layers_model' ? 0 : 120, unit: params.TEST_PROFILE == 'full_layers_model' ? 'HOURS' : 'MINUTES') {
                             sh '''
                             sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/qaic_feature ${BUILD_TAG} bash -c "
@@ -418,7 +430,7 @@ pipeline {
         stage('QAIC Multimodal') {
             steps {
                 script {
-                    runImpactStage('qaic_multimodal', params.RUN_QAIC_MM) {
+                    runImpactStage('qaic_multimodal', params.RUN_QAIC_MM, params.TEST_PROFILE) {
                         timeout(time: params.TEST_PROFILE == 'full_layers_model' ? 0 : 180, unit: params.TEST_PROFILE == 'full_layers_model' ? 'HOURS' : 'MINUTES') {
                             sh '''
                             sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/qaic_multimodal ${BUILD_TAG} bash -c "
@@ -435,7 +447,7 @@ pipeline {
         stage('QAIC DISAGG TESTS') {
             steps {
                 script {
-                    runImpactStage('qaic_disagg', params.RUN_QAIC_DISAGG) {
+                    runImpactStage('qaic_disagg', params.RUN_QAIC_DISAGG, params.TEST_PROFILE) {
                         timeout(time: params.TEST_PROFILE == 'full_layers_model' ? 0 : 180, unit: params.TEST_PROFILE == 'full_layers_model' ? 'HOURS' : 'MINUTES') {
                             sh '''
                             sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/qaic_disagg -e QAIC_MARKEXPR="(on_qaic) and (disagg_dma) and ${CI_SELECTIVE_LAYER_FILTER}" -e CI_QAIC_WORKERS="${CI_QAIC_WORKERS}" ${BUILD_TAG} bash -c '
@@ -467,7 +479,7 @@ pipeline {
         stage('QAIC Reranker Tests') {
             steps {
                 script {
-                    runImpactStage('qaic_reranker', params.RUN_QAIC_MM) {
+                    runImpactStage('qaic_reranker', params.RUN_QAIC_MM, params.TEST_PROFILE) {
                         timeout(time: 20, unit: 'MINUTES') {
                             sh '''
                             sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/qaic_reranker ${BUILD_TAG} bash -c "
@@ -485,7 +497,7 @@ pipeline {
         stage('QAIC Diffusion Models Tests') {
             steps {
                 script {
-                    runImpactStage('qaic_diffusion', params.RUN_QAIC_DIFFUSION) {
+                    runImpactStage('qaic_diffusion', params.RUN_QAIC_DIFFUSION, params.TEST_PROFILE) {
                         timeout(time: 120, unit: 'MINUTES') {
                             sh '''
                             sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/qaic_diffusion ${BUILD_TAG} bash -c "
@@ -503,7 +515,7 @@ pipeline {
         stage('CLI Tests') {
             steps {
                 script {
-                    runImpactStage('cli', params.RUN_CLI) {
+                    runImpactStage('cli', params.RUN_CLI, params.TEST_PROFILE) {
                         timeout(time: 120, unit: 'MINUTES') {
                             sh '''
                             sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/cli ${BUILD_TAG} bash -c "
@@ -521,7 +533,7 @@ pipeline {
         stage('QAIC DYNAMO') {
             steps {
                 script {
-                    runImpactStage('dynamo_qaic', params.RUN_DYNAMO_QAIC) {
+                    runImpactStage('dynamo_qaic', params.RUN_DYNAMO_QAIC, params.TEST_PROFILE) {
                         timeout(time: 240, unit: 'MINUTES') {
                             sh '''
                             sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/dynamo_qaic ${BUILD_TAG} bash -c "
@@ -539,7 +551,7 @@ pipeline {
         stage('QAIC WEIGHT FREE') {
             steps {
                 script {
-                    runImpactStage('weight_free_qaic', params.RUN_WEIGHT_FREE_QAIC) {
+                    runImpactStage('weight_free_qaic', params.RUN_WEIGHT_FREE_QAIC, params.TEST_PROFILE) {
                         timeout(time: 360, unit: 'MINUTES') {
                             sh '''
                             sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/weight_free_qaic ${BUILD_TAG} bash -c "
@@ -558,7 +570,7 @@ pipeline {
         stage('Finetune Tests') {
             steps {
                 script {
-                    runFullImpactStage('finetune', params.RUN_FINETUNE) {
+                    runFullImpactStage('finetune', params.RUN_FINETUNE, params.TEST_PROFILE) {
                         timeout(time: 20, unit: 'MINUTES') {
                             sh '''
                             sudo docker exec -e TMPDIR=/efficient-transformers/.ci-tmp/finetune ${BUILD_TAG} bash -c "

--- a/tests/base/test_onnx_transforms.py
+++ b/tests/base/test_onnx_transforms.py
@@ -7,9 +7,11 @@
 
 import numpy as np
 import onnx
+import pytest
 
 from QEfficient.base.onnx_transforms import (
     FP16ClipTransform,
+    LocalizeFunctionReduceSumAxesTransform,
     OnnxTransformPipeline,
     RenameWsubNodesTransform,
     SplitTensorsTransform,
@@ -112,6 +114,206 @@ def test_rename_wsub_nodes_transform():
         role.replace(".", "/") + "/" + op_type for role, op_type in weighted_ops
     ]
     assert not RenameWsubNodesTransform.apply(model)
+
+
+def _make_constant_node(output_name, values, dtype=np.int64):
+    tensor = onnx.numpy_helper.from_array(np.asarray(values, dtype=dtype), name=output_name)
+    return onnx.helper.make_node("Constant", inputs=[], outputs=[output_name], value=tensor)
+
+
+def _make_reduce_sum_function(function_name="QKNorm"):
+    reduce_node = onnx.helper.make_node("ReduceSum", ["x", "axes"], ["y"], keepdims=1)
+    return onnx.helper.make_function(
+        "qeff.test",
+        function_name,
+        ["x", "axes"],
+        ["y"],
+        [reduce_node],
+        [onnx.helper.make_opsetid("", 17)],
+    )
+
+
+def _reduced_shape(axes_value):
+    shape = [2, 3, 4, 5]
+    for axis in axes_value:
+        shape[axis] = 1
+    return shape
+
+
+def _make_reduce_sum_function_model(axes_values, function_name="QKNorm"):
+    constants = []
+    calls = []
+    inputs = []
+    outputs = []
+    for idx, axes_value in enumerate(axes_values):
+        x_name = f"x{idx}"
+        axes_name = f"axes{idx}"
+        y_name = f"y{idx}"
+        constants.append(_make_constant_node(axes_name, axes_value))
+        calls.append(onnx.helper.make_node(function_name, [x_name, axes_name], [y_name], domain="qeff.test"))
+        inputs.append(onnx.helper.make_tensor_value_info(x_name, onnx.TensorProto.FLOAT, [2, 3, 4, 5]))
+        outputs.append(onnx.helper.make_tensor_value_info(y_name, onnx.TensorProto.FLOAT, _reduced_shape(axes_value)))
+
+    graph = onnx.helper.make_graph(constants + calls, "g", inputs, outputs)
+    model = onnx.helper.make_model(
+        graph,
+        opset_imports=[onnx.helper.make_opsetid("", 17), onnx.helper.make_opsetid("qeff.test", 1)],
+        functions=[_make_reduce_sum_function(function_name)],
+    )
+    model.ir_version = 10
+    onnx.checker.check_model(model)
+    return model
+
+
+def _reduce_sum_axes_input(function):
+    reduce_sum = next(node for node in function.node if node.op_type == "ReduceSum")
+    return reduce_sum.input[1]
+
+
+def _constant_value_by_output(nodes, output_name):
+    for node in nodes:
+        if node.op_type != "Constant" or list(node.output) != [output_name]:
+            continue
+        value_attr = next(attr for attr in node.attribute if attr.name == "value")
+        return onnx.numpy_helper.to_array(value_attr.t)
+    raise AssertionError(f"Constant node producing {output_name!r} not found")
+
+
+class TestLocalizeFunctionReduceSumAxesTransform:
+    @pytest.mark.parametrize("axes", [[-1], [2], [2, 3]])
+    def test_localizes_constant_reduce_sum_axes(self, axes):
+        model = _make_reduce_sum_function_model([axes])
+
+        transformed = LocalizeFunctionReduceSumAxesTransform.apply(model)
+
+        assert transformed
+        function = model.functions[0]
+        call_node = next(node for node in model.graph.node if node.op_type == "QKNorm")
+        local_axes_name = _reduce_sum_axes_input(function)
+
+        assert list(function.input) == ["x"]
+        assert list(call_node.input) == ["x0"]
+        np.testing.assert_array_equal(_constant_value_by_output(function.node, local_axes_name), np.asarray(axes))
+        onnx.checker.check_model(model)
+
+    def test_noop_for_dynamic_reduce_sum_axes(self):
+        function = _make_reduce_sum_function()
+        graph = onnx.helper.make_graph(
+            [onnx.helper.make_node("QKNorm", ["x", "axes"], ["y"], domain="qeff.test")],
+            "g",
+            [
+                onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [2, 3, 4]),
+                onnx.helper.make_tensor_value_info("axes", onnx.TensorProto.INT64, [1]),
+            ],
+            [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [2, 3, 4])],
+        )
+        model = onnx.helper.make_model(
+            graph,
+            opset_imports=[onnx.helper.make_opsetid("", 17), onnx.helper.make_opsetid("qeff.test", 1)],
+            functions=[function],
+        )
+        model.ir_version = 10
+
+        transformed = LocalizeFunctionReduceSumAxesTransform.apply(model)
+
+        assert not transformed
+        assert list(model.functions[0].input) == ["x", "axes"]
+        assert list(model.graph.node[0].input) == ["x", "axes"]
+        onnx.checker.check_model(model)
+
+    def test_noop_for_different_call_site_constants(self):
+        model = _make_reduce_sum_function_model([[-1], [2]])
+
+        transformed = LocalizeFunctionReduceSumAxesTransform.apply(model)
+
+        assert not transformed
+        assert list(model.functions[0].input) == ["x", "axes"]
+        assert [list(node.input) for node in model.graph.node if node.op_type == "QKNorm"] == [
+            ["x0", "axes0"],
+            ["x1", "axes1"],
+        ]
+        onnx.checker.check_model(model)
+
+    def test_noop_for_already_local_constant_axes(self):
+        local_axes = _make_constant_node("axes_local", [-1])
+        reduce_node = onnx.helper.make_node("ReduceSum", ["x", "axes_local"], ["y"], keepdims=1)
+        function = onnx.helper.make_function(
+            "qeff.test",
+            "QKNorm",
+            ["x"],
+            ["y"],
+            [local_axes, reduce_node],
+            [onnx.helper.make_opsetid("", 17)],
+        )
+        graph = onnx.helper.make_graph(
+            [onnx.helper.make_node("QKNorm", ["x"], ["y"], domain="qeff.test")],
+            "g",
+            [onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [2, 3, 4])],
+            [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [2, 3, 4])],
+        )
+        model = onnx.helper.make_model(
+            graph,
+            opset_imports=[onnx.helper.make_opsetid("", 17), onnx.helper.make_opsetid("qeff.test", 1)],
+            functions=[function],
+        )
+        model.ir_version = 10
+
+        transformed = LocalizeFunctionReduceSumAxesTransform.apply(model)
+
+        assert not transformed
+        assert list(model.functions[0].input) == ["x"]
+        assert _reduce_sum_axes_input(model.functions[0]) == "axes_local"
+        onnx.checker.check_model(model)
+
+    def test_noop_for_non_reduce_sum_constant_function_input(self):
+        function = onnx.helper.make_function(
+            "qeff.test",
+            "AddBias",
+            ["x", "bias"],
+            ["y"],
+            [onnx.helper.make_node("Add", ["x", "bias"], ["y"])],
+            [onnx.helper.make_opsetid("", 17)],
+        )
+        graph = onnx.helper.make_graph(
+            [
+                _make_constant_node("bias", [1.0], dtype=np.float32),
+                onnx.helper.make_node("AddBias", ["x", "bias"], ["y"], domain="qeff.test"),
+            ],
+            "g",
+            [onnx.helper.make_tensor_value_info("x", onnx.TensorProto.FLOAT, [1])],
+            [onnx.helper.make_tensor_value_info("y", onnx.TensorProto.FLOAT, [1])],
+        )
+        model = onnx.helper.make_model(
+            graph,
+            opset_imports=[onnx.helper.make_opsetid("", 17), onnx.helper.make_opsetid("qeff.test", 1)],
+            functions=[function],
+        )
+        model.ir_version = 10
+
+        transformed = LocalizeFunctionReduceSumAxesTransform.apply(model)
+
+        assert not transformed
+        assert list(model.functions[0].input) == ["x", "bias"]
+        assert list(model.graph.node[1].input) == ["x", "bias"]
+        onnx.checker.check_model(model)
+
+    def test_localized_model_matches_ort_output_when_available(self):
+        ort = pytest.importorskip("onnxruntime")
+        model = _make_reduce_sum_function_model([[-1]])
+        reference = onnx.ModelProto()
+        reference.CopyFrom(model)
+
+        transformed = LocalizeFunctionReduceSumAxesTransform.apply(model)
+
+        assert transformed
+        session_options = ort.SessionOptions()
+        session_options.log_severity_level = 3
+        reference_session = ort.InferenceSession(reference.SerializeToString(), session_options)
+        transformed_session = ort.InferenceSession(model.SerializeToString(), session_options)
+        x = np.random.randn(2, 3, 4, 5).astype(np.float32)
+        expected = reference_session.run(None, {"x0": x})[0]
+        actual = transformed_session.run(None, {"x0": x})[0]
+        np.testing.assert_allclose(actual, expected, rtol=1e-4, atol=1e-5)
 
 
 def test_split_tensors_transform(tmp_path):

--- a/tests/ci_impact/test_core.py
+++ b/tests/ci_impact/test_core.py
@@ -52,11 +52,16 @@ def test_jenkins_impact_gates_run_after_plan_loading() -> None:
         not re.search(r"impactStageEnabled|env\.CI_IMPACT_MODE|env(?:\[['\"]|\.)IMPACT_", block)
         for block in when_blocks
     )
+    assert "def impactStageEnabled" not in source
+    assert "def loadImpactEnvironment" not in source
+    assert "def readImpactPlan()" in source
+    assert "withEnv(impactRuntimeEnv(plan, profile))" in source
 
     impact_stages = re.findall(r"--impact-stage=([a-z0-9_]+)", source)
     assert impact_stages
     for stage_key in set(impact_stages):
-        assert f"runImpactStage('{stage_key}'" in source
+        assert f"runImpactStage('{stage_key}'," in source
+        assert re.search(rf"runImpactStage\('{stage_key}', [^,]+, params\.TEST_PROFILE\)", source)
 
 
 def _git(repo: Path, *args: str) -> str:

--- a/tests/transformers/models/causal_lm_models/check_causal_models.py
+++ b/tests/transformers/models/causal_lm_models/check_causal_models.py
@@ -106,6 +106,7 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
     mdp_strategy: Optional[str] = None,
     use_onnx_subfunctions: bool = False,
     prompts: Optional[str] = None,
+    skip_onnxruntime: bool = False,
 ):
     torch.manual_seed(42)
     replace_transformers_quantizers()
@@ -156,7 +157,7 @@ def check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
             pytorch_hf_tokens = api_runner.run_hf_model_on_pytorch(model_hf)
 
     onnx_model_path = qeff_model.export(use_onnx_subfunctions=use_onnx_subfunctions)
-    if continuous_batching is False:
+    if continuous_batching is False and not skip_onnxruntime:
         ort_tokens = api_runner.run_kv_model_on_ort(onnx_model_path, is_tlm=is_tlm)
         gen_len = ort_tokens.shape[-1]
 

--- a/tests/transformers/models/causal_lm_models/test_causal_lm_blocking_hqkv.py
+++ b/tests/transformers/models/causal_lm_models/test_causal_lm_blocking_hqkv.py
@@ -90,12 +90,18 @@ def test_dummy_causal_all_blocking_pytorch_vs_kv_vs_ort_vs_ai100(model_name, blo
         n_layer = get_custom_n_layers(model_name)
         hf_config = None
     qaic_config = _build_qaic_config(blocking_mode)
+    is_gemma = getattr(hf_config, "model_type", "").startswith("gemma")
+    skip_ort = is_gemma and blocking_mode in ("qkv", "hqkv")
     check_causal_lm_pytorch_vs_kv_vs_ort_vs_ai100(
         model_name=model_name,
         qaic_config=qaic_config,
         n_layer=n_layer,
         config=hf_config,
         manual_cleanup=manual_cleanup,
+        # Gemma's qkv/hqkv blocked graph is not executable by CPU ORT; keep
+        # the export and QAIC compile coverage for these modes.
+        compile_only=skip_ort,
+        skip_onnxruntime=skip_ort,
     )
 
 

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -1385,7 +1385,7 @@ def test_repeat_kv_quickcheck_hf_qeff_ort_parity(tmp_path):
     sorted(TINY_MOE_PREFILL_SUBFUNCTION_CONFIGS.items()),
     ids=sorted(TINY_MOE_PREFILL_SUBFUNCTION_CONFIGS),
 )
-def test_moe_prefill_subfunction_export_uses_einsum_reductions(model_type, config_kwargs, tmp_path):
+def test_moe_prefill_subfunction_export_uses_reduce_sum_reductions(model_type, config_kwargs, tmp_path):
     config = AutoConfig.for_model(model_type, **config_kwargs)
     model_hf = AutoModelForCausalLM.from_config(config, **MODEL_KWARGS)
     model_hf.eval()
@@ -1419,7 +1419,7 @@ def test_moe_prefill_subfunction_export_uses_einsum_reductions(model_type, confi
     decoder_op_types = _function_op_types(onnx_model, decoder_function_names)
 
     assert len(decoder_function_names) == config.num_hidden_layers
-    assert "Einsum" in decoder_op_types
+    assert "ReduceSum" in decoder_op_types
     assert "CtxGather3D" in decoder_op_types
     assert "CtxScatter3D" in decoder_op_types
     assert "CtxScatter3DInt" in decoder_op_types

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -3482,6 +3482,46 @@ def test_layerwise_compile_hydrates_outer_qpc_paths(monkeypatch, tmp_path):
 
 
 @pytest.mark.llm_model
+def test_dual_qpc_decode_only_continuous_batching_returns_decode_qpc_key(monkeypatch):
+    from QEfficient.transformers.models import modeling_auto
+    from QEfficient.transformers.models.modeling_auto import _QEffAutoModelForImageTextToTextDualQPC
+
+    model = object.__new__(_QEffAutoModelForImageTextToTextDualQPC)
+    model.continuous_batching = True
+    model.ccl_enabled = False
+    model.comp_ctx_lengths_prefill = None
+    model.comp_ctx_lengths_decode = None
+    model.transform = lambda **kwargs: None
+    model.model = type(
+        "Model",
+        (),
+        {
+            "config": type("Config", (), {"torch_dtype": torch.float32, "model_type": "test"})(),
+            "get_output_names": lambda self, **kwargs: {"vision": [], "lang": []},
+            "get_specializations": lambda self, **kwargs: ({"vision": [], "lang": [{"seq_len": 1}]}, {}),
+        },
+    )()
+    model.lang_model = type(
+        "LanguageModel",
+        (),
+        {"onnx_path": "language.onnx", "_compile": staticmethod(lambda **kwargs: "decode.qpc")},
+    )()
+
+    monkeypatch.setattr(modeling_auto, "_filter_custom_io_for_onnx", lambda custom_io, onnx_path: custom_io)
+
+    result = model.compile(
+        prefill_seq_len=1,
+        ctx_len=16,
+        batch_size=1,
+        full_batch_size=4,
+        skip_vision=True,
+        lang_onnx_path="language.onnx",
+    )
+
+    assert result == {"lang_decode_qpc_path": "decode.qpc"}
+
+
+@pytest.mark.llm_model
 def test_layerwise_compile_rejects_unsupported_model():
     """End-to-end smoke: invoking layerwise=True on llama bubbles the guard error."""
     try:

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -3482,46 +3482,6 @@ def test_layerwise_compile_hydrates_outer_qpc_paths(monkeypatch, tmp_path):
 
 
 @pytest.mark.llm_model
-def test_dual_qpc_decode_only_continuous_batching_returns_decode_qpc_key(monkeypatch):
-    from QEfficient.transformers.models import modeling_auto
-    from QEfficient.transformers.models.modeling_auto import _QEffAutoModelForImageTextToTextDualQPC
-
-    model = object.__new__(_QEffAutoModelForImageTextToTextDualQPC)
-    model.continuous_batching = True
-    model.ccl_enabled = False
-    model.comp_ctx_lengths_prefill = None
-    model.comp_ctx_lengths_decode = None
-    model.transform = lambda **kwargs: None
-    model.model = type(
-        "Model",
-        (),
-        {
-            "config": type("Config", (), {"torch_dtype": torch.float32, "model_type": "test"})(),
-            "get_output_names": lambda self, **kwargs: {"vision": [], "lang": []},
-            "get_specializations": lambda self, **kwargs: ({"vision": [], "lang": [{"seq_len": 1}]}, {}),
-        },
-    )()
-    model.lang_model = type(
-        "LanguageModel",
-        (),
-        {"onnx_path": "language.onnx", "_compile": staticmethod(lambda **kwargs: "decode.qpc")},
-    )()
-
-    monkeypatch.setattr(modeling_auto, "_filter_custom_io_for_onnx", lambda custom_io, onnx_path: custom_io)
-
-    result = model.compile(
-        prefill_seq_len=1,
-        ctx_len=16,
-        batch_size=1,
-        full_batch_size=4,
-        skip_vision=True,
-        lang_onnx_path="language.onnx",
-    )
-
-    assert result == {"lang_decode_qpc_path": "decode.qpc"}
-
-
-@pytest.mark.llm_model
 def test_layerwise_compile_rejects_unsupported_model():
     """End-to-end smoke: invoking layerwise=True on llama bubbles the guard error."""
     try:

--- a/tests/unit_test/transforms/test_blocking_transform.py
+++ b/tests/unit_test/transforms/test_blocking_transform.py
@@ -26,6 +26,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+from QEfficient.blocking import attention_blocking
 from QEfficient.blocking.attention_blocking import AttentionBlockingConfig, BlockingMode
 
 VOCAB_SIZE = 500
@@ -298,6 +299,42 @@ class TestBlockingModes:
             assert c.head_block_size == 8
             assert c.skip_kv is False
             assert c.num_batch_blocks == 1
+
+
+@pytest.mark.transforms
+def test_generic_blocked_attention_infers_prefill_only_from_mode(monkeypatch):
+    class Cache:
+        def __init__(self):
+            self.write_only_calls = []
+
+        def write_only(self, key, value, layer_idx, cache_kwargs):
+            self.write_only_calls.append((key, value, layer_idx, cache_kwargs))
+
+    cache = Cache()
+    query = torch.ones(1, 1, 1, 1)
+    key = torch.ones(1, 1, 1, 1)
+    value = torch.ones(1, 1, 1, 1)
+    strategy_calls = []
+
+    def prefill_strategy(**kwargs):
+        strategy_calls.append(kwargs)
+        return kwargs["query"], None
+
+    monkeypatch.setitem(attention_blocking._STRATEGIES, BlockingMode.PREFILL_Q, prefill_strategy)
+
+    output, weights = attention_blocking.generic_blocked_attention_interface(
+        module=type("Attention", (), {"layer_idx": 0})(),
+        query=query,
+        key=key,
+        value=value,
+        past_key_value=cache,
+        blocking_config=AttentionBlockingConfig(mode=BlockingMode.PREFILL_Q, num_q_blocks=1),
+    )
+
+    assert torch.equal(output, query)
+    assert weights is None
+    assert len(cache.write_only_calls) == 1
+    assert len(strategy_calls) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

  - Added `LocalizeFunctionReduceSumAxesTransform` for ONNX subfunction exports.
  - Replaced the previous `torch.einsum(... reduction ...)` workarounds back to equivalent `.sum(...)` forms across QEff modeling/MoE/blocking code.
  - Enabled the ReduceSum axes localization only when `use_onnx_subfunctions=True`.

  We previously used `einsum` in several reduction patterns to avoid ONNX subfunction export promoting constant `ReduceSum` axes into `FunctionProto` inputs. That workaround avoided compiler failures, but it could lower into heavier performance dip's due to lowering of BMM instead of the intended elementwise multiply plus ReduceSum path.

  The desired PyTorch source should be able to stay as:

  ```python
  (query * query).sum(dim=-1, keepdim=True)
  and export as:
  Mul -> ReduceSum <- Constant([-1]) -- inside the ONNX function body.
  ```

  ## ONNX Transform Details

  LocalizeFunctionReduceSumAxesTransform it rewrites a function input when:

  - a node inside an ONNX FunctionProto is ReduceSum
  - the ReduceSum axes input is one of the function formal inputs
  - every top-level call site passes a compile-time constant for that formal input
  - the value is a valid integer scalar or 1-D axes tensor

  When eligible, the transform:

  - inserts a local Constant node inside the function body
  - rewires each matching ReduceSum to use that local constant
  - removes the axes formal input from the function signature