### PR TITLE
fix(write_io): capture complete generate() I/O traces for LLM and VLM models

### DIFF
--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -848,7 +848,9 @@ class QEffTextGenerationBase:
             outputs = self._session.run(chunk_inputs)
 
             if self._write_io_dir is not None:
-                write_io_files(inputs, outputs, self._write_io_dir, "prefill", "aic_batch_io", True, False)
+                write_io_files(
+                    chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False
+                )
         return (
             outputs,
             position_ids,
@@ -1020,8 +1022,9 @@ class QEffTextGenerationBase:
             outputs = self._session.run(decode_inputs)
 
             if self._write_io_dir is not None:
-                write_io_files(decode_inputs, outputs, self._write_io_dir, "decode", "aic_batch_io", True, False)
-                self._write_io_dir = None
+                write_io_files(
+                    decode_inputs, outputs, self._write_io_dir, f"decode_{num_token}", "aic_batch_io", True, False
+                )
 
             # Prepare inputs for next iteration
             decode_inputs["input_ids"] = self._fetch_next_token_id(outputs)
@@ -1055,8 +1058,9 @@ class QEffTextGenerationBase:
             outputs = self._session.run(decode_inputs)
 
             if self._write_io_dir is not None:
-                write_io_files(decode_inputs, outputs, self._write_io_dir, "decode", "aic_batch_io", True, False)
-                self._write_io_dir = None
+                write_io_files(
+                    decode_inputs, outputs, self._write_io_dir, f"decode_{num_token}", "aic_batch_io", True, False
+                )
 
             # Prepare inputs for next iteration
             decode_inputs["input_ids"] = outputs["logits"].argmax(2)

--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -848,9 +848,7 @@ class QEffTextGenerationBase:
             outputs = self._session.run(chunk_inputs)
 
             if self._write_io_dir is not None:
-                write_io_files(
-                    chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False
-                )
+                write_io_files(chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False)
         return (
             outputs,
             position_ids,

--- a/QEfficient/generation/vlm_generation.py
+++ b/QEfficient/generation/vlm_generation.py
@@ -675,7 +675,13 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
                 chunk_outputs = self._vision_session.run(chunk_inputs)
                 if self._write_io_dir is not None:
                     write_io_files(
-                        chunk_inputs, chunk_outputs, self._write_io_dir, f"vision_frame_{i}", "aic_batch_io", True, False
+                        chunk_inputs,
+                        chunk_outputs,
+                        self._write_io_dir,
+                        f"vision_frame_{i}",
+                        "aic_batch_io",
+                        True,
+                        False,
                     )
                 if i == 0:
                     vision_outputs = chunk_outputs

--- a/QEfficient/generation/vlm_generation.py
+++ b/QEfficient/generation/vlm_generation.py
@@ -397,7 +397,7 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
                 chunk_image_idx = outputs["image_idx_output"]
 
             if self._write_io_dir is not None:
-                write_io_files(lang_inputs, outputs, self._write_io_dir, "prefill", "aic_batch_io", True, False)
+                write_io_files(chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False)
 
         # Prepare decode-time cross_attention_mask
         if "cross_attention_mask" in lang_inputs:
@@ -673,6 +673,10 @@ class VisionLanguageGeneration(QEffTextGenerationBase):
             for i in range(num_frames):
                 chunk_inputs["pixel_values"] = vision_inputs["pixel_values"][i * vision_size : (i + 1) * vision_size]
                 chunk_outputs = self._vision_session.run(chunk_inputs)
+                if self._write_io_dir is not None:
+                    write_io_files(
+                        chunk_inputs, chunk_outputs, self._write_io_dir, f"vision_frame_{i}", "aic_batch_io", True, False
+                    )
                 if i == 0:
                     vision_outputs = chunk_outputs
                 else:

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -2565,7 +2565,9 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             chunk_inputs["image_idx"] = outputs["image_idx_output"]
 
             if self._write_io_dir is not None:
-                write_io_files(lang_inputs, outputs, self._write_io_dir, "prefill", "aic_batch_io", True, False)
+                write_io_files(
+                    chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False
+                )
 
         prefill_time = perf_counter() - lang_start + vision_end - vision_start
         # Skip inputs/outputs again
@@ -2624,14 +2626,15 @@ class _QEffAutoModelForImageTextToTextDualQPC:
 
             outputs = lang_session.run(lang_inputs)
             if self._write_io_dir is not None:
-                write_io_files(lang_inputs, outputs, self._write_io_dir, "decode", "aic_batch_io", True, False)
-                self._write_io_dir = None
+                write_io_files(
+                    lang_inputs, outputs, self._write_io_dir, f"decode_{num_token}", "aic_batch_io", True, False
+                )
 
             # Prepare inputs for next iteration
             lang_inputs["input_ids"] = outputs["logits"].argmax(2)
             lang_inputs["position_ids"] += 1
             if "mm_token_type_ids" in lang_inputs:
-                lang_inputs["mm_token_type_ids"] = np.zeros_like(
+                lang_inputs["mm_token_ids"] = np.zeros_like(
                     lang_inputs["input_ids"], dtype=lang_inputs["mm_token_type_ids"].dtype
                 )
             generated_ids[:, num_token] = lang_inputs["input_ids"].squeeze(1)
@@ -3181,7 +3184,9 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
             outputs = qpc_session.run(chunk_inputs)
 
             if self._write_io_dir is not None:
-                write_io_files(chunk_inputs, outputs, self._write_io_dir, "prefill", "aic_batch_io", True, False)
+                write_io_files(
+                    chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False
+                )
 
             chunk_inputs["image_idx"] = outputs["image_idx_output"]
 
@@ -3226,8 +3231,9 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
 
             outputs = qpc_session.run(inputs)
             if self._write_io_dir is not None:
-                write_io_files(inputs, outputs, self._write_io_dir, "decode", "aic_batch_io", True, False)
-                self._write_io_dir = None
+                write_io_files(
+                    inputs, outputs, self._write_io_dir, f"decode_{num_token}", "aic_batch_io", True, False
+                )
 
             # Prepare inputs for next iteration
             inputs["input_ids"] = outputs["logits"].argmax(2)
@@ -5195,7 +5201,7 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
         outputs = self.qpc_session.run(inputs)
 
         if self._write_io_dir is not None:
-            write_io_files(inputs, outputs, self._write_io_dir, "prefill", "aic_batch_io", True, False)
+            write_io_files(inputs, outputs, self._write_io_dir, "prefill_0", "aic_batch_io", True, False)
 
         # array to hold generated tokens
         generated_ids = np.full((self.batch_size, generation_len + 1), self.model.config.eos_token_id)
@@ -5213,8 +5219,9 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
         for num_tokens in range(generation_len):
             outputs = self.qpc_session.run(inputs)
             if self._write_io_dir is not None:
-                write_io_files(inputs, outputs, self._write_io_dir, "decode", "aic_batch_io", True, False)
-                self._write_io_dir = None
+                write_io_files(
+                    inputs, outputs, self._write_io_dir, f"decode_{num_tokens}", "aic_batch_io", True, False
+                )
 
             logits = outputs["logits"]
             next_token = logits.argmax(-1)

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -2462,6 +2462,10 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         vision_outputs = {}
         if vision_inputs:
             vision_outputs = vision_session.run(vision_inputs)
+            if self._write_io_dir is not None:
+                write_io_files(
+                    vision_inputs, vision_outputs, self._write_io_dir, "vision_prefill_0", "aic_batch_io", True, False
+                )
         vision_end = perf_counter()
 
         lang_inputs = {k: v for k, v in inputs.items() if k not in vision_inputs}

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -8,10 +8,10 @@
 import math
 import os
 import warnings
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from time import perf_counter
 from typing import List, Optional, Union
-from datetime import datetime, timezone, timedelta
 
 import numpy as np
 import onnx
@@ -109,6 +109,7 @@ TORCH_TO_NUMPY_DTYPE_MAP = {
     torch.bfloat16: np.float16,  # Since numpy doesn't support bfloat16
     torch.float32: np.float32,
 }
+
 
 def get_io_dir(onnx_path: str) -> str:
     """Return a timestamped io_dir path under the model's onnx directory.
@@ -2579,9 +2580,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             chunk_inputs["image_idx"] = outputs["image_idx_output"]
 
             if self._write_io_dir is not None:
-                write_io_files(
-                    chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False
-                )
+                write_io_files(chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False)
 
         prefill_time = perf_counter() - lang_start + vision_end - vision_start
         # Skip inputs/outputs again
@@ -3198,9 +3197,7 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
             outputs = qpc_session.run(chunk_inputs)
 
             if self._write_io_dir is not None:
-                write_io_files(
-                    chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False
-                )
+                write_io_files(chunk_inputs, outputs, self._write_io_dir, f"prefill_{i}", "aic_batch_io", True, False)
 
             chunk_inputs["image_idx"] = outputs["image_idx_output"]
 
@@ -3245,9 +3242,7 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
 
             outputs = qpc_session.run(inputs)
             if self._write_io_dir is not None:
-                write_io_files(
-                    inputs, outputs, self._write_io_dir, f"decode_{num_token}", "aic_batch_io", True, False
-                )
+                write_io_files(inputs, outputs, self._write_io_dir, f"decode_{num_token}", "aic_batch_io", True, False)
 
             # Prepare inputs for next iteration
             inputs["input_ids"] = outputs["logits"].argmax(2)
@@ -5233,9 +5228,7 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
         for num_tokens in range(generation_len):
             outputs = self.qpc_session.run(inputs)
             if self._write_io_dir is not None:
-                write_io_files(
-                    inputs, outputs, self._write_io_dir, f"decode_{num_tokens}", "aic_batch_io", True, False
-                )
+                write_io_files(inputs, outputs, self._write_io_dir, f"decode_{num_tokens}", "aic_batch_io", True, False)
 
             logits = outputs["logits"]
             next_token = logits.argmax(-1)

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -11,6 +11,7 @@ import warnings
 from pathlib import Path
 from time import perf_counter
 from typing import List, Optional, Union
+from datetime import datetime, timezone, timedelta
 
 import numpy as np
 import onnx
@@ -108,6 +109,15 @@ TORCH_TO_NUMPY_DTYPE_MAP = {
     torch.bfloat16: np.float16,  # Since numpy doesn't support bfloat16
     torch.float32: np.float32,
 }
+
+def get_io_dir(onnx_path: str) -> str:
+    """Return a timestamped io_dir path under the model's onnx directory.
+
+    Format: <onnx_dir>/io_dir/<YYYYMMDD_HHMMSS_EST>
+    """
+    est = timezone(timedelta(hours=-5))
+    timestamp = datetime.now(est).strftime("%Y%m%d_%H%M%S")
+    return os.path.join(os.path.dirname(onnx_path), "io_dir", timestamp)
 
 
 def _resolve_torch_dtype(kwargs: dict) -> None:
@@ -731,7 +741,7 @@ class QEFFAutoModel(QEFFTransformersBase):
         torch.Tensor or np.ndarray
             Output from the AI 100 or PyTorch runtime. The type depends on the runtime and model.
         """
-        self._write_io_dir = os.path.join(os.path.dirname(self.onnx_path), "io_dir") if write_io else None
+        self._write_io_dir = get_io_dir(self.onnx_path) if write_io else None
 
         # AI_100 runtime
         if runtime_ai100:
@@ -2292,7 +2302,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             raise NotImplementedError("PyTorch execution is not supported yet for this model!")
 
         write_io = kwargs.pop("write_io", False)
-        self._write_io_dir = os.path.join(os.path.dirname(self.onnx_path[1]), "io_dir") if write_io else None
+        self._write_io_dir = get_io_dir(self.lang_model.onnx_path) if write_io else None
 
         # Use VisionLanguageGeneration for image-prompt pairs
         if (processor and images) or (tokenizer and prompts) or multi_specs or num_frames:
@@ -3062,7 +3072,7 @@ class _QEFFAutoModelForImageTextToTextSingleQPC(QEFFTransformersBase, Multimodal
         if not runtime_ai100:
             raise NotImplementedError("PyTorch execution is not supported yet for this model!")
 
-        self._write_io_dir = os.path.join(os.path.dirname(self.onnx_path), "io_dir") if write_io else None
+        self._write_io_dir = get_io_dir(self.onnx_path) if write_io else None
 
         return self.cloud_ai_100_generate(
             inputs=inputs, device_ids=device_ids, generation_len=generation_len, streamer=streamer
@@ -4816,7 +4826,7 @@ class QEFFAutoModelForCausalLM(QEFFBaseModel):
             If `runtime_ai100` is False.
         """
         write_io = kwargs.pop("write_io", False)
-        self._write_io_dir = os.path.join(os.path.dirname(self.onnx_path), "io_dir") if write_io else None
+        self._write_io_dir = get_io_dir(self.onnx_path) if write_io else None
 
         if runtime_ai100:
             if not isinstance(self.qpc_path, Path):
@@ -5173,7 +5183,7 @@ class QEFFAutoModelForSpeechSeq2Seq(QEFFTransformersBase, MultimodalUtilityMixin
         if not isinstance(self.qpc_path, Path):
             raise TypeError("Please run compile API first!")
 
-        self._write_io_dir = os.path.join(os.path.dirname(self.onnx_path), "io_dir") if write_io else None
+        self._write_io_dir = get_io_dir(self.onnx_path) if write_io else None
 
         inputs = self.auto_correct_inputs(inputs)
         if self.qpc_session is None:
@@ -5475,7 +5485,7 @@ class QEFFAutoModelForCTC(QEFFTransformersBase):
         Returns:
             :dict: Output from the ``AI_100`` or ``PyTorch`` runtime.
         """
-        self._write_io_dir = os.path.join(os.path.dirname(self.onnx_path), "io_dir") if write_io else None
+        self._write_io_dir = get_io_dir(self.onnx_path) if write_io else None
 
         # AI_100 runtime
         if runtime_ai100:


### PR DESCRIPTION
## Summary

Fix several issues in the `write_io_files` capture flow when using:

```python
model.generate(..., write_io=True)
```

This PR resolves **QRANIUMSW-63509** by:

- Capturing the correct `chunk_inputs` during chunked prefill instead of the full padded inputs
- Preserving all prefill and decode iterations using indexed file names
- Capturing missing vision encoder inputs and outputs in VLM paths
- Preventing collisions between vision and language prefill captures
- Generating a timestamped `io_dir` for each `generate()` invocation
- Fixing Dual-QPC language ONNX path selection
- Adding runtime and virtual environment artifacts to `.gitignore`

## Changes

### Correct prefill input capture

Use the same `chunk_inputs` passed to `session.run()` when writing captured I/O.

### Preserve all iterations

Store each generation step in a unique file:

```text
prefill_0
prefill_1
...
decode_1
decode_2
...
```

Also remove logic that disabled capture after the first decode step.

### Capture vision encoder I/O

Add `write_io_files` support for VLM vision encoder execution paths.

Vision captures are stored separately from language captures:

```text
vision_prefill_0
vision_prefill_1
...
```

This avoids overwrite/collision with language prefill outputs.

### Timestamp output directories

Each `generate()` call now writes into a unique timestamped directory:

```text
io_dir/<timestamp>/
```

preventing collisions across multiple runs.

### Dual-QPC fix

Replace reliance on `self.onnx_path[1]` with the explicit language model ONNX path.

## Example Output

### Text-to-Text Model

```text
~/.cache/qeff_models/Qwen2ForCausalLM/
└── Qwen2ForCausalLM-1657fb5c3133a3d4/
    └── io_dir/
        └── 20260907_033641/
            ├── aic_batch_io.json
            ├── prefill_0
            ├── decode_1
            ├── decode_2
            ├── ...
            └── decode_99
```

### Vision-Language Model

```text
~/.cache/qeff_models/LlavaForConditionalGeneration/
└── LlavaDecoderWrapper-84c9b297d91aeb74/
    └── io_dir/
        └── 20260907_033803/
            ├── aic_batch_io.json
            ├── vision_prefill_0
            ├── prefill_0
            ├── prefill_1
            ├── prefill_2
            ├── prefill_3
            ├── prefill_4
            ├── decode_1
            ├── decode_2
            ├── ...
            └── decode_127
```

This demonstrates that vision prefill, language prefill, and all decode iterations are now preserved instead of being overwritten.

## Result

With `write_io=True`, all inputs and outputs used throughout generation are captured and preserved for both text and vision-language models, including:

- Vision prefill
- Language prefill
- All decode iterations

## Validation

Verified on:

- Qwen2ForCausalLM
- GPT2LMHeadModel
- LlavaForConditionalGeneration

Confirmed:

- Correct chunked input capture
- Vision encoder capture
- No I/O overwrites
- No vision/lang file collisions
- Unique output directories per `generate()` call