### PR TITLE
Enable wight-free export for VLM

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -69,6 +69,10 @@ _LEGACY_MOE_PREFILL_PACKED_CHUNK_SIZE_ERROR = (
 )
 
 
+def _print_timing(label: str, start_time: float) -> None:
+    print(f"[QEfficient timing] {label} took {time.perf_counter() - start_time:.3f} sec", flush=True)
+
+
 def reject_legacy_moe_prefill_packed_chunk_size(kwargs: Optional[dict]) -> None:
     if kwargs and "moe_prefill_packed_chunk_size" in kwargs:
         raise TypeError(_LEGACY_MOE_PREFILL_PACKED_CHUNK_SIZE_ERROR)
@@ -563,43 +567,55 @@ class QEFFBaseModel(ABC):
             if self._weight_free:
                 from QEfficient.exporter.onnx_exporter import export_via_weightfree
 
-                export_result = export_via_weightfree(
-                    self,
-                    onnx_path,
-                    example_inputs,
-                    input_names,
-                    output_names,
-                    dynamic_shapes,
-                    export_kwargs,
-                    onnx_transform_kwargs,
-                )
+                export_start_time = time.perf_counter()
+                try:
+                    export_result = export_via_weightfree(
+                        self,
+                        onnx_path,
+                        example_inputs,
+                        input_names,
+                        output_names,
+                        dynamic_shapes,
+                        export_kwargs,
+                        onnx_transform_kwargs,
+                    )
+                finally:
+                    _print_timing(f"{self.model_name} weight-free dynamo export", export_start_time)
             elif dynamo:
                 from QEfficient.exporter.onnx_exporter import export_via_dynamo
 
                 self._model_offloaded_check()
-                export_result = export_via_dynamo(
-                    self,
-                    onnx_path,
-                    example_inputs,
-                    input_names,
-                    output_names,
-                    dynamic_shapes,
-                    export_kwargs,
-                )
+                export_start_time = time.perf_counter()
+                try:
+                    export_result = export_via_dynamo(
+                        self,
+                        onnx_path,
+                        example_inputs,
+                        input_names,
+                        output_names,
+                        dynamic_shapes,
+                        export_kwargs,
+                    )
+                finally:
+                    _print_timing(f"{self.model_name} dynamo export", export_start_time)
                 self._offload_model_weights(offload_pt_weights)
             else:
                 from QEfficient.exporter.onnx_exporter import export_via_legacy
 
                 self._model_offloaded_check()
-                export_result = export_via_legacy(
-                    self,
-                    onnx_path,
-                    example_inputs,
-                    input_names,
-                    output_names,
-                    dynamic_axes,
-                    export_kwargs,
-                )
+                export_start_time = time.perf_counter()
+                try:
+                    export_result = export_via_legacy(
+                        self,
+                        onnx_path,
+                        example_inputs,
+                        input_names,
+                        output_names,
+                        dynamic_axes,
+                        export_kwargs,
+                    )
+                finally:
+                    _print_timing(f"{self.model_name} legacy export", export_start_time)
                 self._offload_model_weights(offload_pt_weights)
             logger.info("PyTorch export successful")
             self.weight_spec_path = str(export_result.weight_spec_path) if export_result.weight_spec_path else None
@@ -1304,7 +1320,11 @@ class QEFFBaseModel(ABC):
         logger.info(f"Running compiler: {' '.join(command)}")
 
         try:
