### PR TITLE
Enable Dynamo KV-blocking Loop export for kv_headpar

### DIFF
--- a/QEfficient/base/modeling_qeff.py
+++ b/QEfficient/base/modeling_qeff.py
@@ -25,8 +25,10 @@ from QEfficient.base.onnx_transforms import (
     BaseOnnxTransform,
     CustomOpTransform,
     FP16ClipTransform,
+    InlineTorchSubgraphFunctionsTransform,
     OnnxTransformPipeline,
     RenameFunctionOutputsTransform,
+    StaticLoopInputsTransform,
     SplitTensorsTransform,
 )
 from QEfficient.base.pytorch_transforms import PytorchTransform
@@ -609,6 +611,23 @@ class QEFFBaseModel(ABC):
             active_transforms = [
                 transform for transform in self._onnx_transforms if transform not in excluded_transforms
             ]
+            qaic_config_for_transforms = (
+                export_kwargs.get("qaic_config")
+                or self.hash_params.get("qaic_config")
+                or getattr(self.model, "qaic_config", None)
+                or {}
+            )
+            if (
+                dynamo
+                and qaic_config_for_transforms.get("blocking_mode") == "kv_headpar"
+                and qaic_config_for_transforms.get("use_kv_loop_op", True)
+                and not qaic_config_for_transforms.get("kv_loop_dynamic_trip_count", False)
+                and qaic_config_for_transforms.get("num_kv_blocks") is not None
+            ):
+                if getattr(self, "_use_onnx_subfunctions", False) and InlineTorchSubgraphFunctionsTransform not in active_transforms:
+                    active_transforms.append(InlineTorchSubgraphFunctionsTransform)
+                if StaticLoopInputsTransform not in active_transforms:
+                    active_transforms.append(StaticLoopInputsTransform)
             needs_external_tensor_data = any(
                 transform in active_transforms for transform in (FP16ClipTransform, SplitTensorsTransform)
             )
@@ -617,6 +636,7 @@ class QEFFBaseModel(ABC):
                 "model_name": self.model_name,
                 "dynamic_axes": None if dynamo else dynamic_axes,
                 "onnx_export_opset": constants.get_onnx_export_opset(dynamo),
+                "num_kv_blocks": qaic_config_for_transforms.get("num_kv_blocks"),
             }
             if onnx_transform_kwargs is not None:
                 transform_kwargs.update(onnx_transform_kwargs)
@@ -711,6 +731,7 @@ class QEFFBaseModel(ABC):
             bs=bs,
             num_devices=num_devices,
             qaic_config=qaic_config,
+            dynamo=dynamo,
             prefill_only=prefill_only,
             enable_chunking=enable_chunking,
             num_cores=kwargs.get("num_cores", compiler_options.get("aic_num_cores", constants.DEFAULT_AIC_NUM_CORES)),

--- a/QEfficient/base/onnx_transforms.py
+++ b/QEfficient/base/onnx_transforms.py
@@ -5,6 +5,7 @@
 #
 # ----------------------------------------------------------------------------
 
+import copy
 import logging
 import os
 import re
@@ -561,6 +562,260 @@ class AdapterWeightsToInputsTransform(BaseOnnxTransform):
         return model, transformed
 
 