-            subprocess.run(command, capture_output=True, check=True)
+            compile_start_time = time.perf_counter()
+            try:
+                subprocess.run(command, capture_output=True, check=True)
+            finally:
+                _print_timing(f"{self.model_name} qaic compile", compile_start_time)
         except subprocess.CalledProcessError as e:
             raise RuntimeError(
                 "\n".join(

--- a/QEfficient/exporter/weight_free/checkpoint_key_resolver.py
+++ b/QEfficient/exporter/weight_free/checkpoint_key_resolver.py
@@ -6,7 +6,6 @@
 # ----------------------------------------------------------------------------
 
 from pathlib import Path
-from typing import Dict, List, Optional
 
 import onnx_ir as ir
 from torch import nn
@@ -58,7 +57,7 @@ def _collect_tied_weights(model: nn.Module) -> list[TiedWeightAlias]:
     return [TiedWeightAlias(alias=alias, canonical=canonical) for alias, canonical in tied_mapping.items()]
 
 
-def _moe_weight_aliases(name: str) -> List[str]:
+def _moe_weight_aliases(name: str) -> list[str]:
     """Return equivalent checkpoint aliases for shared MoEWeights parameters."""
     aliases = []
     canonical = name
@@ -75,22 +74,43 @@ def _moe_weight_aliases(name: str) -> List[str]:
     return aliases
 
 
-def _find_checkpoint_key(candidates: List[str], checkpoint_index: Dict[str, str], onnx_name: str) -> Optional[str]:
+def _vlm_wrapper_aliases(name: str) -> list[str]:
+    """Return checkpoint aliases introduced by VLM component wrapper nesting."""
+    aliases = []
+    if name.startswith("model.model."):
+        aliases.append("model." + name[len("model.model.") :])
+    if name.startswith("model.vision_model."):
+        aliases.append("model.visual." + name[len("model.vision_model.") :])
+    if name.startswith("vision_model."):
+        aliases.append("model.visual." + name[len("vision_model.") :])
+    if name.startswith("visual."):
+        aliases.append("model.visual." + name[len("visual.") :])
+    if name.startswith("language_model."):
+        aliases.append("model.language_model." + name[len("language_model.") :])
+    if name.startswith("model.lm_head."):
+        aliases.append("lm_head." + name[len("model.lm_head.") :])
+    if name.startswith("lm_head."):
+        aliases.append("model.lm_head." + name[len("lm_head.") :])
+    return aliases
+
+
+def _find_checkpoint_key(candidates: list[str], checkpoint_index: dict[str, str], onnx_name: str) -> str | None:
     """Return the unique matching checkpoint key, or fail on ambiguous matches."""
     seen = set()
     matches = []
     for candidate in candidates:
-        if candidate in seen:
-            continue
-        seen.add(candidate)
-        if candidate in checkpoint_index:
-            matches.append(candidate)
-        for alias in _moe_weight_aliases(candidate):
+        for alias in [candidate, *_vlm_wrapper_aliases(candidate)]:
             if alias in seen:
                 continue
             seen.add(alias)
             if alias in checkpoint_index:
                 matches.append(alias)
+            for moe_alias in _moe_weight_aliases(alias):
+                if moe_alias in seen:
+                    continue
+                seen.add(moe_alias)
+                if moe_alias in checkpoint_index:
+                    matches.append(moe_alias)
     if len(matches) > 1:
         raise ValueError(
             f"Ambiguous checkpoint key for ONNX initializer '{onnx_name}': matched {matches}. "
@@ -106,9 +126,9 @@ def _is_computed_initializer(name: str) -> bool:
 
 def find_checkpoint_key(
     onnx_name: str,
-    checkpoint_index: Dict[str, str],
+    checkpoint_index: dict[str, str],
     backbone: nn.Module,
-) -> Optional[str]:
+) -> str | None:
     """Resolve an ONNX initializer name to its safetensors checkpoint key.
 
     Most weights match directly. The fallback rules cover wrapper prefixes,
@@ -179,15 +199,14 @@ def promote_initializers_and_build_spec(onnx_program, model_ref: str, model_name
         for checkpoint_file in checkpoint_files
     ]
     backbone = qeff_model.model.base_model if isinstance(qeff_model.model, PooledModel) else qeff_model.model
-    promoted_inputs: List[WeightSpecInput] = []
+    promoted_inputs: list[WeightSpecInput] = []
 
     for name, init_value in list(model_ir.graph.initializers.items()):
-        if name not in model_names:
-            continue
-
         onnx_name = tied_weight_map.get(name, name)
         checkpoint_key = find_checkpoint_key(onnx_name, checkpoint_index, backbone)
         if checkpoint_key is None:
+            if name not in model_names:
+                continue
             if _is_computed_initializer(onnx_name):
                 continue
             raise ValueError(

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -1121,6 +1121,13 @@ class QEffVisionEncoderForTextImageToTextModel(QEFFBaseModel):
         KVCacheExternalModuleMapperTransform,
     ]
     _onnx_transforms = []
+    _checkpoint_transforms = [
+        GptOssMxfp4ExpertDequantSplitCheckpointTransform,
+        MoEExpertStackingCheckpointTransform,
+        MoEFusedExpertSplitCheckpointTransform,
+        GraniteMoeFusedExpertSplitCheckpointTransform,
+        DtypeConversionCheckpointTransform,
+    ]
 
     def __init__(self, model: nn.modules, **kwargs):
         """
@@ -1136,9 +1143,19 @@ class QEffVisionEncoderForTextImageToTextModel(QEFFBaseModel):
         _configure_proxy_for_model(self, kwargs.pop("enable_proxy", False))
         super().__init__(model, **kwargs)
         self.model = model.get_qeff_vision_encoder()
+        self.model.config = self.config
         self.hash_params["qeff_auto_class"] = self.__class__.__name__
 
-    def export(self, inputs, output_names, dynamic_axes, export_dir=None, offload_pt_weights=True, **kwargs):
+    def export(
+        self,
+        inputs,
+        output_names,
+        dynamic_axes,
+        export_dir=None,
+        offload_pt_weights=True,
+        dynamo: bool = False,
+        **kwargs,
+    ):
         """
         Exports the vision encoder component to ONNX format.
 
@@ -1162,13 +1179,20 @@ class QEffVisionEncoderForTextImageToTextModel(QEFFBaseModel):
         str
             Path to the generated ONNX graph file for the vision encoder.
         """
+        dynamo = dynamo or self._weight_free
+        export_kwargs = {
+            "use_onnx_subfunctions": kwargs.get("use_onnx_subfunctions", False),
+            "dynamo": dynamo,
+        }
+        if dynamo:
+            export_kwargs["dynamic_shapes"] = kwargs.get("dynamic_shapes")
         return self._export(
             inputs,
             output_names=output_names,
             dynamic_axes=dynamic_axes,
             export_dir=export_dir,
             offload_pt_weights=offload_pt_weights,
-            use_onnx_subfunctions=kwargs.get("use_onnx_subfunctions", False),
+            **export_kwargs,
         )
 
     def compile(
@@ -1181,6 +1205,7 @@ class QEffVisionEncoderForTextImageToTextModel(QEFFBaseModel):
         aic_num_cores,
         custom_io,
         use_onnx_subfunctions: bool = False,
+        dynamo: bool = False,
         **compiler_options,
     ) -> str:
         """
@@ -1212,6 +1237,7 @@ class QEffVisionEncoderForTextImageToTextModel(QEFFBaseModel):
         str
             Path to the compiled QPC package for the vision encoder.
         """
+        dynamo = dynamo or self._weight_free
         return self._compile(
             compile_dir=compile_dir,
             specializations=specializations,
@@ -1221,6 +1247,7 @@ class QEffVisionEncoderForTextImageToTextModel(QEFFBaseModel):
             aic_num_cores=aic_num_cores,
             custom_io=custom_io,
             use_onnx_subfunctions=use_onnx_subfunctions,
+            dynamo=dynamo,
             **compiler_options,
         )
 
@@ -1259,6 +1286,13 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
         SimpleDecodeMoeTransform,
     ]
     _onnx_transforms = []
+    _checkpoint_transforms = [
+        GptOssMxfp4ExpertDequantSplitCheckpointTransform,
+        MoEExpertStackingCheckpointTransform,
+        MoEFusedExpertSplitCheckpointTransform,
+        GraniteMoeFusedExpertSplitCheckpointTransform,
+        DtypeConversionCheckpointTransform,
+    ]
 
     def __init__(self, model, qaic_config: Optional[dict] = None, **kwargs):
         """
@@ -1277,6 +1311,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
         _configure_proxy_for_model(self, kwargs.pop("enable_proxy", False))
         super().__init__(model, **kwargs)
         self.model = model.get_qeff_language_decoder()
+        self.model.config = self.config
         self.model.qaic_config = qaic_config
         self.hash_params["qeff_auto_class"] = self.__class__.__name__
         self.continuous_batching = False
@@ -1314,6 +1349,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
         prefill_only: bool = False,
         enable_chunking: bool = False,
         kv_cache_prefix: Optional[str] = None,
+        dynamo: bool = False,
         **kwargs,
     ):
         """
@@ -1353,6 +1389,10 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
             self.__update_prefill_transform(False, retain_full_kv=kwargs.get("retain_full_kv", False))
 
         qaic_config = kwargs.pop("qaic_config", getattr(self.model, "qaic_config", None))
+        dynamo = dynamo or self._weight_free
+
+        if dynamo and QEfficient.base.modeling_qeff.QEFFBaseModel._layerwise_active:
+            raise NotImplementedError("Dynamo export is not supported for layerwise VLM export in v1.")
 
         if QEfficient.base.modeling_qeff.QEFFBaseModel._layerwise_active:
             return self._export_layerwise(
@@ -1378,6 +1418,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
                 export_dir=export_dir,
                 offload_pt_weights=offload_pt_weights,
                 use_onnx_subfunctions=kwargs.get("use_onnx_subfunctions", False),
+                dynamo=dynamo,
             )
 
     def compile(
@@ -1390,6 +1431,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
         aic_num_cores,
         custom_io,
         use_onnx_subfunctions: bool = False,
+        dynamo: bool = False,
         **compiler_options,
     ) -> str:
         """
@@ -1421,6 +1463,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
         str
             Path to the compiled QPC package for the language decoder.
         """
+        dynamo = dynamo or self._weight_free
         return self._compile(
             compile_dir=compile_dir,
             specializations=specializations,
@@ -1430,6 +1473,7 @@ class QEffCausalLMForTextImageToTextModel(QEFFBaseModel):
             aic_num_cores=aic_num_cores,
             custom_io=custom_io,
             use_onnx_subfunctions=use_onnx_subfunctions,
+            dynamo=dynamo,
             **compiler_options,
         )
 
@@ -1486,6 +1530,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         self.model = model
         self.config = model.config
         self._pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None)
+        self._weight_free = kwargs.get("weight_free", False)
 
         self.vision_model = QEffVisionEncoderForTextImageToTextModel(model, **kwargs)
         self.lang_model = QEffCausalLMForTextImageToTextModel(model, qaic_config=qaic_config, **kwargs)
@@ -1503,7 +1548,13 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         self.lang_model.model, _ = SamplerTransform.apply(self.lang_model.model, qaic_config, **kwargs)
 
     @classmethod
-    def from_pretrained(cls, pretrained_model_name_or_path: str, qaic_config: Optional[dict] = None, **kwargs):
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str,
+        qaic_config: Optional[dict] = None,
+        weight_free: bool = False,
+        **kwargs,
+    ):
         """
         Load a QEfficient multimodal model for dual QPC from a pretrained HuggingFace model or local path.
 
@@ -1539,7 +1590,10 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         )
 
         _resolve_torch_dtype(kwargs)
-        model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
+        if weight_free:
+            model = _build_meta_model(cls._hf_auto_class, pretrained_model_name_or_path, kwargs)
+        else:
+            model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
 
         kwargs.update({"enable_proxy": enable_proxy} if enable_proxy else {})
 
@@ -1547,6 +1601,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             model,
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             qaic_config=qaic_config,
+            weight_free=weight_free,
             **kwargs,
         )
 
@@ -1561,6 +1616,11 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             A list containing the ONNX paths of the vision model and the language model.
         """
         return [self.vision_model.onnx_path, self.lang_model.onnx_path]
+
+    @property
+    def weight_spec_path(self):
+        """Get the weight-spec paths for the vision and language components."""
+        return [self.vision_model.weight_spec_path, self.lang_model.weight_spec_path]
 
     def __update_prefill_transform(
         self,
@@ -1596,6 +1656,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
         offload_pt_weights: Optional[bool] = None,
+        dynamo: bool = False,
         **kwargs,
     ) -> str:
         """
@@ -1620,6 +1681,10 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         """
         layerwise_cache_probe = kwargs.pop("_layerwise_cache_probe", False)
         reject_legacy_moe_prefill_packed_chunk_size(kwargs)
+        dynamo = dynamo or self._weight_free
+        use_onnx_subfunctions = use_onnx_subfunctions or self._weight_free
+        if layerwise and dynamo:
+            raise NotImplementedError("Dynamo export is not supported for layerwise VLM export in v1.")
         if layerwise:
             return self._run_layerwise_export(
                 export_dir=export_dir,
@@ -1701,6 +1766,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 export_dir=export_dir,
                 offload_pt_weights=False,
                 use_onnx_subfunctions=use_onnx_subfunctions,
+                dynamo=dynamo,
             )
 
         # TODO: remove the current pt weight offload capability once CustomLoader is in place
@@ -1725,6 +1791,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 qaic_config=qaic_config,
                 _layerwise_cache_probe=layerwise_cache_probe,
                 kv_cache_prefix=kv_cache_prefix,
+                dynamo=dynamo,
             )
         return self.onnx_path
 
@@ -1909,6 +1976,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
         layerwise: bool = False,
         layerwise_window_size: int = 1,
         kv_cache_prefix: Optional[str] = None,
+        dynamo: bool = False,
         **compiler_options,
     ) -> str:
         """
@@ -1971,6 +2039,11 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             raise ValueError("Expected at least one of 'skip_lang' or 'skip_vision' to be False")
         reject_legacy_moe_prefill_packed_chunk_size(compiler_options)
         _ignore_public_mdp_ts_num_devices(compiler_options)
+        dynamo = dynamo or self._weight_free
+        use_onnx_subfunctions = use_onnx_subfunctions or self._weight_free
+
+        if layerwise and dynamo:
+            raise NotImplementedError("Dynamo export is not supported for layerwise VLM compile in v1.")
 
         if layerwise:
             if skip_lang and not skip_vision:
@@ -1999,6 +2072,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                     enable_chunking=enable_chunking,
                     qaic_config=qaic_config,
                     kv_cache_prefix=kv_cache_prefix,
+                    dynamo=dynamo,
                     **compiler_options,
                 )
                 self.vision_model.onnx_path = vision_wrapper.vision_model.onnx_path
@@ -2030,6 +2104,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 qaic_config=qaic_config,
                 layerwise_window_size=layerwise_window_size,
                 kv_cache_prefix=kv_cache_prefix,
+                dynamo=dynamo,
                 **compiler_options,
             )
 
@@ -2128,6 +2203,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                     _layerwise_cache_probe=layerwise_cache_probe,
                     kv_cache_prefix=kv_cache_prefix,
                     offload_pt_weights=offload_pt_weights,
+                    dynamo=dynamo,
                 )
             if layerwise_cache_probe:
                 return self.lang_model.onnx_path
@@ -2165,6 +2241,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 custom_io=custom_io_vision,
                 mxint8_kv_cache=mxint8_kv_cache,
                 use_onnx_subfunctions=use_onnx_subfunctions,
+                dynamo=dynamo,
                 **compiler_options_vision,
             )
             self.qpc_paths["vision_qpc_path"] = vision_qpc_path
@@ -2227,6 +2304,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 custom_io=custom_io_lang,
                 mxint8_kv_cache=mxint8_kv_cache,
                 use_onnx_subfunctions=use_onnx_subfunctions,
+                dynamo=dynamo,
                 **compiler_options,
             )
             self.qpc_paths.update({qpc_key: lang_qpc_path})
@@ -3357,6 +3435,8 @@ class QEFFAutoModelForImageTextToText:
         Union[_QEffAutoModelForImageTextToTextDualQPC, _QEFFAutoModelForImageTextToTextSingleQPC]
             The wrapped model instance, configured for either dual or single QPC.
         """
+        if kwargs.get("weight_free", False) and kv_offload is not True:
+            raise NotImplementedError("weight_free=True for VLM is supported only with kv_offload=True in v1.")
         if kv_offload:
             return _QEffAutoModelForImageTextToTextDualQPC(
                 model, continuous_batching, qaic_config=qaic_config, **kwargs
@@ -3373,6 +3453,7 @@ class QEFFAutoModelForImageTextToText:
         continuous_batching: bool = False,
         qaic_config: Optional[dict] = None,
         layerwise: bool = False,
+        weight_free: bool = False,
         **kwargs,
     ):
         """
@@ -3405,6 +3486,15 @@ class QEFFAutoModelForImageTextToText:
             If `continuous_batching` is provided as True.
         """
         enable_proxy = kwargs.pop("enable_proxy", False)
+        if layerwise and weight_free:
+            raise ValueError(
+                "`layerwise=True` and `weight_free=True` are mutually exclusive for VLM in v1."
+            )
+
+        if weight_free:
+            if kv_offload is False:
+                raise NotImplementedError("weight_free=True for VLM is supported only with kv_offload=True in v1.")
+            kv_offload = True
 
         # TODO: add a check to see if kv_offload is allowed for given model by loading the config and checking architecture or type of config here.
         if continuous_batching and not kv_offload:
@@ -3425,12 +3515,11 @@ class QEFFAutoModelForImageTextToText:
         )
 
         _resolve_torch_dtype(kwargs)
-        if layerwise:
+        if layerwise or weight_free:
             # Layer-wise mode: build the outer model on the meta device so the
-            # caller's ``from_pretrained`` does not pull the full checkpoint
-            # into RAM. compile()/export() rebuilds a real per-window model
-            # internally via the layer-wise driver, so the outer instance is
-            # only used as a config holder.
+            # caller's ``from_pretrained`` does not pull the full checkpoint into RAM.
+            # Weight-free uses the same meta construction, then supplies real
+            # checkpoint tensors through weight_spec.json at export/compile time.
             model = _build_meta_model(cls._hf_auto_class, pretrained_model_name_or_path, kwargs)
         else:
             model = cls._hf_auto_class.from_pretrained(pretrained_model_name_or_path, **kwargs)
@@ -3443,6 +3532,7 @@ class QEFFAutoModelForImageTextToText:
             continuous_batching=continuous_batching,
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             qaic_config=qaic_config,
+            weight_free=weight_free,
             **kwargs,
         )
         # Mark the wrapper so its compile() can default ``layerwise=True`` if

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -96,6 +96,8 @@ def qeff_apply_interleaved_mrope(freqs, mrope_section):
 
 
 def qeff_prepare_mrope_cos_sin(cos, sin, position_ids, mrope_section, dtype=None):
+    cos = cos.to(device=position_ids.device)
+    sin = sin.to(device=position_ids.device)
     invalid_pos_mask = position_ids < 0
     safe_position_ids = torch.where(invalid_pos_mask, torch.zeros_like(position_ids), position_ids)
     flat_pos = safe_position_ids.reshape(-1)
@@ -173,13 +175,9 @@ class QEffQwen3VLMoeVisionModel(Qwen3VLMoeVisionModel):
     def rot_pos_emb(self, grid_thw: torch.Tensor) -> torch.Tensor:
         merge_size = self.spatial_merge_size
         max_hw = max(grid_thw.shape)
-        freq_table = self.rotary_pos_emb(max_hw)  # (max_hw, dim // 2)
-        device = freq_table.device
+        device = grid_thw.device
+        freq_table = self.rotary_pos_emb(max_hw).to(device=device)  # (max_hw, dim // 2)
         bs, num_frames, height, width = grid_thw.shape
-        grid_thw = (torch.tensor(grid_thw.shape, dtype=torch.int64)).unsqueeze(0)
-
-        total_tokens = int(torch.prod(grid_thw, dim=1).sum().item())
-        pos_ids = torch.empty((total_tokens, 2), dtype=torch.long, device=device)
 
         merged_h, merged_w = height // merge_size, width // merge_size
 
@@ -207,15 +205,15 @@ class QEffQwen3VLMoeVisionModel(Qwen3VLMoeVisionModel):
 
     def fast_pos_embed_interpolate(self, grid_thw):
         bs, t, h, w = grid_thw.shape
-        h_idxs = torch.linspace(0, self.num_grid_per_side - 1, h)
-        w_idxs = torch.linspace(0, self.num_grid_per_side - 1, w)
+        device = self.pos_embed.weight.device
+        h_idxs = torch.linspace(0, self.num_grid_per_side - 1, h, device=device)
+        w_idxs = torch.linspace(0, self.num_grid_per_side - 1, w, device=device)
 
         h_idxs_floor = h_idxs.int()
         w_idxs_floor = w_idxs.int()
-        max_t = torch.tensor(self.num_grid_per_side - 1, device=h_idxs.device)
 