+class InlineTorchSubgraphFunctionsTransform(BaseOnnxTransform):
+    """Inline torch-export local subgraph functions before QAIC compilation.
+
+    QAIC currently rejects ONNX Loop nodes when they appear inside local
+    FunctionProto bodies because function-local values are not accepted as
+    compile-time constants for Loop control inputs. Dynamo subfunction export
+    emits decoder layers and while_loop body/condition helpers in the
+    ``pkg.torch.__subgraph__`` domain, so this transform inlines those generated
+    torch subgraphs back into their callers. QEfficient custom op function
+    prototypes are left untouched.
+    """
+
+    _TORCH_SUBGRAPH_DOMAIN = "pkg.torch.__subgraph__"
+
+    @classmethod
+    def apply(cls, model: ModelProto, **kwargs) -> bool:
+        functions_by_key = {(function.domain, function.name): function for function in model.functions}
+        function_keys_to_inline = {
+            key for key in functions_by_key if key[0] == cls._TORCH_SUBGRAPH_DOMAIN
+        }
+        if not function_keys_to_inline:
+            return False
+
+        def scoped_name(name: str, value_map: Dict[str, str], prefix: str) -> str:
+            if not name:
+                return name
+            return value_map.get(name, f"{prefix}/{name}")
+
+        def collect_graph_local_names(graph) -> set[str]:
+            local_names = {value.name for value in graph.input}
+            local_names.update(value.name for value in graph.output)
+            local_names.update(value.name for value in graph.value_info)
+            local_names.update(tensor.name for tensor in graph.initializer)
+            for node in graph.node:
+                local_names.update(output for output in node.output if output)
+            return local_names
+
+        def clone_graph(graph, parent_map: Dict[str, str], parent_prefix: str, graph_prefix: str):
+            cloned_graph = onnx.GraphProto()
+            cloned_graph.CopyFrom(graph)
+            cloned_graph.name = f"{graph_prefix}/{graph.name}" if graph.name else graph_prefix
+
+            local_names = collect_graph_local_names(graph)
+            local_map = dict(parent_map)
+            for name in local_names:
+                local_map[name] = f"{graph_prefix}/{name}"
+
+            def map_graph_input(name: str) -> str:
+                if not name:
+                    return name
+                if name in local_names:
+                    return local_map[name]
+                if name in parent_map:
+                    return parent_map[name]
+                return f"{parent_prefix}/{name}"
+
+            def map_graph_local(name: str) -> str:
+                return scoped_name(name, local_map, graph_prefix)
+
+            for graph_input in cloned_graph.input:
+                graph_input.name = map_graph_local(graph_input.name)
+            for graph_output in cloned_graph.output:
+                graph_output.name = map_graph_local(graph_output.name)
+            for value_info in cloned_graph.value_info:
+                value_info.name = map_graph_local(value_info.name)
+            for initializer in cloned_graph.initializer:
+                initializer.name = map_graph_local(initializer.name)
+            for sparse_initializer in cloned_graph.sparse_initializer:
+                if sparse_initializer.values.name:
+                    sparse_initializer.values.name = map_graph_local(sparse_initializer.values.name)
+                if sparse_initializer.indices.name:
+                    sparse_initializer.indices.name = map_graph_local(sparse_initializer.indices.name)
+
+            cloned_nodes = []
+            for node in graph.node:
+                cloned_node = clone_node(
+                    node,
+                    local_map,
+                    graph_prefix,
+                    input_mapper=map_graph_input,
+                )
+                cloned_nodes.extend(expand_node(cloned_node, graph_prefix))
+            del cloned_graph.node[:]
+            cloned_graph.node.extend(cloned_nodes)
+            return cloned_graph
+
+        def clone_attribute(attribute, value_map: Dict[str, str], parent_prefix: str, graph_prefix: str):
+            cloned_attribute = onnx.AttributeProto()
+            cloned_attribute.CopyFrom(attribute)
+            if attribute.HasField("g"):
+                cloned_attribute.g.CopyFrom(
+                    clone_graph(attribute.g, value_map, parent_prefix, f"{graph_prefix}/{attribute.name}")
+                )
+            if attribute.graphs:
+                del cloned_attribute.graphs[:]
+                for graph_index, graph in enumerate(attribute.graphs):
+                    cloned_attribute.graphs.append(
+                        clone_graph(graph, value_map, parent_prefix, f"{graph_prefix}/{attribute.name}_{graph_index}")
+                    )
+            return cloned_attribute
+
+        def clone_node(node, value_map: Dict[str, str], prefix: str, input_mapper=None):
+            cloned_node = onnx.NodeProto()
+            cloned_node.CopyFrom(node)
+            original_name = cloned_node.name or cloned_node.op_type
+            if cloned_node.name:
+                cloned_node.name = f"{prefix}/{cloned_node.name}"
+            if input_mapper is None:
+                input_mapper = lambda input_name: scoped_name(input_name, value_map, prefix)
+            cloned_node.input[:] = [input_mapper(input_name) for input_name in node.input]
+            cloned_node.output[:] = [scoped_name(output_name, value_map, prefix) for output_name in node.output]
+            attributes = list(node.attribute)
+            del cloned_node.attribute[:]
+            for attribute in attributes:
+                cloned_node.attribute.append(clone_attribute(attribute, value_map, prefix, f"{prefix}/{original_name}"))
+            return cloned_node
+
+        def expand_node(node, prefix: str) -> List[onnx.NodeProto]:
+            function = functions_by_key.get((node.domain, node.op_type))
+            if function is None or (function.domain, function.name) not in function_keys_to_inline:
+                return [node]
+
+            value_map = {formal: actual for formal, actual in zip(function.input, node.input)}
+            value_map.update({formal: actual for formal, actual in zip(function.output, node.output)})
+            expanded_nodes = []
+            for function_node in function.node:
+                cloned_node = clone_node(function_node, value_map, prefix)
+                expanded_nodes.extend(expand_node(cloned_node, prefix))
+            return expanded_nodes
+
+        expanded_graph_nodes = []
+        inlined_call_count = 0
+        for node_index, node in enumerate(model.graph.node):
+            expanded_nodes = expand_node(node, node.name or f"node_{node_index}")
+            if len(expanded_nodes) != 1 or expanded_nodes[0] is not node:
+                inlined_call_count += 1
+            expanded_graph_nodes.extend(expanded_nodes)
+
+        if inlined_call_count == 0:
+            return False
+
+        del model.graph.node[:]
+        model.graph.node.extend(expanded_graph_nodes)
+        remaining_functions = [
+            function for function in model.functions if (function.domain, function.name) not in function_keys_to_inline
+        ]
+        del model.functions[:]
+        model.functions.extend(remaining_functions)
+        return True
+
+
+class StaticLoopInputsTransform(BaseOnnxTransform):
+    """Rewrite exported ONNX Loop inputs to static constants for compiler unrolling.
+
+    torch.while_loop can export a Loop with dynamic graph-produced control
+    inputs. The current QAIC compiler expects those Loop control inputs to be
+    compile-time constants. For fixed-CL KV blocking models, ``num_kv_blocks``
+    is the static maximum trip count.
+    """
+
+    @classmethod
+    def apply(cls, model: ModelProto, *, num_kv_blocks: Optional[int] = None, **kwargs) -> bool:
+        if num_kv_blocks is None:
+            return False
+
+        transformed = False
+        loop_index = 0
+
+        def next_names() -> Tuple[str, str]:
+            nonlocal loop_index
+            trip_name = f"qeff_static_loop_trip_count_{loop_index}"
+            cond_name = f"qeff_static_loop_cond_true_{loop_index}"
+            loop_index += 1
+            return trip_name, cond_name
+
+        def make_trip_tensor(name: str) -> TensorProto:
+            return onnx.helper.make_tensor(name, TensorProto.INT64, [], [int(num_kv_blocks)])
+
+        def make_cond_tensor(name: str) -> TensorProto:
+            return onnx.helper.make_tensor(name, TensorProto.BOOL, [], [True])
+
+        def rewrite_loop_node(node, trip_name: str, cond_name: str) -> bool:
+            if len(node.input) < 2:
+                logger.warning(
+                    "StaticLoopInputsTransform: Loop node '%s' has fewer than 2 inputs; skipping.", node.name
+                )
+                return False
+            node.input[0] = trip_name
+            node.input[1] = cond_name
+            return True
+
+        def rewrite_graph(graph) -> bool:
+            graph_changed = False
+            initializer_names = {initializer.name for initializer in graph.initializer}
+
+            def add_initializer_once(name: str, tensor: TensorProto) -> None:
+                if name not in initializer_names:
+                    graph.initializer.append(tensor)
+                    initializer_names.add(name)
+
+            for node in graph.node:
+                for attr in node.attribute:
+                    if attr.HasField("g"):
+                        graph_changed |= rewrite_graph(attr.g)
+                    for nested_graph in attr.graphs:
+                        graph_changed |= rewrite_graph(nested_graph)
+
+                if node.op_type != "Loop":
+                    continue
+                trip_name, cond_name = next_names()
+                add_initializer_once(trip_name, make_trip_tensor(trip_name))
+                add_initializer_once(cond_name, make_cond_tensor(cond_name))
+                graph_changed |= rewrite_loop_node(node, trip_name, cond_name)
+            return graph_changed
+
+        def rewrite_function(function) -> bool:
+            function_changed = False
+            constant_nodes = []
+            for node in function.node:
+                for attr in node.attribute:
+                    if attr.HasField("g"):
+                        function_changed |= rewrite_graph(attr.g)
+                    for nested_graph in attr.graphs:
+                        function_changed |= rewrite_graph(nested_graph)
+
+                if node.op_type != "Loop":
+                    continue
+                trip_name, cond_name = next_names()
+                constant_nodes.extend(
+                    [
+                        onnx.helper.make_node(
+                            "Constant", [], [trip_name], value=make_trip_tensor(f"{trip_name}_value")
+                        ),
+                        onnx.helper.make_node(
+                            "Constant", [], [cond_name], value=make_cond_tensor(f"{cond_name}_value")
+                        ),
+                    ]
+                )
+                function_changed |= rewrite_loop_node(node, trip_name, cond_name)
+
+            if constant_nodes:
+                existing_nodes = list(function.node)
+                del function.node[:]
+                function.node.extend(constant_nodes)
+                function.node.extend(existing_nodes)
+            return function_changed
+
+        transformed |= rewrite_graph(model.graph)
+        for function in model.functions:
+            transformed |= rewrite_function(function)
+
+        return transformed
+
+
 class PruneFakeInitializersTransform(BaseOnnxTransform):
     """Remove initializers backed by FakeTensors from a dynamo onnx_program before serialisation.
 
@@ -699,6 +954,12 @@ class OnnxTransformPipeline(BaseOnnxTransform):
 
         if AdapterWeightsToInputsTransform in requested:
             applied[AdapterWeightsToInputsTransform] = AdapterWeightsToInputsTransform.apply(model, **kwargs)
+
+        if InlineTorchSubgraphFunctionsTransform in requested:
+            applied[InlineTorchSubgraphFunctionsTransform] = InlineTorchSubgraphFunctionsTransform.apply(model, **kwargs)
+
+        if StaticLoopInputsTransform in requested:
+            applied[StaticLoopInputsTransform] = StaticLoopInputsTransform.apply(model, **kwargs)
 
         for t, done in applied.items():
             logger.info(f"Transform '{t.__name__}' applied={done}")

--- a/QEfficient/blocking/attention_blocking.py
+++ b/QEfficient/blocking/attention_blocking.py
@@ -22,6 +22,7 @@ from QEfficient.blocking.blocked_attention_forwards import (
     blocked_kv_attention_forward,
     blocked_kv_attention_forward_decode_headpar_batch,
     blocked_kv_attention_forward_headpar_offline,
+    blocked_kv_attention_forward_headpar_offline_loop,
     blocked_kv_attention_forward_prefill_headpar_offline,
     blocked_kv_mla_attention_forward,
     blocked_q_attention_forward,
@@ -138,6 +139,8 @@ class AttentionBlockingConfig:
     n_rep_chunk: Optional[int] = None
     ctx_len: Optional[int] = None
     kv_block_unroll: Optional[int] = 1
+    use_kv_loop_op: Optional[bool] = False
+    kv_loop_dynamic_trip_count: Optional[bool] = False
 
 
 # Required AttentionBlockingConfig fields per blocking mode.
@@ -243,9 +246,12 @@ def generic_blocked_attention_interface(
     prefill_only: bool = False,
     **kwargs,
 ):
-    strategy = _STRATEGIES[
-        BlockingMode.get_final_mode(blocking_config, prefill_only=prefill_only, is_mla=is_mla, mla_kwargs=mla_kwargs)
-    ]
+    mode = BlockingMode.get_final_mode(
+        blocking_config, prefill_only=prefill_only, is_mla=is_mla, mla_kwargs=mla_kwargs
+    )
+    strategy = _STRATEGIES[mode]
+    if mode == BlockingMode.KV_HEADPAR and blocking_config.use_kv_loop_op:
+        strategy = blocked_kv_attention_forward_headpar_offline_loop
 
     cache_kwargs = {"position_ids": position_ids, "batch_index": batch_index}
 
@@ -261,8 +267,17 @@ def generic_blocked_attention_interface(
                 )
             past_key_value.write_only(key, value, module.layer_idx, cache_kwargs)
         elif past_key_value is not None:
-            use_kv_blocked = "kv" in blocking_config.mode and supports_blocked_kv(past_key_value)
-            if blocking_config.mode == BlockingMode.KV_BATCH_FOLD:
+            use_kv_blocked_mode = (
+                mode == BlockingMode.KV
+                or mode == BlockingMode.KV_HEADPAR
+                or mode == BlockingMode.KV_BATCH_FOLD
+                or mode == BlockingMode.QKV
+                or mode == BlockingMode.HKV
+                or mode == BlockingMode.HQKV
+                or mode == BlockingMode.BHQKV
+            )
+            use_kv_blocked = use_kv_blocked_mode and supports_blocked_kv(past_key_value)
+            if mode == BlockingMode.KV_BATCH_FOLD:
                 past_key_value.write_only_batch(key, value, module.layer_idx, cache_kwargs)
             elif use_kv_blocked and sliding_window is None:
                 past_key_value.write_only(key, value, module.layer_idx, cache_kwargs)
@@ -303,6 +318,7 @@ def generic_blocked_attention_interface(
         configured_split=blocking_config.headpar_split,
         ctx_len=blocking_config.ctx_len,
         kv_block_unroll=blocking_config.kv_block_unroll,
+        kv_loop_dynamic_trip_count=blocking_config.kv_loop_dynamic_trip_count or False,
         skip_kv=blocking_config.skip_kv or False,
         # prefill-specific
         n_rep_chunk=blocking_config.n_rep_chunk,

--- a/QEfficient/blocking/blocked_attention_forwards.py
+++ b/QEfficient/blocking/blocked_attention_forwards.py
@@ -192,7 +192,7 @@ def blocked_kv_attention_forward(
         if skip_kv:
             skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
             # Eager mode Only
-            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing():
+            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing() and not _is_dynamo_compiling():
                 if skip_future.item():
                     break
 
@@ -297,7 +297,7 @@ def blocked_kv_attention_forward_decode_headpar_batch(
         skip_future = None
         if skip_kv:
             skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
-            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing():
+            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing() and not _is_dynamo_compiling():
                 if skip_future.item():
                     break
 
@@ -460,7 +460,7 @@ def blocked_kv_attention_forward_headpar_offline(
         if skip_kv:
             skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
             # Eager mode Only
-            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing():
+            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing() and not _is_dynamo_compiling():
                 if skip_future.item():
                     break
 
@@ -870,7 +870,7 @@ def blocked_qkv_attention_forward_prefill_headpar_offline(
             skip_future = None
             if skip_kv:
                 skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
-                if not is_export and skip_future.item():
+                if not is_export and not _is_dynamo_compiling() and skip_future.item():
                     break
 
             k_block = past_key_value.read_only_blocked_K(start_index, end_index, layer_idx, cache_kwargs)
@@ -1006,7 +1006,7 @@ def blocked_qkv_attention_forward_prefill_online(
             skip_future = None
             if skip_kv:
                 skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
-                if not is_export and skip_future.item():
+                if not is_export and not _is_dynamo_compiling() and skip_future.item():
                     break
 
             k_block = past_key_value.read_only_blocked_K(start_index, end_index, layer_idx, cache_kwargs)
@@ -1097,7 +1097,7 @@ def blocked_kv_attention_forward_prefill_headpar_offline(
         skip_future = None
         if skip_kv:
             skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
-            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing():
+            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing() and not _is_dynamo_compiling():
                 if skip_future.item():
                     break
 
@@ -1366,7 +1366,7 @@ def blocked_qkv_attention_forward(
             if skip_kv:
                 skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
                 # Eager mode Only
-                if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing():
+                if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing() and not _is_dynamo_compiling():
                     if skip_future.item():
                         break
 
@@ -1522,7 +1522,7 @@ def blocked_hqkv_attention_forward(
                 if skip_kv:
                     skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
                     # Eager mode Only
-                    if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing():
+                    if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing() and not _is_dynamo_compiling():
                         if skip_future.item():
                             break
 
@@ -1702,7 +1702,7 @@ def blocked_bhqkv_attention_forward(
                     if skip_kv:
                         skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
                         # Eager mode Only
-                        if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing():
+                        if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing() and not _is_dynamo_compiling():
                             if skip_future.item():
                                 break
 
@@ -1974,7 +1974,7 @@ def blocked_kv_mla_attention_forward(
         if skip_kv:
             skip_future = (torch.tensor(start_index, device=query.device) > current_position).all()
             # Eager mode Only
-            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing():
+            if not torch.onnx.is_in_onnx_export() and not torch.jit.is_tracing() and not _is_dynamo_compiling():
                 if skip_future.item():
                     break
 

--- a/QEfficient/blocking/blocked_attention_forwards.py
+++ b/QEfficient/blocking/blocked_attention_forwards.py
@@ -14,6 +14,7 @@ import torch
 from torch import nn
 from transformers.cache_utils import Cache
 
+from QEfficient.customop import ctx_gather_blocked_kv
 from QEfficient.transformers.modeling_attn_mask_utils import _create_causal_mask
 from QEfficient.utils.constants import HEADPAR_MASKED_ATTENTION_VALUE, MIN_MASKED_ATTENTION_VALUE
 
@@ -357,6 +358,55 @@ def blocked_kv_attention_forward_decode_headpar_batch(
     return attn_output.transpose(1, 2).contiguous(), None
 
 
+def _is_dynamo_compiling() -> bool:
+    dynamo = getattr(torch, "_dynamo", None)
+    if dynamo is None:
+        return False
+    try:
+        return bool(dynamo.is_compiling())
+    except Exception:
+        return False
+
+
+def _get_layer_cache_tensors(
+    past_key_value: Cache, layer_idx: int
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    if hasattr(past_key_value, "layers"):
+        layer = past_key_value.layers[layer_idx]
+        return getattr(layer, "keys", None), getattr(layer, "values", None)
+    if hasattr(past_key_value, "key_cache") and hasattr(past_key_value, "value_cache"):
+        return past_key_value.key_cache[layer_idx], past_key_value.value_cache[layer_idx]
+    try:
+        return past_key_value[layer_idx]
+    except Exception:
+        return None, None
+
+
+def _read_fixed_blocked_kv_for_loop(
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    start_index: torch.Tensor,
+    block_size: int,
+    position_ids: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    batch, num_kv_heads, ctx_len, head_dim = key_cache.shape
+    ctx_indices = (
+        start_index.to(dtype=position_ids.dtype)
+        + torch.arange(block_size, dtype=position_ids.dtype, device=position_ids.device)
+    )[None, None, ...]
+    gather_limit = position_ids.max(1, keepdim=True).values.unsqueeze(1).to(position_ids.dtype)
+    invalid_mask = (ctx_indices > gather_limit) | (ctx_indices >= ctx_len)
+    safe_indices = torch.where(invalid_mask, torch.zeros_like(ctx_indices), ctx_indices)
+    safe_indices = safe_indices.expand(batch, num_kv_heads, block_size)
+
+    key_block = ctx_gather_blocked_kv(key_cache, safe_indices)
+    value_block = ctx_gather_blocked_kv(value_cache, safe_indices)
+    value_block = torch.where(
+        invalid_mask.unsqueeze(-1), torch.zeros_like(value_block, dtype=value_block.dtype), value_block
+    )
+    return key_block, value_block, invalid_mask
+
+
 def blocked_kv_attention_forward_headpar_offline(
     module: nn.Module,
     query: torch.Tensor,
@@ -423,7 +473,7 @@ def blocked_kv_attention_forward_headpar_offline(
             block_len += pad_len
         split_block_len = block_len // split
 
-        key_5d = k_block.view(batch_size, num_kv_heads, split, split_block_len, head_dim)
+        key_5d = torch.stack(torch.split(k_block, split_block_len, dim=2), dim=2)
         attn_weights_block = torch.matmul(query_5d, key_5d.transpose(-1, -2)) * scaling
 
         if pad_len > 0:
@@ -465,7 +515,7 @@ def blocked_kv_attention_forward_headpar_offline(
         v_block = past_key_value.read_only_blocked_V(start_index, end_index, layer_idx, cache_kwargs)
         if pad_len > 0:
             v_block = nn.functional.pad(v_block, (0, 0, 0, pad_len))
-        value_5d = v_block.view(batch_size, num_kv_heads, split, split_block_len, head_dim)
+        value_5d = torch.stack(torch.split(v_block, split_block_len, dim=2), dim=2)
         sum_block = torch.einsum("bsgkn->bsgk", exp_block)
         out_block = torch.matmul(exp_block, value_5d)
         if skip_kv and (torch.onnx.is_in_onnx_export() or torch.jit.is_tracing()):
@@ -500,6 +550,219 @@ def blocked_kv_attention_forward_headpar_offline(
         scale_old = torch.exp(split_max - new_max)
         scale_sink = torch.exp(sink_logits - new_max)
 
+        split_sum = split_sum * scale_old + scale_sink
+        split_out = split_out * scale_old.unsqueeze(-1)
+        split_max = new_max
+
+    output = split_out / split_sum.unsqueeze(-1)
+    attn_output = output.view(batch_size, num_kv_heads, num_kv_groups, seq_len, head_dim).reshape(
+        batch_size, num_heads, seq_len, head_dim
+    )
+    return attn_output.transpose(1, 2).contiguous(), None
+
+
+def blocked_kv_attention_forward_headpar_offline_loop(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    scaling: float,
+    num_kv_blocks: int,
+    cache_kwargs: Dict[str, Any],
+    layer_idx: int,
+    past_key_value: Cache,
+    ctx_len: int,
+    *,
+    use_causal_mask: bool = False,
+    sliding_window: Optional[int] = None,
+    skip_kv: bool = False,
+    position_bias: Optional[torch.Tensor] = None,
+    sinks: Optional[torch.Tensor] = None,
+    configured_split: Optional[int] = None,
+    kv_loop_dynamic_trip_count: bool = False,
+    **kwargs,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Dynamo-only ONNX Loop variant of head-parallel decode KV blocking.
+
+    The eager/TorchScript path delegates to the established Python-for
+    implementation. During Dynamo export this uses ``torch.while_loop`` so the
+    KV-block iteration is represented as a structured ONNX Loop instead of being
+    unrolled into ``num_kv_blocks`` copies of the block body.
+    """
+    if not _is_dynamo_compiling():
+        return blocked_kv_attention_forward_headpar_offline(
+            module=module,
+            query=query,
+            key=key,
+            value=value,
+            attention_mask=attention_mask,
+            scaling=scaling,
+            num_kv_blocks=num_kv_blocks,
+            cache_kwargs=cache_kwargs,
+            layer_idx=layer_idx,
+            past_key_value=past_key_value,
+            ctx_len=ctx_len,
+            use_causal_mask=use_causal_mask,
+            sliding_window=sliding_window,
+            skip_kv=skip_kv,
+            position_bias=position_bias,
+            sinks=sinks,
+            configured_split=configured_split,
+            **kwargs,
+        )
+
+    def _fallback_to_python_for():
+        return blocked_kv_attention_forward_headpar_offline(
+            module=module,
+            query=query,
+            key=key,
+            value=value,
+            attention_mask=attention_mask,
+            scaling=scaling,
+            num_kv_blocks=num_kv_blocks,
+            cache_kwargs=cache_kwargs,
+            layer_idx=layer_idx,
+            past_key_value=past_key_value,
+            ctx_len=ctx_len,
+            use_causal_mask=use_causal_mask,
+            sliding_window=sliding_window,
+            skip_kv=skip_kv,
+            position_bias=position_bias,
+            sinks=sinks,
+            configured_split=configured_split,
+            **kwargs,
+        )
+
+    if (
+        sliding_window is not None
+        or position_bias is not None
+        or configured_split is None
+        or cache_kwargs.get("batch_index", None) is not None
+    ):
+        return _fallback_to_python_for()
+
+    key_cache, value_cache = _get_layer_cache_tensors(past_key_value, layer_idx)
+    if key_cache is None or value_cache is None:
+        return _fallback_to_python_for()
+
+    batch_size, num_heads, seq_len, head_dim = query.shape
+    num_kv_groups = getattr(module, "num_key_value_groups", None)
+    if num_kv_groups is None:
+        return _fallback_to_python_for()
+
+    past_seen_tokens = ctx_len
+    position_ids = cache_kwargs.get("position_ids")
+    num_kv_heads = num_heads // num_kv_groups
+    split = int(configured_split)
+    num_kv_blocks = max(1, int(num_kv_blocks))
+    kv_block_size = -(-past_seen_tokens // num_kv_blocks)
+    if past_seen_tokens % num_kv_blocks != 0 or kv_block_size % split != 0:
+        return _fallback_to_python_for()
+    split_block_len = kv_block_size // split
+    current_position = position_ids.max(dim=-1).values
+
+    query_folded = query.reshape(batch_size, num_kv_heads, seq_len * num_kv_groups, head_dim)
+    query_5d = query_folded.unsqueeze(2).expand(batch_size, num_kv_heads, split, seq_len * num_kv_groups, head_dim)
+
+    initial_max = torch.full(
+        (batch_size, num_kv_heads, split, seq_len * num_kv_groups),
+        float(HEADPAR_MASKED_ATTENTION_VALUE),
+        dtype=query.dtype,
+        device=query.device,
+    )
+    running_sum = torch.zeros_like(initial_max)
+    running_out = torch.zeros(
+        batch_size,
+        num_kv_heads,
+        split,
+        seq_len * num_kv_groups,
+        head_dim,
+        dtype=query.dtype,
+        device=query.device,
+    )
+    block_index = torch.zeros((), dtype=torch.int64, device=query.device)
+    if kv_loop_dynamic_trip_count:
+        live_blocks = torch.div(current_position.max() + kv_block_size, kv_block_size, rounding_mode="floor")
+        loop_bound = torch.clamp(live_blocks, min=0, max=num_kv_blocks).to(torch.int64)
+    else:
+        loop_bound = num_kv_blocks
+
+    def cond_fn(
+        index: torch.Tensor,
+        block_max: torch.Tensor,
+        block_sum: torch.Tensor,
+        block_out: torch.Tensor,
+    ) -> torch.Tensor:
+        del block_max, block_sum, block_out
+        return index < loop_bound
+
+    def body_fn(
+        index: torch.Tensor,
+        block_max: torch.Tensor,
+        block_sum: torch.Tensor,
+        block_out: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        start_index = index * kv_block_size
+
+        k_block, v_block, invalid_mask = _read_fixed_blocked_kv_for_loop(
+            key_cache, value_cache, start_index, kv_block_size, position_ids
+        )
+        key_5d = k_block.unflatten(2, (split, split_block_len))
+        attn_weights_block = torch.matmul(query_5d, key_5d.transpose(-1, -2)) * scaling
+
+        split_offsets = torch.arange(split, dtype=position_ids.dtype, device=query.device).view(1, 1, split, 1, 1)
+        token_offsets = torch.arange(split_block_len, dtype=position_ids.dtype, device=query.device).view(
+            1, 1, 1, 1, split_block_len
+        )
+        kv_indices = start_index.to(dtype=position_ids.dtype) + split_offsets * split_block_len + token_offsets
+        query_indices = position_ids.unsqueeze(1).unsqueeze(2).unsqueeze(3).unsqueeze(-1)
+        query_indices = query_indices.expand(-1, 1, 1, num_kv_groups, -1, 1).flatten(3, 4)
+        causal_mask = kv_indices > query_indices
+        invalid_mask_5d = torch.stack(torch.split(invalid_mask, split_block_len, dim=2), dim=2).unsqueeze(3)
+        attn_weights_block = attn_weights_block.masked_fill(
+            causal_mask | invalid_mask_5d, HEADPAR_MASKED_ATTENTION_VALUE
+        )
+
+        candidate_max = attn_weights_block.max(dim=-1).values
+        exp_block = torch.exp(attn_weights_block - candidate_max.unsqueeze(-1))
+
+        value_5d = v_block.unflatten(2, (split, split_block_len))
+        candidate_sum = torch.einsum("bsgkn->bsgk", exp_block)
+        candidate_out = torch.matmul(exp_block, value_5d)
+
+        new_max = torch.maximum(block_max, candidate_max)
+        old_weight = torch.exp(block_max - new_max)
+        new_weight = torch.exp(candidate_max - new_max)
+        new_sum = block_sum * old_weight + candidate_sum * new_weight
+        new_out = block_out * old_weight.unsqueeze(-1) + candidate_out * new_weight.unsqueeze(-1)
+
+        if skip_kv and not kv_loop_dynamic_trip_count:
+            skip_future = (start_index > current_position).all()
+            new_max = torch.where(skip_future, block_max, new_max)
+            new_sum = torch.where(skip_future, block_sum, new_sum)
+            new_out = torch.where(skip_future, block_out, new_out)
+
+        return index + 1, new_max, new_sum, new_out
+
+    _, block_max, block_sum, block_out = torch.while_loop(
+        cond_fn,
+        body_fn,
+        (block_index, initial_max, running_sum, running_out),
+    )
+
+    split_max = block_max.max(dim=2).values
+    split_weight = torch.exp(block_max - split_max.unsqueeze(2))
+    split_sum = torch.einsum("bsgk->bsk", (split_weight * block_sum))
+    split_out = torch.einsum("bsgkv->bskv", (split_weight.unsqueeze(-1) * block_out))
+
+    if sinks is not None:
+        sinks_logits = sinks.reshape(1, -1, 1, 1).expand(batch_size, -1, seq_len, -1)
+        sinks_folded = sinks_logits.reshape(batch_size, num_kv_heads, seq_len * num_kv_groups, 1)
+        sink_logits = sinks_folded.squeeze(-1)
+        new_max = torch.maximum(split_max, sink_logits)
+        scale_old = torch.exp(split_max - new_max)
+        scale_sink = torch.exp(sink_logits - new_max)
         split_sum = split_sum * scale_old + scale_sink
         split_out = split_out * scale_old.unsqueeze(-1)
         split_max = new_max
@@ -612,8 +875,8 @@ def blocked_qkv_attention_forward_prefill_headpar_offline(
 
             k_block = past_key_value.read_only_blocked_K(start_index, end_index, layer_idx, cache_kwargs)
             v_block = past_key_value.read_only_blocked_V(start_index, end_index, layer_idx, cache_kwargs)
-            key_5d = k_block.view(batch_size, num_kv_heads, split, split_block_len, head_dim)
-            value_5d = v_block.view(batch_size, num_kv_heads, split, split_block_len, head_dim)
+            key_5d = k_block.unflatten(2, (split, split_block_len))
+            value_5d = v_block.unflatten(2, (split, split_block_len))
             K_4d = key_5d.reshape(batch_size, num_kv_heads * split, split_block_len, head_dim)
             V_4d = value_5d.reshape(batch_size, num_kv_heads * split, split_block_len, head_dim)
 

--- a/QEfficient/blocking/blocking_configurator.py
+++ b/QEfficient/blocking/blocking_configurator.py
@@ -360,12 +360,17 @@ def build_transformer_blocking_config_for_transform(
     if blocking_mode == BlockingMode.KV_BATCH_FOLD:
         blocking_config.batch_fold = True
 
+    if blocking_mode == BlockingMode.KV_HEADPAR and compile_options.get("dynamo", False):
+        blocking_config.use_kv_loop_op = True
+
     # optional blocking parameters to set if given in qaic_config
     for param in (
         "skip_kv",
         "n_rep_chunk",
         "ctx_len",
         "kv_block_unroll",
+        "use_kv_loop_op",
+        "kv_loop_dynamic_trip_count",
     ):
         if qaic_config.get(param) is not None:
             setattr(blocking_config, param, qaic_config.get(param))

--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -2072,6 +2072,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
             bs=batch_size,
             num_devices=num_devices,
             qaic_config=qaic_config,
+            dynamo=dynamo,
             aic_num_cores=num_cores,
             mdp_num_partitions=compiler_options.get("mdp_num_partitions", 1),
             prefill_only=prefill_only,

--- a/QEfficient/transformers/models/mpt/modeling_mpt.py
+++ b/QEfficient/transformers/models/mpt/modeling_mpt.py
@@ -64,7 +64,12 @@ class QEffMptAttention(MptAttention):
         use_blocking = blocking_config is not None and (blocking_config.mode != BlockingMode.NONE)
 
         if use_blocking:
-            if position_bias is not None:
+            use_kv_headpar_loop = (
+                blocking_config.mode == BlockingMode.KV_HEADPAR and bool(blocking_config.use_kv_loop_op)
+            )
+            if use_kv_headpar_loop and not hasattr(self, "num_key_value_groups"):
+                self.num_key_value_groups = 1
+            if position_bias is not None and not use_kv_headpar_loop:
                 if len(position_bias.shape) != 3:
                     raise ValueError(
                         f"Expecting position_bias shape to be 3 dimensions, got {len(position_bias.shape)}"
@@ -89,7 +94,7 @@ class QEffMptAttention(MptAttention):
                 batch_index=batch_index,
                 position_ids=position_ids,
                 past_seen_tokens=past_seen_tokens,
-                position_bias=position_bias,
+                position_bias=None if use_kv_headpar_loop else position_bias,
             )
             context_states = attn_output.contiguous().view(batch_size, seq_length, -1)
             attn_output = self.out_proj(context_states)

--- a/examples/dynamo/causal_lm/README.md
+++ b/examples/dynamo/causal_lm/README.md
@@ -54,8 +54,24 @@ python examples/dynamo/causal_lm/basic_dynamo_inference.py \
     --prefill-seq-len 128 \
     --ctx-len 128 \
     --num-cores 16 \
-    --use-weight-free-export
+    --weight-free
 ```
+
+**KV head-parallel blocking with ONNX Loop:**
+```bash
+python examples/dynamo/causal_lm/kv_blocking_loop_inference.py \
+    --model-name Qwen/Qwen2-1.5B-Instruct \
+    --prompt "My name is" \
+    --prefill-seq-len 32 \
+    --ctx-len 128 \
+    --num-kv-blocks 2 \
+    --num-cores 16
+```
+
+This example passes `qaic_config={"blocking_mode": "kv_headpar"}` and exports
+with `dynamo=True`. QEfficient enables the supported KV-block Loop path by
+default for this combination, so the KV-block loop is represented as an ONNX
+`Loop` instead of a Python-for-unrolled graph.
 
 **Parameters:**
 
@@ -69,13 +85,13 @@ python examples/dynamo/causal_lm/basic_dynamo_inference.py \
 | `--num-cores` | `16` | Number of AI 100 cores |
 | `--aic-hw-version` | `ai100` | Hardware version |
 | `--num-hidden-layers` | `-1` | Override model depth (for debugging) |
-| `--use-weight-free-export` | `False` | Build a meta-device model and load weights during compile |
+| `--weight-free` | `False` | Build a meta-device model and load weights during compile |
 | `--device-group` | `None` | Device IDs, e.g. `[0,1]` |
 
 This example:
 - Loads the model normally by default
-- Builds the model with meta tensors when `--use-weight-free-export` is set
-- Exports using `torch.export` with ONNX subfunctions enabled
+- Builds the model with meta tensors when `--weight-free` is set
+- Exports using `torch.export`; ONNX subfunctions are opt-in with `--enable-onnx-subfunctions`
 - Compiles to a QPC binary for Cloud AI 100
 - Runs token generation and prints the output
 

--- a/examples/dynamo/causal_lm/kv_blocking_loop_inference.py
+++ b/examples/dynamo/causal_lm/kv_blocking_loop_inference.py
@@ -5,7 +5,7 @@
 #
 # -----------------------------------------------------------------------------
 
-"""Dynamo-based export and inference for Causal LM models on Cloud AI 100.
+"""Dynamo CausalLM example using KV head-parallel blocking with ONNX Loop export.
 
 Requires PyTorch >= 2.13. Install dependencies before running:
     pip install -r examples/dynamo/causal_lm/requirements.txt
@@ -21,32 +21,19 @@ from QEfficient.utils import constants
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Dynamo-based export and inference for Causal LM models on Cloud AI 100.",
+        description="Dynamo CausalLM export with kv_headpar blocking represented as ONNX Loop.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    parser.add_argument("--model-name", type=str, default="tiny-random/gpt-oss-mxfp4", help="HuggingFace model ID")
+    parser.add_argument("--model-name", type=str, default="Qwen/Qwen2-1.5B-Instruct", help="HuggingFace model ID")
     parser.add_argument("--num-hidden-layers", type=int, default=-1, help="Override number of hidden layers")
     parser.add_argument("--prompt", type=str, default="My name is", help="Input prompt for generation")
     parser.add_argument("--prefill-seq-len", type=int, default=32, help="Prefill sequence length")
     parser.add_argument("--ctx-len", type=int, default=128, help="Context (KV-cache) length")
     parser.add_argument("--generation-len", type=int, default=100, help="Number of new tokens to generate")
-    parser.add_argument(
-        "--blocking-mode",
-        choices=["kv", "kv_headpar", "q", "h", "qkv", "hq", "hkv", "hqkv"],
-        default=None,
-        help="Optional attention blocking mode to pass through qaic_config",
-    )
-    parser.add_argument("--num-kv-blocks", type=int, default=None, help="Number of KV blocks for KV blocking")
-    parser.add_argument("--num-q-blocks", type=int, default=None, help="Number of Q blocks for Q/QKV blocking")
-    parser.add_argument("--head-block-size", type=int, default=None, help="Head block size for head blocking modes")
+    parser.add_argument("--num-kv-blocks", type=int, default=2, help="Number of KV blocks")
     parser.add_argument("--headpar-split", type=int, default=None, help="Override split count for kv_headpar")
     parser.add_argument(
-        "--disable-kv-loop-op",
-        action="store_true",
-        help="Disable the dynamo ONNX Loop implementation for kv_headpar",
-    )
-    parser.add_argument(
-        "--kv-loop-dynamic-trip-count",
+        "--dynamic-trip-count",
         action="store_true",
         help="Use runtime live-block count as the ONNX Loop bound instead of static max blocks",
     )
@@ -72,34 +59,25 @@ def main():
     )
     args = parser.parse_args()
 
-    # Load tokenizer and model
     tokenizer = AutoTokenizer.from_pretrained(args.model_name)
     config = AutoConfig.from_pretrained(args.model_name)
     if args.num_hidden_layers > 0:
         config.num_hidden_layers = args.num_hidden_layers
+
     model = QEFFAutoModelForCausalLM.from_pretrained(
         args.model_name,
         config=config,
         weight_free=args.weight_free,
     )
 
-    qaic_config = None
-    if args.blocking_mode is not None:
-        qaic_config = {"blocking_mode": args.blocking_mode}
-        if args.num_kv_blocks is not None:
-            qaic_config["num_kv_blocks"] = args.num_kv_blocks
-        if args.num_q_blocks is not None:
-            qaic_config["num_q_blocks"] = args.num_q_blocks
-        if args.head_block_size is not None:
-            qaic_config["head_block_size"] = args.head_block_size
-        if args.headpar_split is not None:
-            qaic_config["headpar_split"] = args.headpar_split
-        if args.disable_kv_loop_op:
-            qaic_config["use_kv_loop_op"] = False
-        if args.kv_loop_dynamic_trip_count:
-            qaic_config["kv_loop_dynamic_trip_count"] = True
+    qaic_config = {
+        "blocking_mode": "kv_headpar",
+        "num_kv_blocks": args.num_kv_blocks,
+        "kv_loop_dynamic_trip_count": args.dynamic_trip_count,
+    }
+    if args.headpar_split is not None:
+        qaic_config["headpar_split"] = args.headpar_split
 
-    # Export (via torch.export / dynamo) + compile to QPC
     qpc_path = model.compile(
         prefill_seq_len=args.prefill_seq_len,
         ctx_len=args.ctx_len,
@@ -112,7 +90,6 @@ def main():
     )
     print(f"Model compiled to: {qpc_path}")
 
-    # Run inference on device
     exec_info = model.generate(
         tokenizer=tokenizer,
         prompts=[args.prompt],

--- a/tests/dynamo/test_kv_blocking_loop.py
+++ b/tests/dynamo/test_kv_blocking_loop.py
@@ -16,11 +16,13 @@ import onnx
 import pytest
 import torch
 from torch import nn
+from transformers import AutoConfig, AutoModelForCausalLM
 
 from QEfficient.base.onnx_transforms import StaticLoopInputsTransform
 from QEfficient.blocking.attention_blocking import BlockingMode
 from QEfficient.blocking.blocked_attention_forwards import blocked_kv_attention_forward_headpar_offline_loop
 from QEfficient.blocking.blocking_configurator import build_transformer_blocking_config_for_transform
+from QEfficient.transformers.models.modeling_auto import QEFFAutoModelForCausalLM
 from QEfficient.utils.export_utils import build_dynamo_export_kwargs
 
 
@@ -83,6 +85,28 @@ def _collect_onnx_nodes(model: onnx.ModelProto) -> list[onnx.NodeProto]:
     for function in model.functions:
         visit(function.node)
     return nodes
+
+
+def _collect_graph_nodes(graph: onnx.GraphProto) -> list[onnx.NodeProto]:
+    nodes = []
+
+    def visit(node_list):
+        for node in node_list:
+            nodes.append(node)
+            for attr in node.attribute:
+                if attr.type == onnx.AttributeProto.GRAPH:
+                    visit(attr.g.node)
+                elif attr.type == onnx.AttributeProto.GRAPHS:
+                    for nested_graph in attr.graphs:
+                        visit(nested_graph.node)
+
+    visit(graph.node)
+    return nodes
+
+
+def _metadata_value(model: onnx.ModelProto, key: str) -> str:
+    metadata = {entry.key: entry.value for entry in model.metadata_props}
+    return metadata.get(key, "")
 
 
 @pytest.mark.dynamo
@@ -149,6 +173,65 @@ def test_kv_headpar_loop_config_is_dynamo_only():
     assert dynamo_config.use_kv_loop_op is True
     assert legacy_config.mode == BlockingMode.KV_HEADPAR
     assert legacy_config.use_kv_loop_op is False
+
+
+@pytest.mark.dynamo
+@pytest.mark.dynamo_export
+def test_qeff_tiny_causallm_kv_headpar_loop_with_subfunctions_exports_static_loops(tmp_export_dir):
+    config = AutoConfig.for_model(
+        "qwen2",
+        vocab_size=127,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        max_position_embeddings=64,
+        pad_token_id=0,
+        bos_token_id=1,
+        eos_token_id=2,
+    )
+    model = AutoModelForCausalLM.from_config(config, attn_implementation="eager").eval()
+    qaic_config = {"blocking_mode": "kv_headpar", "num_kv_blocks": 2, "headpar_split": 2}
+    qeff_model = QEFFAutoModelForCausalLM(model, cb=False, qaic_config=qaic_config)
+
+    qeff_model.transform(
+        ctx_len=16,
+        seq_len=8,
+        bs=1,
+        num_devices=1,
+        qaic_config=qaic_config,
+        dynamo=True,
+        num_cores=2,
+        prefill_seq_len=8,
+    )
+    onnx_path = qeff_model.export(
+        tmp_export_dir,
+        prefill_seq_len=8,
+        num_cores=2,
+        dynamo=True,
+        use_onnx_subfunctions=True,
+        offload_pt_weights=False,
+    )
+
+    exported = onnx.load(onnx_path, load_external_data=False)
+    transform_metadata = _metadata_value(exported, "qeff_transforms")
+    assert "InlineTorchSubgraphFunctionsTransform" in transform_metadata
+    assert "StaticLoopInputsTransform" in transform_metadata
+
+    graph_loop_nodes = [node for node in _collect_graph_nodes(exported.graph) if node.op_type == "Loop"]
+    assert graph_loop_nodes, "Expected KV headpar Dynamo export to retain ONNX Loop nodes in the main graph"
+    function_loop_nodes = [
+        node for function in exported.functions for node in function.node if node.op_type == "Loop"
+    ]
+    assert not function_loop_nodes, "Loop nodes must be inlined out of FunctionProto bodies for QAIC subfunctions"
+
+    initializers = {initializer.name: initializer for initializer in exported.graph.initializer}
+    for loop_node in graph_loop_nodes:
+        assert loop_node.input[0].startswith("qeff_static_loop_trip_count_")
+        assert loop_node.input[1].startswith("qeff_static_loop_cond_true_")
+        assert onnx.numpy_helper.to_array(initializers[loop_node.input[0]]).item() == 2
+        assert onnx.numpy_helper.to_array(initializers[loop_node.input[1]]).item() is True
 
 
 def test_static_loop_inputs_transform_rewrites_loop_control_inputs():

--- a/tests/dynamo/test_kv_blocking_loop.py
+++ b/tests/dynamo/test_kv_blocking_loop.py
@@ -1,0 +1,243 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+"""Dynamo export tests for KV-blocked attention represented as ONNX Loop."""
+
+from __future__ import annotations
+
+import collections
+from pathlib import Path
+
+import onnx
+import pytest
+import torch
+from torch import nn
+
+from QEfficient.base.onnx_transforms import StaticLoopInputsTransform
+from QEfficient.blocking.attention_blocking import BlockingMode
+from QEfficient.blocking.blocked_attention_forwards import blocked_kv_attention_forward_headpar_offline_loop
+from QEfficient.blocking.blocking_configurator import build_transformer_blocking_config_for_transform
+from QEfficient.utils.export_utils import build_dynamo_export_kwargs
+
+
+class _TinyAttentionModule(nn.Module):
+    num_key_value_groups = 1
+
+
+class _CacheLayer:
+    def __init__(self, keys: torch.Tensor, values: torch.Tensor):
+        self.keys = keys
+        self.values = values
+
+
+class _LoopKVCache:
+    def __init__(self, keys: torch.Tensor, values: torch.Tensor):
+        self.layers = [_CacheLayer(keys, values)]
+
+
+class _KVHeadparLoopWrapper(nn.Module):
+    def __init__(self, keys: torch.Tensor, values: torch.Tensor):
+        super().__init__()
+        self.register_buffer("keys", keys)
+        self.register_buffer("values", values)
+        self.attn = _TinyAttentionModule()
+
+    def forward(self, query: torch.Tensor, position_ids: torch.Tensor) -> torch.Tensor:
+        cache = _LoopKVCache(self.keys, self.values)
+        output, _ = blocked_kv_attention_forward_headpar_offline_loop(
+            module=self.attn,
+            query=query,
+            key=query,
+            value=query,
+            attention_mask=None,
+            scaling=0.5,
+            num_kv_blocks=2,
+            cache_kwargs={"position_ids": position_ids},
+            layer_idx=0,
+            past_key_value=cache,
+            ctx_len=8,
+            configured_split=2,
+            skip_kv=True,
+        )
+        return output
+
+
+def _collect_onnx_nodes(model: onnx.ModelProto) -> list[onnx.NodeProto]:
+    nodes = []
+
+    def visit(node_list):
+        for node in node_list:
+            nodes.append(node)
+            for attr in node.attribute:
+                if attr.type == onnx.AttributeProto.GRAPH:
+                    visit(attr.g.node)
+                elif attr.type == onnx.AttributeProto.GRAPHS:
+                    for graph in attr.graphs:
+                        visit(graph.node)
+
+    visit(model.graph.node)
+    for function in model.functions:
+        visit(function.node)
+    return nodes
+
+
+@pytest.mark.dynamo
+@pytest.mark.dynamo_export
+def test_kv_headpar_loop_export_contains_onnx_loop(tmp_path: Path):
+    torch.manual_seed(11)
+    model = _KVHeadparLoopWrapper(
+        keys=torch.randn(2, 2, 8, 4),
+        values=torch.randn(2, 2, 8, 4),
+    ).eval()
+    query = torch.randn(2, 2, 1, 4)
+    position_ids = torch.tensor([[0], [3]], dtype=torch.int64)
+    onnx_path = tmp_path / "kv_headpar_loop.onnx"
+
+    export_kwargs = build_dynamo_export_kwargs({"external_data": False})
+    torch.onnx.export(
+        model,
+        (query, position_ids),
+        onnx_path,
+        input_names=["query", "position_ids"],
+        output_names=["attn_output"],
+        **export_kwargs,
+    )
+
+    exported = onnx.load(onnx_path, load_external_data=False)
+    counts = collections.Counter(node.op_type for node in _collect_onnx_nodes(exported))
+    assert counts["Loop"] == 1
+
+
+@pytest.mark.dynamo
+def test_kv_headpar_loop_config_is_dynamo_only():
+    cfg = type(
+        "Cfg",
+        (),
+        {
+            "num_attention_heads": 2,
+            "num_key_value_heads": 2,
+            "hidden_size": 8,
+        },
+    )()
+
+    dynamo_config = build_transformer_blocking_config_for_transform(
+        cfg,
+        ctx_len=8,
+        seq_len=1,
+        bs=1,
+        num_devices=1,
+        qaic_config={"blocking_mode": "kv_headpar", "num_kv_blocks": 2},
+        aic_num_cores=2,
+        dynamo=True,
+    )
+    legacy_config = build_transformer_blocking_config_for_transform(
+        cfg,
+        ctx_len=8,
+        seq_len=1,
+        bs=1,
+        num_devices=1,
+        qaic_config={"blocking_mode": "kv_headpar", "num_kv_blocks": 2},
+        aic_num_cores=2,
+        dynamo=False,
+    )
+
+    assert dynamo_config.mode == BlockingMode.KV_HEADPAR
+    assert dynamo_config.use_kv_loop_op is True
+    assert legacy_config.mode == BlockingMode.KV_HEADPAR
+    assert legacy_config.use_kv_loop_op is False
+
+
+def test_static_loop_inputs_transform_rewrites_loop_control_inputs():
+    body = onnx.helper.make_graph(
+        [
+            onnx.helper.make_node(
+                "Identity",
+                ["cond_in"],
+                ["cond_out"],
+            ),
+            onnx.helper.make_node(
+                "Identity",
+                ["state_in"],
+                ["state_out"],
+            ),
+        ],
+        "loop_body",
+        [
+            onnx.helper.make_tensor_value_info("iter", onnx.TensorProto.INT64, []),
+            onnx.helper.make_tensor_value_info("cond_in", onnx.TensorProto.BOOL, []),
+            onnx.helper.make_tensor_value_info("state_in", onnx.TensorProto.FLOAT, [1]),
+        ],
+        [
+            onnx.helper.make_tensor_value_info("cond_out", onnx.TensorProto.BOOL, []),
+            onnx.helper.make_tensor_value_info("state_out", onnx.TensorProto.FLOAT, [1]),
+        ],
+    )
+    graph = onnx.helper.make_graph(
+        [
+            onnx.helper.make_node("Greater", ["state", "zero"], ["runtime_cond"]),
+            onnx.helper.make_node("Loop", ["runtime_trip", "runtime_cond", "state"], ["loop_out"], body=body),
+        ],
+        "main",
+        [onnx.helper.make_tensor_value_info("state", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("loop_out", onnx.TensorProto.FLOAT, [1])],
+        [
+            onnx.helper.make_tensor("zero", onnx.TensorProto.FLOAT, [1], [0.0]),
+            onnx.helper.make_tensor("runtime_trip", onnx.TensorProto.INT64, [], [8]),
+        ],
+    )
+    model = onnx.helper.make_model(graph)
+
+    transformed = StaticLoopInputsTransform.apply(model, num_kv_blocks=2)
+
+    assert transformed
+    loop_node = next(node for node in model.graph.node if node.op_type == "Loop")
+    initializers = {initializer.name: initializer for initializer in model.graph.initializer}
+    assert loop_node.input[:2] == ["qeff_static_loop_trip_count_0", "qeff_static_loop_cond_true_0"]
+    assert onnx.numpy_helper.to_array(initializers[loop_node.input[0]]).item() == 2
+    assert onnx.numpy_helper.to_array(initializers[loop_node.input[1]]).item() is True
+
+
+def test_static_loop_inputs_transform_rewrites_function_loop_control_inputs():
+    body = onnx.helper.make_graph(
+        [
+            onnx.helper.make_node("Identity", ["cond_in"], ["cond_out"]),
+            onnx.helper.make_node("Identity", ["state_in"], ["state_out"]),
+        ],
+        "loop_body",
+        [
+            onnx.helper.make_tensor_value_info("iter", onnx.TensorProto.INT64, []),
+            onnx.helper.make_tensor_value_info("cond_in", onnx.TensorProto.BOOL, []),
+            onnx.helper.make_tensor_value_info("state_in", onnx.TensorProto.FLOAT, [1]),
+        ],
+        [
+            onnx.helper.make_tensor_value_info("cond_out", onnx.TensorProto.BOOL, []),
+            onnx.helper.make_tensor_value_info("state_out", onnx.TensorProto.FLOAT, [1]),
+        ],
+    )
+    function = onnx.helper.make_function(
+        "qeff.test",
+        "LoopFunction",
+        ["runtime_trip", "runtime_cond", "state"],
+        ["loop_out"],
+        [onnx.helper.make_node("Loop", ["runtime_trip", "runtime_cond", "state"], ["loop_out"], body=body)],
+        [onnx.helper.make_opsetid("", 18)],
+    )
+    graph = onnx.helper.make_graph(
+        [],
+        "main",
+        [onnx.helper.make_tensor_value_info("state", onnx.TensorProto.FLOAT, [1])],
+        [onnx.helper.make_tensor_value_info("state", onnx.TensorProto.FLOAT, [1])],
+    )
+    model = onnx.helper.make_model(graph, functions=[function])
+
+    transformed = StaticLoopInputsTransform.apply(model, num_kv_blocks=4)
+
+    assert transformed
+    loop_node = next(node for node in model.functions[0].node if node.op_type == "Loop")
+    assert loop_node.input[:2] == ["qeff_static_loop_trip_count_0", "qeff_static_loop_cond_true_0"]
+    constant_outputs = {node.output[0] for node in model.functions[0].node if node.op_type == "Constant"}
+    assert set(loop_node.input[:2]) <= constant_outputs

--- a/tests/dynamo/test_kv_blocking_loop_tiny_on_qaic.py
+++ b/tests/dynamo/test_kv_blocking_loop_tiny_on_qaic.py
@@ -1,0 +1,96 @@
+# -----------------------------------------------------------------------------
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# -----------------------------------------------------------------------------
+
+"""Run tiny CausalLM KV-headpar Dynamo Loop models on QAIC.
+
+This mirrors examples/dynamo/causal_lm/basic_dynamo_inference.py, but keeps the
+coverage in pytest form and pins the KV-loop dimensions requested for regression:
+PL=64, CL=128, num_kv_blocks=2.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from QEfficient.transformers.models.modeling_auto import QEFFAutoModelForCausalLM
+
+from ._helpers import DYNAMO_CAUSAL_LM_MODEL_IDS, load_hf_model, load_tokenizer, skip_on_model_fetch_error
+
+PREFILL_SEQ_LEN = 64
+CTX_LEN = 128
+NUM_KV_BLOCKS = 2
+HEADPAR_SPLIT = 2
+BATCH_SIZE = 1
+GENERATION_LEN = 2
+NUM_CORES = 2
+PROMPT = "My name is"
+
+KV_HEADPAR_LOOP_TINY_MODEL_TYPES = {
+    "gpt_oss",
+    "granite",
+    "llama",
+    "mistral",
+    "mixtral",
+    "mpt",
+    "qwen2",
+    "starcoder2",
+}
+KV_HEADPAR_LOOP_TINY_MODEL_IDS = {
+    model_type: model_id
+    for model_type, model_id in DYNAMO_CAUSAL_LM_MODEL_IDS.items()
+    if model_type in KV_HEADPAR_LOOP_TINY_MODEL_TYPES
+}
+
+
+@pytest.mark.dynamo
+@pytest.mark.dynamo_export
+@pytest.mark.on_qaic
+@pytest.mark.llm_model
+@pytest.mark.parametrize(
+    "model_type,model_id",
+    sorted(KV_HEADPAR_LOOP_TINY_MODEL_IDS.items()),
+    ids=sorted(KV_HEADPAR_LOOP_TINY_MODEL_IDS),
+)
+def test_kv_headpar_dynamo_loop_subfunctions_tiny_generate_on_qaic(model_type, model_id, tmp_export_dir):
+    del model_type
+    qaic_config = {
+        "blocking_mode": "kv_headpar",
+        "num_kv_blocks": NUM_KV_BLOCKS,
+        "headpar_split": HEADPAR_SPLIT,
+    }
+
+    try:
+        model_hf = load_hf_model(model_id)
+        tokenizer = load_tokenizer(model_id)
+    except Exception as exc:
+        skip_on_model_fetch_error(exc, model_id)
+
+    qeff_model = QEFFAutoModelForCausalLM(model_hf, continuous_batching=False, qaic_config=qaic_config)
+    qpc_path = qeff_model.compile(
+        compile_dir=str(tmp_export_dir / "kv_headpar_loop_tiny_compile"),
+        prefill_seq_len=PREFILL_SEQ_LEN,
+        ctx_len=CTX_LEN,
+        num_cores=NUM_CORES,
+        batch_size=BATCH_SIZE,
+        qaic_config=qaic_config,
+        dynamo=True,
+        use_onnx_subfunctions=True,
+        offload_pt_weights=False,
+    )
+
+    exec_info = qeff_model.generate(
+        tokenizer=tokenizer,
+        prompts=[PROMPT],
+        generation_len=GENERATION_LEN,
+    )
+
+    assert Path(qpc_path).is_dir()
+    assert exec_info is not None
+    assert exec_info.generated_texts is not None
+    assert len(exec_info.generated_texts) == BATCH_SIZE

--- a/tests/dynamo/test_on_qaic.py
+++ b/tests/dynamo/test_on_qaic.py
@@ -45,6 +45,43 @@ from ._helpers import (
 @pytest.mark.dynamo
 @pytest.mark.on_qaic
 @pytest.mark.llm_model
+def test_dynamo_kv_headpar_loop_subfunctions_generate_on_qaic(tmp_export_dir):
+    """Compile and execute KV-headpar Dynamo Loop export with ONNX subfunctions on QAIC."""
+    model_id = DYNAMO_CAUSAL_LM_MODEL_IDS["qwen2"]
+    qaic_config = {"blocking_mode": "kv_headpar", "num_kv_blocks": 2, "headpar_split": 2}
+
+    try:
+        model_hf = load_hf_model(model_id)
+        tokenizer = load_tokenizer(model_id)
+    except Exception as exc:
+        skip_on_model_fetch_error(exc, model_id)
+
+    qeff_model = QEFFAutoModelForCausalLM(model_hf, qaic_config=qaic_config)
+    qpc_path = qeff_model.compile(
+        compile_dir=str(tmp_export_dir / "kv_headpar_loop_subfunctions_compile"),
+        prefill_seq_len=PROMPT_LEN,
+        ctx_len=CTX_LEN,
+        num_cores=2,
+        batch_size=BATCH_SIZE,
+        use_onnx_subfunctions=True,
+        dynamo=True,
+        offload_pt_weights=False,
+    )
+    output = qeff_model.generate(
+        tokenizer=tokenizer,
+        prompts=["hello world"],
+        generation_len=2,
+    )
+
+    assert qpc_path is not None
+    assert output is not None
+    assert output.generated_texts is not None
+    assert len(output.generated_texts) == 1
+
+
+@pytest.mark.dynamo
+@pytest.mark.on_qaic
+@pytest.mark.llm_model
 @pytest.mark.parametrize(
     "model_type,model_id", list(DYNAMO_CAUSAL_LM_MODEL_IDS.items()), ids=list(DYNAMO_CAUSAL_LM_MODEL_IDS)
 )

--- a/tests/unit_test/models/test_model_quickcheck.py
+++ b/tests/unit_test/models/test_model_quickcheck.py
@@ -113,6 +113,22 @@ CAUSAL_MULTI_SUBFUNCTION_MODEL_TYPES = {
     # "granitemoe" is intentionally not listed in CAUSAL_RUNTIME_MODEL_IDS yet.
 }
 
+CAUSAL_KV_HEADPAR_LOOP_MODEL_TYPES = {
+    "gpt_oss",
+    "granite",
+    "llama",
+    "mistral",
+    "mixtral",
+    "mpt",
+    "qwen2",
+    "starcoder2",
+}
+CAUSAL_KV_HEADPAR_LOOP_MODEL_IDS = {
+    model_type: model_id
+    for model_type, model_id in CAUSAL_RUNTIME_MODEL_IDS.items()
+    if model_type in CAUSAL_KV_HEADPAR_LOOP_MODEL_TYPES
+}
+
 VLM_TEXT_RUNTIME_MODEL_ID = "tiny-random/gemma-3"
 VLM_EXPORT_MODEL_IDS = {
     "gemma3": "tiny-random/gemma-3",
@@ -378,6 +394,27 @@ def _function_op_types(onnx_model, function_names: Set[str]) -> Set[str]:
         if function_proto.name in function_names
         for node in function_proto.node
     }
+
+
+def _collect_onnx_graph_nodes(graph: onnx.GraphProto) -> list[onnx.NodeProto]:
+    nodes = []
+
+    def visit(node_list):
+        for node in node_list:
+            nodes.append(node)
+            for attr in node.attribute:
+                if attr.type == onnx.AttributeProto.GRAPH:
+                    visit(attr.g.node)
+                elif attr.type == onnx.AttributeProto.GRAPHS:
+                    for nested_graph in attr.graphs:
+                        visit(nested_graph.node)
+
+    visit(graph.node)
+    return nodes
+
+
+def _metadata_value(onnx_model: onnx.ModelProto, key: str) -> str:
+    return {entry.key: entry.value for entry in onnx_model.metadata_props}.get(key, "")
 
 
 def _assert_has_retained_state_outputs(onnx_path: Path) -> None:
@@ -1506,6 +1543,83 @@ def test_causal_subfunction_export_smoke_all_models(model_type, model_id, tmp_pa
 
     assert np.array_equal(hf_tokens, kv_tokens.squeeze(0))
     assert np.array_equal(kv_tokens, ort_tokens)
+
+
+@pytest.mark.llm_model
+@pytest.mark.dynamo
+@pytest.mark.dynamo_export
+@pytest.mark.parametrize(
+    ("model_type", "model_id"),
+    sorted(CAUSAL_KV_HEADPAR_LOOP_MODEL_IDS.items()),
+    ids=sorted(CAUSAL_KV_HEADPAR_LOOP_MODEL_IDS),
+)
+def test_causal_kv_headpar_dynamo_subfunction_export_static_loop_supported_models(
+    model_type, model_id, tmp_path, monkeypatch
+):
+    ctx_len = 128
+    prefill_seq_len = 64
+    num_kv_blocks = 2
+    qaic_config = {"blocking_mode": "kv_headpar", "num_kv_blocks": num_kv_blocks, "headpar_split": 2}
+
+    try:
+        model_hf = AutoModelForCausalLM.from_pretrained(
+            model_id,
+            **MODEL_KWARGS,
+            low_cpu_mem_usage=False,
+            trust_remote_code=True,
+            torch_dtype=torch.float32,
+        ).eval()
+    except Exception as exc:
+        _skip_on_model_fetch_error(exc, model_id)
+
+    qeff_model = QEFFAutoModelForCausalLM(model_hf, continuous_batching=False, qaic_config=deepcopy(qaic_config))
+    qeff_model.transform(
+        ctx_len=ctx_len,
+        seq_len=prefill_seq_len,
+        bs=1,
+        num_devices=1,
+        qaic_config=qaic_config,
+        dynamo=True,
+        num_cores=2,
+        prefill_seq_len=prefill_seq_len,
+    )
+
+    from QEfficient.utils import constants
+
+    monkeypatch.setattr(constants, "ONNX_EXPORT_EXAMPLE_SEQ_LEN", ctx_len)
+    try:
+        onnx_path = _exported_onnx_path(
+            qeff_model.export(
+                tmp_path / f"{model_type}-kv-headpar-dynamo-subfunctions",
+                dynamo=True,
+                use_onnx_subfunctions=True,
+                offload_pt_weights=False,
+                prefill_seq_len=prefill_seq_len,
+            )
+        )
+    except AssertionError as exc:
+        if "requires the Dynamo export environment" in str(exc):
+            pytest.skip(str(exc))
+        raise
+
+    onnx_model = onnx.load(onnx_path, load_external_data=False)
+    transform_metadata = _metadata_value(onnx_model, "qeff_transforms")
+    assert "InlineTorchSubgraphFunctionsTransform" in transform_metadata
+    assert "StaticLoopInputsTransform" in transform_metadata
+    graph_loop_nodes = [node for node in _collect_onnx_graph_nodes(onnx_model.graph) if node.op_type == "Loop"]
+    assert graph_loop_nodes, f"Expected {model_type} kv_headpar Dynamo export to contain ONNX Loop nodes"
+
+    function_loop_nodes = [
+        node for function_proto in onnx_model.functions for node in function_proto.node if node.op_type == "Loop"
+    ]
+    assert not function_loop_nodes, "Loop nodes must be inlined out of FunctionProto bodies for QAIC subfunctions"
+
+    initializers = {initializer.name: initializer for initializer in onnx_model.graph.initializer}
+    for loop_node in graph_loop_nodes:
+        assert loop_node.input[0].startswith("qeff_static_loop_trip_count_")
+        assert loop_node.input[1].startswith("qeff_static_loop_cond_true_")
+        assert onnx.numpy_helper.to_array(initializers[loop_node.input[0]]).item() == num_kv_blocks
+        assert onnx.numpy_helper.to_array(initializers[loop_node.input[1]]).item() is True
 
 
 @pytest.mark.llm_model

--- a/tests/unit_test/transforms/test_blocking_transform.py
+++ b/tests/unit_test/transforms/test_blocking_transform.py
@@ -395,3 +395,68 @@ class TestBlockingWrapperFallbackAndParity:
         assert torch.equal(original_token, transformed_token), (
             "Original and transformed model outputs diverged for same CPU input"
         )
+
+
+# ---------------------------------------------------------------------------
+# Tests: Dynamo KV Loop config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.transforms
+class TestDynamoKVLoopBlockingConfig:
+    """Dynamo export should opt kv_headpar decode into the ONNX Loop implementation."""
+
+    def test_kv_headpar_dynamo_enables_loop_op(self):
+        from QEfficient.blocking.blocking_configurator import build_transformer_blocking_config_for_transform
+
+        cfg = make_tiny_llama().config
+        blocking_config = build_transformer_blocking_config_for_transform(
+            cfg,
+            ctx_len=CTX_LEN,
+            seq_len=1,
+            bs=1,
+            num_devices=1,
+            qaic_config={"blocking_mode": "kv_headpar", "num_kv_blocks": 4},
+            aic_num_cores=2,
+            dynamo=True,
+        )
+
+        assert blocking_config.mode == BlockingMode.KV_HEADPAR
+        assert blocking_config.use_kv_loop_op is True
+        assert blocking_config.kv_loop_dynamic_trip_count is False
+
+    def test_kv_headpar_legacy_keeps_loop_op_disabled(self):
+        from QEfficient.blocking.blocking_configurator import build_transformer_blocking_config_for_transform
+
+        cfg = make_tiny_llama().config
+        blocking_config = build_transformer_blocking_config_for_transform(
+            cfg,
+            ctx_len=CTX_LEN,
+            seq_len=1,
+            bs=1,
+            num_devices=1,
+            qaic_config={"blocking_mode": "kv_headpar", "num_kv_blocks": 4},
+            aic_num_cores=2,
+            dynamo=False,
+        )
+
+        assert blocking_config.mode == BlockingMode.KV_HEADPAR
+        assert blocking_config.use_kv_loop_op is False
+
+    def test_kv_headpar_dynamo_loop_op_can_be_disabled(self):
+        from QEfficient.blocking.blocking_configurator import build_transformer_blocking_config_for_transform
+
+        cfg = make_tiny_llama().config
+        blocking_config = build_transformer_blocking_config_for_transform(
+            cfg,
+            ctx_len=CTX_LEN,
+            seq_len=1,
+            bs=1,
+            num_devices=1,
+            qaic_config={"blocking_mode": "kv_headpar", "num_kv_blocks": 4, "use_kv_loop_op": False},
+            aic_num_cores=2,
+            dynamo=True,
+        )
+
+        assert blocking_config.mode == BlockingMode.KV_HEADPAR
+        assert blocking_config.use_kv_loop_op is False


### PR DESCRIPTION
 Integrate a Dynamo-only torch.while_loop implementation for blocked_kv_attention_forward_headpar_offline so KV-blocked decode can export a structured ONNX Loop instead of unrolling the Python for-loop per KV block.

  Key changes:
  - Enable the KV Loop path by default for blocking_mode=kv_headpar when dynamo=True.
  - Preserve the legacy Python-loop path for dynamo=False and allow explicit opt-out with use_kv_loop_op=False.
  - Add StaticLoopInputsTransform to rewrite ONNX Loop trip count and initial condition to static constants required by QAIC compiler unrolling.
  - Add InlineTorchSubgraphFunctionsTransform for dynamo subfunction export, inlining torch-generated subgraph functions that contain Loop nodes so QAIC does not see Loop control inputs inside FunctionProto bodies.
  - Update Dynamo causal LM examples and README with KV-blocking CLI support.
  - Add Dynamo/unit tests covering Loop export, config defaults, static Loop
    input rewriting, and function-body Loop handling.

  Verified:
  - tests/dynamo/test_kv_blocking_loop.py: 4 passed
  - tests/unit_test/transforms/test_blocking_transform.py::TestDynamoKVLoopBlockingConfig: 3 passed
  - Qwen2-1.5B kv_headpar Dynamo compile succeeds with and without
    --enable-onnx-subfunctions.