-        h_idxs_ceil = torch.minimum(h_idxs_floor + 1, max_t)  # working
-        w_idxs_ceil = torch.minimum(w_idxs_floor + 1, max_t)
+        h_idxs_ceil = (h_idxs_floor + 1).clamp(max=self.num_grid_per_side - 1)
+        w_idxs_ceil = (w_idxs_floor + 1).clamp(max=self.num_grid_per_side - 1)
 
         dh = h_idxs - h_idxs_floor
         dw = w_idxs - w_idxs_floor
@@ -265,6 +263,7 @@ class QEffQwen3VLMoeVisionModel(Qwen3VLMoeVisionModel):
         return patch_pos_embeds
 
     def forward(self, hidden_states: torch.Tensor, grid_thw: torch.Tensor) -> torch.Tensor:
+        grid_thw = grid_thw.to(device=hidden_states.device)
         hidden_states = self.patch_embed(hidden_states)
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
         hidden_states = hidden_states + pos_embeds
@@ -278,15 +277,15 @@ class QEffQwen3VLMoeVisionModel(Qwen3VLMoeVisionModel):
         position_embeddings = (emb.cos(), emb.sin())
         bs, t, h, w = grid_thw.shape
 
-        t = torch.arange(t, t + 1).squeeze().expand(bs)
-        h = torch.arange(h, h + 1).squeeze().expand(bs)
-        w = torch.arange(w, w + 1).squeeze().expand(bs)
+        t = torch.arange(t, t + 1, device=grid_thw.device).squeeze().expand(bs)
+        h = torch.arange(h, h + 1, device=grid_thw.device).squeeze().expand(bs)
+        w = torch.arange(w, w + 1, device=grid_thw.device).squeeze().expand(bs)
 
         cu_seqlens = (h * w).cumsum(
             dim=0,
             dtype=torch.int32,
         )
-        cu_seqlens = torch.cat([torch.tensor([0], dtype=cu_seqlens.dtype), cu_seqlens])
+        cu_seqlens = torch.cat([torch.zeros(1, dtype=cu_seqlens.dtype, device=cu_seqlens.device), cu_seqlens])
 
         deepstack_feature_lists = []
         for layer_num, blk in enumerate(self.blocks):
@@ -333,6 +332,8 @@ class QEffQwen3VLMoeVisionAttention(Qwen3VLMoeVisionAttention):
             sin = emb.sin()
         else:
             cos, sin = position_embeddings
+        cos = cos.to(device=q.device)
+        sin = sin.to(device=q.device)
         q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
 
         attention_mask = torch.full(
@@ -341,8 +342,8 @@ class QEffQwen3VLMoeVisionAttention(Qwen3VLMoeVisionAttention):
 
         # Create index grids
         seq_len = attention_mask.shape[-1]
-        rows = torch.arange(seq_len).view(1, -1)
-        cols = torch.arange(seq_len).view(-1, 1)
+        rows = torch.arange(seq_len, device=q.device).view(1, -1)
+        cols = torch.arange(seq_len, device=q.device).view(-1, 1)
 
         # Prepare start and end indices
         start = cu_seqlens[:-1].view(-1, 1, 1)
@@ -353,13 +354,13 @@ class QEffQwen3VLMoeVisionAttention(Qwen3VLMoeVisionAttention):
         col_mask = (cols >= start) & (cols < end)
         block_mask = row_mask & col_mask  # shape: (num_blocks, seq_len, seq_len)
 
-        # Combine all blocks into one mask
-        final_mask = torch.ones((seq_len, seq_len), dtype=self.config.dtype)
-        final_mask[block_mask.any(dim=0)] = 0
-
-        final_mask = torch.where(final_mask == 1.0, torch.finfo(q.dtype).min, final_mask)
-
-        attention_mask[0] = final_mask
+        allowed_mask = block_mask.any(dim=0)
+        final_mask = torch.full((seq_len, seq_len), torch.finfo(q.dtype).min, device=q.device, dtype=q.dtype)
+        attention_mask = torch.where(
+            allowed_mask.unsqueeze(0),
+            torch.zeros_like(attention_mask),
+            final_mask.unsqueeze(0),
+        )
 
         q = q.transpose(0, 1)
         k = k.transpose(0, 1)
@@ -390,9 +391,7 @@ def eager_attention_forward(
 
     attn_weights = torch.matmul(query, key_states.transpose(2, 3)) / math.sqrt(module.head_dim)
     if attention_mask is not None:
-        attn_weights = torch.where(
-            attention_mask, torch.tensor(MIN_MASKED_ATTENTION_VALUE, dtype=module.config.torch_dtype), attn_weights
-        )
+        attn_weights = attn_weights.masked_fill(attention_mask, MIN_MASKED_ATTENTION_VALUE)
 
     attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
     attn_output = torch.matmul(attn_weights, value_states)
@@ -623,7 +622,6 @@ class QEffQwen3VLMoeTextModel(Qwen3VLMoeTextModel):
         )
 
         hidden_states = inputs_embeds
-        position_embeddings = self.rotary_emb(hidden_states, position_ids[1:])
         cos, sin = qeff_prepare_mrope_cos_sin(
             self.cos_cached,
             self.sin_cached,
@@ -657,7 +655,6 @@ class QEffQwen3VLMoeTextModel(Qwen3VLMoeTextModel):
                 output_attentions=output_attentions,
                 use_cache=use_cache,
                 cache_position=cache_position,
-                position_embeddings=position_embeddings,
                 sin_cached=sin,
                 cos_cached=cos,
                 **kwargs,
@@ -775,7 +772,7 @@ class QEffQwen3VLEncoderWrapper(nn.Module):
     def forward(self, pixel_values, image_grid_thw):
         image_embeds, deepstack_feature_lists = self.model.visual(pixel_values, grid_thw=image_grid_thw)
         bs = image_grid_thw.shape[0]
-        split_size = torch.floor_divide(torch.tensor(image_embeds.size(0)), bs)
+        split_size = image_embeds.shape[0] // bs
         image_embeds = image_embeds.reshape(bs, split_size, image_embeds.size(1))
         deepstack_features = torch.stack(
             [feature.reshape(bs, split_size, feature.size(1)) for feature in deepstack_feature_lists],
@@ -917,7 +914,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
                 hidden_states = _batch_index_gather(hidden_states, batch_index)
             logits = self.model.lm_head(hidden_states)
             image_idx = (indices1.max() + 1).unsqueeze(0).unsqueeze(0)
-            return logits, vision_embeds, deepstack_features, image_idx, outputs.past_key_values
+            return logits, vision_embeds.clone(), deepstack_features.clone(), image_idx, outputs.past_key_values
 
         if QEffQwen3VLMoeTextModel._start == 0:
             B, N, C = inputs_embeds.shape
@@ -960,7 +957,7 @@ class QEffQwen3VLDecoderWrapper(nn.Module):
                 hidden_states = outputs.last_hidden_state[:, -1:, :]
             logits = hidden_states
             image_idx = (indices1.max() + 1).unsqueeze(0).unsqueeze(0)
-            return logits, vision_embeds, deepstack_features, image_idx, outputs.past_key_values
+            return logits, vision_embeds.clone(), deepstack_features.clone(), image_idx, outputs.past_key_values
 
         elif QEffQwen3VLMoeTextModel._end == QEffQwen3VLMoeTextModel._total_layers:
             outputs = self.language_model(

--- a/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/QEfficient/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -212,8 +212,10 @@ class QEffQwen3VLMoeVisionModel(Qwen3VLMoeVisionModel):
         h_idxs_floor = h_idxs.int()
         w_idxs_floor = w_idxs.int()
 
-        h_idxs_ceil = (h_idxs_floor + 1).clamp(max=self.num_grid_per_side - 1)
-        w_idxs_ceil = (w_idxs_floor + 1).clamp(max=self.num_grid_per_side - 1)
+        max_idx_h = torch.full_like(h_idxs_floor, self.num_grid_per_side - 1)
+        max_idx_w = torch.full_like(w_idxs_floor, self.num_grid_per_side - 1)
+        h_idxs_ceil = torch.minimum(h_idxs_floor + 1, max_idx_h)
+        w_idxs_ceil = torch.minimum(w_idxs_floor + 1, max_idx_w)
 
         dh = h_idxs - h_idxs_floor
         dw = w_idxs - w_idxs_floor

--- a/QEfficient/utils/export_utils.py
+++ b/QEfficient/utils/export_utils.py
@@ -63,16 +63,14 @@ def reorder_inputs_by_signature(model, example_inputs, dynamic_shapes=None):
     """
     sig_keys = list(inspect.signature(model.forward).parameters.keys())
     sig_key_set = set(sig_keys)
-    ordered_inputs, ordered_shapes = {}, {}
+    ordered_inputs = {}
     for k in sig_keys:
         if k in example_inputs:
             ordered_inputs[k] = example_inputs[k]
-        if dynamic_shapes is not None and k in dynamic_shapes:
-            ordered_shapes[k] = dynamic_shapes[k]
     reordered_inputs = {**ordered_inputs, **{k: v for k, v in example_inputs.items() if k not in sig_key_set}}
     if dynamic_shapes is not None:
-        reordered_shapes = {**ordered_shapes, **{k: v for k, v in dynamic_shapes.items() if k not in sig_key_set}}
-        return reordered_inputs, reordered_shapes
+        dynamic_shapes = {k: dynamic_shapes.get(k) for k in reordered_inputs}
+        return reordered_inputs, dynamic_shapes
     return reordered_inputs, None
 
 
@@ -125,21 +123,34 @@ def convert_dynamic_axes_to_dynamic_shapes(
         torch.export dynamic_shapes dict with Dim objects, suitable for
         torch.onnx.export(dynamic_shapes=...).
     """
-    max_seq_len = getattr(model_config, "max_position_embeddings", 1024)
+    text_config = getattr(model_config, "text_config", None)
+    effective_config = text_config if text_config is not None else model_config
+    max_seq_len = getattr(effective_config, "max_position_embeddings", 1024)
     model_type = getattr(model_config, "model_type", None)
-    batch_min = 1 if model_type == "gpt_oss" else 2
+    is_vlm = hasattr(model_config, "vision_config")
+    batch_min = 1 if model_type == "gpt_oss" or is_vlm else 2
+    batch_max = 2 if model_type == "qwen3_vl_moe" else DYNAMO_DIM_MAX_BATCH_SIZE
+    seq_min = 1 if is_vlm else 2
+    vlm_dim_max = max(max_seq_len, 65536)
+    static_vlm_feature_layers = None
+    if is_vlm:
+        deepstack_visual_indexes = getattr(model_config.vision_config, "deepstack_visual_indexes", None)
+        if deepstack_visual_indexes is not None:
+            static_vlm_feature_layers = len(deepstack_visual_indexes)
 
     dim_registry: Dict[str, Any] = {}
 
     def resolve_dim(dim_name: str):
         if dim_name not in dim_registry:
             if dim_name == "batch_size":
-                dim_registry[dim_name] = Dim("batch_size", min=batch_min, max=DYNAMO_DIM_MAX_BATCH_SIZE)
+                dim_registry[dim_name] = Dim("batch_size", min=batch_min, max=batch_max)
+            elif dim_name == "vision_batch_size":
+                dim_registry[dim_name] = Dim("vision_batch_size", min=batch_min, max=batch_max)
             elif dim_name == "full_batch_size":
                 # CB pool capacity; different min prevents torch.export collapsing it with batch_size.
                 dim_registry[dim_name] = Dim("full_batch_size", min=batch_min + 1, max=DYNAMO_DIM_MAX_BATCH_SIZE)
             elif "seq_len" in dim_name:
-                dim_registry[dim_name] = Dim("seq_len", min=2, max=max_seq_len)
+                dim_registry[dim_name] = Dim("seq_len", min=seq_min, max=max_seq_len)
             elif "comp_ctx_lengths" in dim_name:
                 dim_registry[dim_name] = Dim("comp_ctx_lengths", min=DYNAMO_DIM_MIN_COMP_CTX_LENGTHS, max=max_seq_len)
             elif "ctx_len" in dim_name:
@@ -150,6 +161,19 @@ def convert_dynamic_axes_to_dynamic_shapes(
                     min=2,
                     max=getattr(model_config, "sliding_window", max_seq_len),
                 )
+            elif dim_name in {
+                "grid_height",
+                "grid_width",
+                "grid_h",
+                "grid_w",
+                "time",
+                "vision_size",
+                "num_feature_layers",
+            }:
+                if dim_name == "num_feature_layers" and static_vlm_feature_layers is not None:
+                    dim_registry[dim_name] = static_vlm_feature_layers
+                else:
+                    dim_registry[dim_name] = Dim(dim_name, min=1, max=vlm_dim_max)
             else:
                 dim_registry[dim_name] = Dim.DYNAMIC
         return dim_registry[dim_name]
@@ -161,7 +185,12 @@ def convert_dynamic_axes_to_dynamic_shapes(
     k_pe_layers: Dict[int, Any] = {}
 
     for input_name, axes_map in dynamic_axes.items():
-        resolved = {axis_idx: resolve_dim(dim_name) for axis_idx, dim_name in axes_map.items()}
+        resolved = {}
+        for axis_idx, dim_name in axes_map.items():
+            dim = resolve_dim(dim_name)
+            if isinstance(dim, int):
+                continue
+            resolved[axis_idx] = dim
         if input_name.startswith("past_key."):
             past_keys[int(input_name.split(".")[1])] = resolved
         elif input_name.startswith("past_value."):
@@ -299,8 +328,8 @@ def export_wrapper(func):
             # Resolve dynamic_shapes from dynamic_axes before the hash so the hash captures
             # the actual shape constraints.
             dynamic_axes = kwargs.get("dynamic_axes")
-            if dynamic_axes is not None:
-                model_config = getattr(self.model, "config", None)
+            if dynamic_axes is not None and "dynamic_shapes" not in kwargs:
+                model_config = getattr(self.model, "config", None) or getattr(self, "config", None)
                 kwargs["dynamic_shapes"] = convert_dynamic_axes_to_dynamic_shapes(dynamic_axes, model_config)
 
         # Cache probe flag (used for layerwise inspection runs)

--- a/examples/dynamo/README.md
+++ b/examples/dynamo/README.md
@@ -10,6 +10,7 @@ export.
 | Example | Description |
 |---|---|
 | [causal_lm](causal_lm/) | Export, compile, and run text-only CausalLM models with dynamo. |
+| [image_text_to_text](image_text_to_text/) | Export, compile, and run dual-QPC VLM models with dynamo. |
 
 ## Prerequisites
 
@@ -23,6 +24,12 @@ Install the dependencies for the example you want to run. For CausalLM:
 
 ```bash
 pip install -r examples/dynamo/causal_lm/requirements.txt
+```
+
+For image-text-to-text VLMs:
+
+```bash
+pip install -r examples/dynamo/image_text_to_text/requirements.txt
 ```
 
 For private or gated Hugging Face models, export your token before running the
@@ -52,5 +59,15 @@ python examples/dynamo/causal_lm/basic_dynamo_inference.py \
     --prefill-seq-len 128 \
     --ctx-len 128 \
     --num-cores 16 \
-    --use-weight-free-export
+    --weight-free
 ```
+
+## Image-Text-To-Text Quick Start
+
+```bash
+python examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py
+```
+
+The VLM example defaults to dual-QPC Qwen3-VL-MoE with weight-free export,
+ONNX subfunctions, and a reduced-layer bring-up config. See
+`examples/dynamo/image_text_to_text/README.md` for the full argument list.

--- a/examples/dynamo/image_text_to_text/README.md
+++ b/examples/dynamo/image_text_to_text/README.md
@@ -1,0 +1,85 @@
+# Dynamo Image-Text-to-Text Example
+
+This folder contains a Qwen3-VL-MoE script for exporting, compiling, and
+running a dual-QPC VLM on Cloud AI 100 using the **dynamo** (`torch.export`)
+export path.
+
+The default path uses weight-free export. The Hugging Face model is built on
+meta tensors and the QAIC compiler loads weights from the checkpoint through
+`weight_spec.json`.
+
+## Prerequisites
+
+Install QEfficient from the repository root:
+
+```bash
+pip install -e .
+```
+
+Install dynamo and VLM dependencies:
+
+```bash
+pip install -r examples/dynamo/image_text_to_text/requirements.txt
+```
+
+For private or gated Hugging Face models:
+
+```bash
+export HF_TOKEN=<your_token>
+```
+
+For local artifact placement:
+
+```bash
+export HF_HUB_CACHE=/home/huggingface_hub
+export HF_HUB_ENABLE_HF_TRANSFER=1
+export QEFF_HOME=/path/to/qeff_artifacts
+export QEFF_CHECKPOINT_HOME=/path/to/qeff_prepared_checkpoints
+```
+
+## Qwen3-VL-MoE
+
+Default usage:
+
+```bash
+python examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py
+```
+
+The default run uses a reduced bring-up config:
+
+- `vision_config.depth = 9`
+- `text_config.num_hidden_layers = 1`
+- `vision_config.deepstack_visual_indexes = [8]`
+
+Disable that reduction with:
+
+```bash
+python examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py --no-reduce-layers
+```
+
+Disable weight-free export only for explicit experimentation:
+
+```bash
+python examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py --no-weight-free
+```
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `--model-name` | `Qwen/Qwen3-VL-30B-A3B-Instruct` | Hugging Face model ID |
+| `--prompt` | `"Describe all the colors seen in the image."` | Text prompt |
+| `--image-url` | `https://picsum.photos/id/237/536/354` | Image URL |
+| `--height` | `354` | Compile image height |
+| `--width` | `536` | Compile image width |
+| `--batch-size` | `1` | Compile/runtime batch size |
+| `--prefill-seq-len` | `128` | Prefill sequence length |
+| `--ctx-len` | `4096` | KV-cache context length |
+| `--generation-len` | `100` | New tokens to generate |
+| `--num-cores` | hardware default | Number of AI cores |
+| `--num-devices` | `4` | Number of devices |
+| `--mos` | `1` | Compiler MOS setting |
+| `--aic-hw-version` | hardware default | AIC hardware version |
+| `--reduce-layers` / `--no-reduce-layers` | `True` | Use the reduced bring-up config |
+| `--weight-free` / `--no-weight-free` | `True` | Enable weight-free export |
+| `--skip-vision` | `False` | Compile and run text path only |

--- a/examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py
+++ b/examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py
@@ -1,0 +1,178 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+"""Dynamo-based export and inference for Qwen3-VL-MoE on Cloud AI 100.
+
+Requires PyTorch >= 2.13. Install dependencies before running:
+    pip install -r examples/dynamo/image_text_to_text/requirements.txt
+"""
+
+import argparse
+
+import requests
+import transformers
+from PIL import Image
+from qwen_vl_utils import process_vision_info
+from transformers import AutoConfig, AutoProcessor
+
+from QEfficient import QEFFAutoModelForImageTextToText
+from QEfficient.utils import constants
+
+
+def load_image(image_url: str, width: int, height: int) -> Image.Image:
+    """Load a remote image, falling back to a deterministic local image."""
+    try:
+        response = requests.get(image_url, stream=True, timeout=30)
+        response.raise_for_status()
+        return Image.open(response.raw).convert("RGB")
+    except requests.RequestException:
+        return Image.new("RGB", (width, height), color=(120, 70, 200))
+
+
+def maybe_reduce_config(config, *, reduce_layers: bool, vision_depth: int, text_layers: int):
+    """Apply the small bring-up config used by the Qwen3-VL-MoE example."""
+    if not reduce_layers:
+        return config
+
+    config.vision_config.depth = vision_depth
+    config.text_config.num_hidden_layers = text_layers
+    config.vision_config.deepstack_visual_indexes = [vision_depth - 1]
+    return config
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Dynamo-based dual-QPC VLM export and inference for Qwen3-VL-MoE on Cloud AI 100.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--model-name", type=str, default="Qwen/Qwen3-VL-30B-A3B-Instruct")
+    parser.add_argument("--prompt", type=str, default="Describe all the colors seen in the image.")
+    parser.add_argument("--image-url", type=str, default="https://picsum.photos/id/237/536/354")
+    parser.add_argument("--height", type=int, default=354)
+    parser.add_argument("--width", type=int, default=536)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--prefill-seq-len", type=int, default=128)
+    parser.add_argument("--ctx-len", type=int, default=4096)
+    parser.add_argument("--generation-len", type=int, default=100)
+    parser.add_argument("--num-cores", type=int, default=constants.DEFAULT_AIC_NUM_CORES)
+    parser.add_argument("--num-devices", type=int, default=4)
+    parser.add_argument("--mos", type=int, default=1)
+    parser.add_argument("--aic-hw-version", type=str, default=constants.DEFAULT_AIC_HW_VERSION)
+    parser.add_argument("--vision-depth", type=int, default=9)
+    parser.add_argument("--text-layers", type=int, default=1)
+    parser.add_argument(
+        "--reduce-layers",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Use a reduced-layer config for faster bring-up.",
+    )
+    parser.add_argument(
+        "--weight-free",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Build the model on meta tensors and load weights at compile time.",
+    )
+    parser.add_argument(
+        "--skip-vision",
+        action="store_true",
+        help="Compile and run the text path only.",
+    )
+    args = parser.parse_args()
+
+    config = AutoConfig.from_pretrained(args.model_name)
+    config = maybe_reduce_config(
+        config,
+        reduce_layers=args.reduce_layers,
+        vision_depth=args.vision_depth,
+        text_layers=args.text_layers,
+    )
+
+    qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
+        args.model_name,
+        attn_implementation="eager",
+        kv_offload=True,
+        config=config,
+        weight_free=args.weight_free,
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(args.model_name)
+    processor = AutoProcessor.from_pretrained(args.model_name)
+
+    compile_kwargs = {
+        "batch_size": args.batch_size,
+        "prefill_seq_len": args.prefill_seq_len,
+        "ctx_len": args.ctx_len,
+        "num_cores": args.num_cores,
+        "num_devices": args.num_devices,
+        "height": args.height,
+        "width": args.width,
+        "mxfp6_matmul": True,
+        "aic_enable_depth_first": True,
+        "mos": args.mos,
+        "use_onnx_subfunctions": True,
+        "dynamo": True,
+        "aic_hw_version": args.aic_hw_version,
+    }
+    if args.skip_vision:
+        compile_kwargs["skip_vision"] = True
+    else:
+        compile_kwargs.update({"split_model_io": True, "mxint8_kv_cache": True})
+
+    qpc_paths = qeff_model.compile(**compile_kwargs)
+    print(f"Model compiled to: {qpc_paths}")
+    print(f"Weight specs: {qeff_model.weight_spec_path}")
+
+    if args.skip_vision:
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": args.prompt}],
+            }
+        ]
+        messages = [messages] * args.batch_size
+        inputs = processor.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+    else:
+        image = load_image(args.image_url, args.width, args.height)
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "image": image},
+                    {"type": "text", "text": args.prompt},
+                ],
+            }
+        ]
+        messages = [messages] * args.batch_size
+        texts = [processor.apply_chat_template(msg, tokenize=False, add_generation_prompt=True) for msg in messages]
+        image_inputs, video_inputs = process_vision_info(messages)
+        inputs = processor(
+            text=texts,
+            images=image_inputs,
+            videos=video_inputs,
+            padding=True,
+            return_tensors="pt",
+        )
+
+    inputs = qeff_model.model.prepare_inputs_for_generation(
+        inputs=inputs,
+        prefill_seq_len=args.prefill_seq_len,
+        batch_size=args.batch_size,
+    )
+    output = qeff_model.generate(inputs=inputs, generation_len=args.generation_len)
+
+    print(output.generated_ids)
+    print(tokenizer.batch_decode(output.generated_ids))
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py
+++ b/examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py
@@ -113,7 +113,6 @@ def main():
         "aic_enable_depth_first": True,
         "mos": args.mos,
         "use_onnx_subfunctions": True,
-        "dynamo": True,
         "aic_hw_version": args.aic_hw_version,
     }
     if args.skip_vision:

--- a/examples/dynamo/image_text_to_text/requirements.txt
+++ b/examples/dynamo/image_text_to_text/requirements.txt
@@ -1,0 +1,7 @@
+# PyTorch >= 2.13 is required for dynamo export (dynamo=True).
+# Install with: pip install -r examples/dynamo/image_text_to_text/requirements.txt
+
+-r ../causal_lm/requirements.txt
+
+# Qwen VLM preprocessing utilities.
+qwen-vl-utils>=0.0.14

--- a/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -17,15 +17,16 @@ model_id = "Qwen/Qwen3-VL-30B-A3B-Instruct"
 config = AutoConfig.from_pretrained(model_id)
 
 # For faster execution user can run with lesser layers, For Testing Purpose Only. Please ensure to use the configuration given below as random configurations may fail due to deepstack
-# config.vision_config.depth = 9
-# config.text_config.num_hidden_layers = 1
-# config.vision_config.deepstack_visual_indexes = [8]
+config.vision_config.depth = 9
+config.text_config.num_hidden_layers = 1
+config.vision_config.deepstack_visual_indexes = [8]
 
 qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
     model_id,
     attn_implementation="eager",
     kv_offload=True,
     config=config,
+    weight_free=True,
     # For CCL activation
     # qaic_config={
     #     "ccl_enabled": True,
@@ -59,6 +60,7 @@ if skip_vision:
         skip_vision=True,
         mos=1,
         use_onnx_subfunctions=True,
+        dynamo=True,
         # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
         # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
@@ -105,6 +107,7 @@ else:
         aic_enable_depth_first=True,
         mos=1,
         use_onnx_subfunctions=True,
+        dynamo=True,
         # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
         # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
@@ -112,7 +115,12 @@ else:
     ### IMAGE + TEXT ###
     image_url = "https://picsum.photos/id/237/536/354"
 
-    image = Image.open(requests.get(image_url, stream=True).raw)
+    try:
+        response = requests.get(image_url, stream=True, timeout=30)
+        response.raise_for_status()
+        image = Image.open(response.raw).convert("RGB")
+    except Exception:
+        image = Image.new("RGB", (536, 354), color=(120, 70, 200))
 
     messages_1 = [
         {

--- a/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
+++ b/examples/image_text_to_text/models/qwen3_vl_moe/qwen3_vl_moe.py
@@ -26,7 +26,6 @@ qeff_model = QEFFAutoModelForImageTextToText.from_pretrained(
     attn_implementation="eager",
     kv_offload=True,
     config=config,
-    weight_free=True,
     # For CCL activation
     # qaic_config={
     #     "ccl_enabled": True,
@@ -60,7 +59,6 @@ if skip_vision:
         skip_vision=True,
         mos=1,
         use_onnx_subfunctions=True,
-        dynamo=True,
         # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
         # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )
@@ -107,7 +105,6 @@ else:
         aic_enable_depth_first=True,
         mos=1,
         use_onnx_subfunctions=True,
-        dynamo=True,
         # comp_ctx_lengths_prefill=comp_ctx_lengths_prefill,
         # comp_ctx_lengths_decode=comp_ctx_lengths_decode,
     )

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -73,6 +73,7 @@ from QEfficient.transformers.models.modeling_auto import (
 )
 from QEfficient.transformers.quantizers.auto import replace_transformers_quantizers
 from QEfficient.utils._utils import _infer_specialization_name, to_named_specializations
+from QEfficient.utils.export_utils import convert_dynamic_axes_to_dynamic_shapes, reorder_inputs_by_signature
 from QEfficient.utils.run_utils import ApiRunner
 
 ort.set_default_logger_severity(3)
@@ -3297,6 +3298,132 @@ def test_layerwise_merge_renames_decoder_function_variants_without_collisions():
         for node in merged.graph.node
         if (node.domain, node.op_type) in function_inputs
     )
+
+
+@pytest.mark.llm_model
+def test_qwen3_vl_moe_dynamo_dynamic_shapes_cover_vlm_axes():
+    qeff_model = _tiny_qwen_qeff_model("qwen3_vl_moe")
+    dynamic_axes = qeff_model.model.get_onnx_dynamic_axes(kv_offload=True)
+
+    vision_shapes = convert_dynamic_axes_to_dynamic_shapes(dynamic_axes["vision"], qeff_model.config)
+    lang_shapes = convert_dynamic_axes_to_dynamic_shapes(dynamic_axes["lang"], qeff_model.config)
+
+    batch_dim = vision_shapes["image_grid_thw"][0]
+    vision_size_dim = lang_shapes["vision_embeds"][1]
+
+    assert getattr(batch_dim, "min", None) == 1
+    assert getattr(batch_dim, "max", None) == 2
+    assert vision_shapes["image_grid_thw"][1].__name__ == "time"
+    assert vision_shapes["image_grid_thw"][2].__name__ == "grid_h"
+    assert vision_shapes["image_grid_thw"][3].__name__ == "grid_w"
+    assert vision_shapes["pixel_values"][0].__name__ == "grid_height"
+    assert vision_shapes["pixel_values"][1].__name__ == "grid_width"
+    assert getattr(lang_shapes["input_ids"][0], "min", None) == 1
+    assert getattr(lang_shapes["input_ids"][0], "max", None) == 2
+    assert getattr(lang_shapes["input_ids"][1], "min", None) == 1
+    assert lang_shapes["vision_embeds"][0].__name__ == "vision_batch_size"
+    assert 0 not in lang_shapes["deepstack_features"]
+    assert lang_shapes["deepstack_features"][1] is lang_shapes["vision_embeds"][0]
+    assert lang_shapes["deepstack_features"][2] is vision_size_dim
+    assert lang_shapes["past_key_values"][0][0][0] is lang_shapes["input_ids"][0]
+
+
+@pytest.mark.llm_model
+def test_dynamo_reorder_filters_output_only_dynamic_shapes():
+    class DummyModule(nn.Module):
+        def forward(self, input_ids, image_idx):
+            return input_ids
+
+    input_ids_shape = {0: torch.export.Dim("batch_size", min=1, max=4)}
+    dynamic_shapes = {
+        "input_ids": input_ids_shape,
+        "logits": {0: torch.export.Dim("batch_size", min=1, max=4)},
+    }
+    _, filtered_shapes = reorder_inputs_by_signature(
+        DummyModule(),
+        {"input_ids": torch.ones((1, 4), dtype=torch.int64), "image_idx": torch.zeros((1, 1), dtype=torch.int64)},
+        dynamic_shapes,
+    )
+
+    assert filtered_shapes == {"input_ids": input_ids_shape, "image_idx": None}
+
+
+@pytest.mark.llm_model
+def test_qwen3_vl_moe_dual_qpc_compile_weight_free_implies_dynamo_and_subfunctions(monkeypatch, tmp_path):
+    qeff_model = _tiny_qwen_qeff_model("qwen3_vl_moe")
+    qeff_model.config.torch_dtype = torch.float32
+    qeff_model._weight_free = True
+    qeff_model.vision_model._weight_free = True
+    qeff_model.lang_model._weight_free = True
+
+    export_kwargs = {}
+    compile_kwargs = {}
+
+    def fake_vision_export(*args, **kwargs):
+        export_kwargs["vision"] = kwargs
+        qeff_model.vision_model.onnx_path = tmp_path / "vision.onnx"
+        return qeff_model.vision_model.onnx_path
+
+    def fake_lang_export(*args, **kwargs):
+        export_kwargs["lang"] = kwargs
+        qeff_model.lang_model.onnx_path = tmp_path / "lang.onnx"
+        return qeff_model.lang_model.onnx_path
+
+    def fake_vision_compile(**kwargs):
+        compile_kwargs["vision"] = kwargs
+        return "vision-qpc"
+
+    def fake_lang_compile(**kwargs):
+        compile_kwargs["lang"] = kwargs
+        return "lang-qpc"
+
+    monkeypatch.setattr(qeff_model, "transform", lambda **kwargs: None)
+    monkeypatch.setattr(qeff_model.vision_model, "export", fake_vision_export)
+    monkeypatch.setattr(qeff_model.lang_model, "export", fake_lang_export)
+    monkeypatch.setattr(qeff_model.vision_model, "_compile", fake_vision_compile)
+    monkeypatch.setattr(qeff_model.lang_model, "_compile", fake_lang_compile)
+
+    qpc_paths = qeff_model.compile(
+        compile_dir=tmp_path,
+        batch_size=1,
+        prefill_seq_len=4,
+        ctx_len=128,
+        height=32,
+        width=32,
+        num_devices=1,
+        num_cores=1,
+    )
+
+    assert qpc_paths == {"vision_qpc_path": "vision-qpc", "lang_qpc_path": "lang-qpc"}
+    assert export_kwargs["vision"]["dynamo"] is True
+    assert export_kwargs["lang"]["dynamo"] is True
+    assert export_kwargs["vision"]["use_onnx_subfunctions"] is True
+    assert export_kwargs["lang"]["use_onnx_subfunctions"] is True
+    assert compile_kwargs["vision"]["dynamo"] is True
+    assert compile_kwargs["lang"]["dynamo"] is True
+    assert compile_kwargs["vision"]["use_onnx_subfunctions"] is True
+    assert compile_kwargs["lang"]["use_onnx_subfunctions"] is True
+
+
+@pytest.mark.llm_model
+def test_qwen3_vl_moe_weight_free_rejects_single_qpc_and_layerwise():
+    with pytest.raises(NotImplementedError, match="kv_offload=True"):
+        QEFFAutoModelForImageTextToText.from_pretrained("dummy", kv_offload=False, weight_free=True)
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        QEFFAutoModelForImageTextToText.from_pretrained("dummy", kv_offload=True, layerwise=True, weight_free=True)
+
+    qeff_model = _tiny_qwen_qeff_model("qwen3_vl_moe")
+    qeff_model._weight_free = True
+    with pytest.raises(NotImplementedError, match="layerwise VLM compile"):
+        qeff_model.compile(
+            batch_size=1,
+            prefill_seq_len=4,
+            ctx_len=32,
+            height=32,
+            width=32,
+            layerwise=True,
+        )
 
 
 @pytest.mark.llm_model

--- a/tests/weight_free/test_transforms.py
+++ b/tests/weight_free/test_transforms.py
@@ -422,6 +422,29 @@ class TestWeightFreeCheckpointTransforms:
         assert graph.inputs == []
         assert spec.inputs == []
 
+    def test_resolver_accepts_vlm_wrapper_prefix_aliases(self):
+        checkpoint_index = {
+            "model.visual.blocks.0.attn.qkv.weight": "model.safetensors",
+            "model.language_model.layers.0.mlp.moe_weights.gate": "model.safetensors",
+            "lm_head.weight": "model.safetensors",
+        }
+        backbone = MagicMock()
+        backbone.base_model_prefix = "model"
+
+        assert (
+            find_checkpoint_key("model.vision_model.blocks.0.attn.qkv.weight", checkpoint_index, backbone)
+            == "model.visual.blocks.0.attn.qkv.weight"
+        )
+        assert (
+            find_checkpoint_key(
+                "model.model.language_model.layers.0.mlp.experts.moe_weights.gate",
+                checkpoint_index,
+                backbone,
+            )
+            == "model.language_model.layers.0.mlp.moe_weights.gate"
+        )
+        assert find_checkpoint_key("model.lm_head.weight", checkpoint_index, backbone) == "lm_head.weight"
+
     def test_promotes_embed_tokens_for_tied_model(self, tmp_path, monkeypatch):
         """When tie_word_embeddings=True, torch.export deduplicates tied weights —
         only model.embed_tokens.weight appears as an ONNX initializer, never
@@ -461,6 +484,40 @@ class TestWeightFreeCheckpointTransforms:
         assert [v.name for v in graph.inputs] == ["model.embed_tokens.weight"]
         assert spec.inputs[0].name == "model.embed_tokens.weight"
         assert spec.inputs[0].location.key == "model.embed_tokens.weight"
+
+    def test_promotes_vlm_wrapper_alias_not_in_component_named_parameters(self, tmp_path, monkeypatch):
+        """VLM component ONNX names can use wrapper aliases absent from named_parameters()."""
+        src = tmp_path / "src"
+        src.mkdir()
+        weight = torch.arange(4, dtype=torch.float32).reshape(2, 2)
+        _write_safetensors_checkpoint(src, {"model.visual.weight": weight})
+
+        class VisionComponent(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = torch.nn.Module()
+                self.model.visual = torch.nn.Linear(2, 2, bias=False)
+
+        initializer = SimpleNamespace(shape=weight.shape, dtype=ir.DataType.FLOAT)
+        graph = SimpleNamespace(initializers={"model.vision_model.weight": initializer}, inputs=[])
+        onnx_program = SimpleNamespace(model=SimpleNamespace(graph=graph))
+        monkeypatch.setattr(
+            checkpoint_key_resolver.ir,
+            "Value",
+            lambda name, shape, type: SimpleNamespace(name=name, shape=shape, type=type),
+        )
+
+        spec = checkpoint_key_resolver.promote_initializers_and_build_spec(
+            onnx_program=onnx_program,
+            model_ref=str(src),
+            model_name="tiny-vlm",
+            qeff_model=SimpleNamespace(model=VisionComponent()),
+        )
+
+        assert "model.vision_model.weight" not in graph.initializers
+        assert [v.name for v in graph.inputs] == ["model.vision_model.weight"]
+        assert spec.inputs[0].name == "model.vision_model.weight"
+        assert spec.inputs[0].location.key == "model.visual.weight"
 
 
 def _fake_export(


### PR DESCRIPTION
## Summary

This PR enables the VLM weight-free export path for `Qwen/Qwen3-VL-30B-A3B-Instruct`, a Qwen3-VL-MoE image-text-to-text model.

Model validated:

```text
Qwen/Qwen3-VL-30B-A3B-Instruct
```

Validation script:

```text
examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py
```
## Performance Comparison

Measured with the full-layer model using:

```bash
python examples/dynamo/image_text_to_text/qwen3_vl_moe_dynamo_inference.py
```

Legacy means no weight-free export. Weight-free uses the Dynamo/`torch.export` path because weight-free export is implemented on top of Dynamo export.

### Export Time

| Component | Legacy | Weight-Free Dynamo | Saved | Improvement |
| --- | ---: | ---: | ---: | ---: |
| Vision export | 28.685 sec | 17.584 sec | 11.101 sec | 1.63x faster, 38.70% lower |
| Decoder export | 1352.880 sec | 86.967 sec | 1265.913 sec | 15.56x faster, 93.57% lower |
| Total export | 1381.565 sec | 104.551 sec | 1277.014 sec | 13.21x faster, 92.43% lower |

### Compile Time

| Component | Legacy | Weight-Free Dynamo | Saved | Improvement |
| --- | ---: | ---: | ---: | ---: |
| Vision compile | 19.051 sec | 18.644 sec | 0.407 sec | 1.02x faster, 2.14% lower |
| Decoder compile | 1705.522 sec | 366.976 sec | 1338.546 sec | 4.65x faster, 78.48% lower |
| Total compile | 1724.573 sec | 385.620 sec | 1338.953 sec | 4.47x faster, 77.64% lower |

## Artifact Size Comparison

For ONNX size, this table uses the complete wrapper export directory excluding QPC, because legacy export stores large external tensor files beside the small `.onnx` protobuf.

### ONNX Export Artifact Size

| Component | Legacy | Weight-Free Dynamo | Reduction |
| --- | ---: | ---: | ---: |
| Vision ONNX artifact | 2.01 GiB | 1.48 MiB | 1386.14x smaller, 99.928% lower |
| Decoder ONNX artifact | 113.81 GiB | 76.92 MiB | 1515.12x smaller, 99.934% lower |
| Total ONNX artifact | 115.82 GiB | 78.40 MiB | 1512.68x smaller, 99.934% lower |

### QPC Size

| Component | Legacy | Weight-Free Dynamo | Delta |
| --- | ---: | ---: | ---: |
| Vision QPC | 1.04 GiB | 1.04 GiB | 97.65 KiB smaller |
| Decoder QPC | 44.55 GiB | 44.55 GiB | 2.25 MiB larger |
| Total QPC | 45.59 GiB | 45.59 GiB | 2.15 MiB larger |

The QPC size is effectively unchanged, as expected. The major storage improvement is in the exported ONNX artifact before compile.

## Runtime Comparison

| Metric | Legacy | Weight-Free Dynamo | Delta |
| --- | ---: | ---: | ---: |
| Average prefill / TTFT | 1.03 sec | 1.03 sec | no change |
| Decode throughput | 66.49 tok/sec | 65.60 tok/sec | -1.34% |
| Total throughput | 39.59 tok/sec | 39.30 tok/sec | -0.73% |
| Total E2E inference time | 2.50 sec | 2.52 sec | +0.80% |

Runtime is effectively at parity while export, compile, and pre-compile artifact size improve substantially.

