### PR TITLE
Updated numpy and protobuf version

### DIFF
--- a/QEfficient/diffusers/README.md
+++ b/QEfficient/diffusers/README.md
@@ -34,7 +34,7 @@ QEfficient Diffusers brings the power of state-of-the-art diffusion models to Qu
 
 ### Prerequisites
 
-Ensure you have Python 3.8+ and the required dependencies:
+Ensure you have Python 3.10+ and the required dependencies:
 
 ```bash
 # Create Python virtual environment (Recommended Python 3.10)
@@ -92,4 +92,3 @@ We welcome contributions! Please see our [Contributing Guide](../../CONTRIBUTING
 - 🐛 **Issues**: [GitHub Issues](https://github.com/quic/efficient-transformers/issues)
 
 ---
-

--- a/examples/dynamo/causal_lm/README.md
+++ b/examples/dynamo/causal_lm/README.md
@@ -20,7 +20,7 @@ pip install -e .
 pip install -r examples/dynamo/causal_lm/requirements.txt
 ```
 
-> **Note:** `requirements.txt` installs PyTorch 2.13 CPU wheels and `onnxscript`/`compressed-tensors`. These override any existing torch installation. For x86_64 and aarch64 — Python 3.9–3.12.
+> **Note:** `requirements.txt` installs PyTorch 2.13 CPU wheels and `onnxscript`/`compressed-tensors`. These override any existing torch installation. For x86_64 and aarch64 — Python 3.10–3.12.
 
 ### 3. HuggingFace authentication (gated models)
 ```bash

--- a/examples/dynamo/causal_lm/requirements.txt
+++ b/examples/dynamo/causal_lm/requirements.txt
@@ -3,14 +3,12 @@
 
 # torch — per Python version and architecture
 torch==2.13.0 ; platform_machine=='aarch64'
-torch @ https://download.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp39-cp39-manylinux_2_28_x86_64.whl ; python_version=='3.9' and platform_machine=='x86_64'
 torch @ https://download.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version=='3.10' and platform_machine=='x86_64'
 torch @ https://download.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version=='3.11' and platform_machine=='x86_64'
 torch @ https://download.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version=='3.12' and platform_machine=='x86_64'
 
 # torchvision — per Python version and architecture
 torchvision==0.28.0 ; platform_machine=='aarch64'
-torchvision @ https://download.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp39-cp39-manylinux_2_28_x86_64.whl ; python_version=='3.9' and platform_machine=='x86_64'
 torchvision @ https://download.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version=='3.10' and platform_machine=='x86_64'
 torchvision @ https://download.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version=='3.11' and platform_machine=='x86_64'
 torchvision @ https://download.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version=='3.12' and platform_machine=='x86_64'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence for Inference Accelerator",
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.10,<3.13"
 dependencies = [
     "transformers==5.5.4",
     "diffusers==0.38.0",
@@ -29,8 +29,8 @@ dependencies = [
     "sentencepiece==0.2.0",
     "onnx==1.18.0",
     "onnxruntime==1.22",
-    "numpy==1.26.4",
-    "protobuf==6.31.0",
+    "numpy>=2.2.6,<3",
+    "protobuf==6.33.6",
     "onnxscript==0.2.5",
     # for layerwise infra
     "onnx-ir==0.2.1",
@@ -48,12 +48,9 @@ dependencies = [
     "compressed-tensors==0.15.0",
     "torch==2.7.0; platform_machine=='aarch64'",
     # Specifying torch cpu package URL per python version, update the list once pytorch releases whl for python>3.11
-    "torch@https://download.pytorch.org/whl/cpu/torch-2.4.1%2Bcpu-cp38-cp38-linux_x86_64.whl ; python_version=='3.8' and platform_machine=='x86_64'",
-    "torch@https://download.pytorch.org/whl/cpu/torch-2.7.0%2Bcpu-cp39-cp39-manylinux_2_28_x86_64.whl ; python_version=='3.9' and platform_machine=='x86_64'",
     "torch@https://download.pytorch.org/whl/cpu/torch-2.7.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version=='3.10' and platform_machine=='x86_64'",
     "torch@https://download.pytorch.org/whl/cpu/torch-2.7.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version=='3.11' and platform_machine=='x86_64'",
     "torch@https://download.pytorch.org/whl/cpu/torch-2.7.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version=='3.12' and platform_machine=='x86_64'",
-    "torchvision@https://download.pytorch.org/whl/cpu/torchvision-0.22.0%2Bcpu-cp39-cp39-manylinux_2_28_x86_64.whl ; python_version=='3.9' and platform_machine=='x86_64'",
     "torchvision@https://download.pytorch.org/whl/cpu/torchvision-0.22.0%2Bcpu-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version=='3.10' and platform_machine=='x86_64'",
     "torchvision@https://download.pytorch.org/whl/cpu/torchvision-0.22.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version=='3.11' and platform_machine=='x86_64'",
     "torchvision@https://download.pytorch.org/whl/cpu/torchvision-0.22.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version=='3.12' and platform_machine=='x86_64'",

--- a/tests/unit_test/e2e/test_embedding_e2e.py
+++ b/tests/unit_test/e2e/test_embedding_e2e.py
@@ -331,8 +331,8 @@ class TestEmbeddingORTAccuracy:
 
         if ort_hidden is not None:
             ort_mean = ort_hidden.mean(axis=1)
-            pt_top = int(pt_mean.argmax(-1))
-            ort_top = int(ort_mean.argmax(-1))
+            pt_top = pt_mean.argmax(-1).item()
+            ort_top = ort_mean.argmax(-1).item()
             assert pt_top == ort_top, f"Mean-pooled embedding argmax mismatch: QEff={pt_top}, ORT={ort_top}"
 
 

--- a/tests/unit_test/e2e/test_seq_classification_e2e.py
+++ b/tests/unit_test/e2e/test_seq_classification_e2e.py
@@ -194,7 +194,7 @@ class TestSeqClassORTAccuracy:
         ort_inputs = {k: v.numpy() for k, v in inputs.items()}
         output_names = [o.name for o in session.get_outputs()]
         ort_out = dict(zip(output_names, session.run(output_names, ort_inputs)))
-        ort_class = int(ort_out["logits"].argmax(-1))
+        ort_class = ort_out["logits"].argmax(-1).item()
         assert qeff_class == ort_class, f"Class mismatch QEff vs ORT: QEff={qeff_class}, ORT={ort_class}"
 
     def test_bert_ort_predicts_same_class_as_hf(self, tmp_export_dir):
@@ -210,7 +210,7 @@ class TestSeqClassORTAccuracy:
         ort_inputs = {k: v.numpy() for k, v in inputs.items()}
         output_names = [o.name for o in session.get_outputs()]
         ort_out = dict(zip(output_names, session.run(output_names, ort_inputs)))
-        ort_class = int(ort_out["logits"].argmax(-1))
+        ort_class = ort_out["logits"].argmax(-1).item()
         assert hf_class == ort_class, f"Full pipeline class mismatch: HF={hf_class}, ORT={ort_class}"
 
     def test_bert_ort_logits_numerically_close_to_qeff(self, tmp_export_dir):
@@ -295,7 +295,7 @@ class TestSeqClassORTAccuracy:
             ort_inputs = {k: v.numpy() for k, v in inputs.items()}
             output_names = [o.name for o in session.get_outputs()]
             ort_out = dict(zip(output_names, session.run(output_names, ort_inputs)))
-            ort_class = int(ort_out["logits"].argmax(-1))
+            ort_class = ort_out["logits"].argmax(-1).item()
             assert hf_class == ort_class, f"DeBERTa pipeline mismatch: HF={hf_class}, ORT={ort_class}"
         except Exception as e:
             pytest.skip(f"DeBERTa-v2 not available or export failed: {e}")

--- a/tests/unit_test/models/test_causal_lm_accuracy.py
+++ b/tests/unit_test/models/test_causal_lm_accuracy.py
@@ -703,8 +703,8 @@ class TestCausalLMONNXStructure:
     def test_gpt2_ort_prefill_produces_correct_logits(self, tmp_export_dir):
         """ORT prefill must produce logits matching QEff PyTorch."""
         pt_logits, ort_logits, _, _, _, _ = self._check_ort_prefill_accuracy(make_tiny_gpt2, "GPT2", tmp_export_dir)
-        pt_token = int(pt_logits.argmax(-1))
-        ort_token = int(ort_logits.argmax(-1))
+        pt_token = pt_logits.argmax(-1).item()
+        ort_token = ort_logits.argmax(-1).item()
         assert pt_token == ort_token, f"Token mismatch: PyTorch={pt_token}, ORT={ort_token}"
 
     def test_llama_ort_session_creation_succeeds(self, tmp_export_dir):
@@ -786,8 +786,8 @@ class TestCausalLMONNXStructure:
     def test_llama_ort_prefill_produces_correct_logits(self, tmp_export_dir):
         """ORT Llama prefill must produce logits matching QEff PyTorch."""
         pt_logits, ort_logits, _, _, _, _ = self._check_ort_prefill_accuracy(make_tiny_llama, "Llama", tmp_export_dir)
-        pt_token = int(pt_logits.argmax(-1))
-        ort_token = int(ort_logits.argmax(-1))
+        pt_token = pt_logits.argmax(-1).item()
+        ort_token = ort_logits.argmax(-1).item()
         assert pt_token == ort_token, f"[Llama] Token mismatch: PyTorch={pt_token}, ORT={ort_token}"
 
     def test_mistral_ort_prefill_produces_correct_logits(self, tmp_export_dir):
@@ -795,22 +795,22 @@ class TestCausalLMONNXStructure:
         pt_logits, ort_logits, _, _, _, _ = self._check_ort_prefill_accuracy(
             make_tiny_mistral, "Mistral", tmp_export_dir
         )
-        pt_token = int(pt_logits.argmax(-1))
-        ort_token = int(ort_logits.argmax(-1))
+        pt_token = pt_logits.argmax(-1).item()
+        ort_token = ort_logits.argmax(-1).item()
         assert pt_token == ort_token, f"[Mistral] Token mismatch: PyTorch={pt_token}, ORT={ort_token}"
 
     def test_qwen2_ort_prefill_produces_correct_logits(self, tmp_export_dir):
         """ORT Qwen2 prefill must produce logits matching QEff PyTorch."""
         pt_logits, ort_logits, _, _, _, _ = self._check_ort_prefill_accuracy(make_tiny_qwen2, "Qwen2", tmp_export_dir)
-        pt_token = int(pt_logits.argmax(-1))
-        ort_token = int(ort_logits.argmax(-1))
+        pt_token = pt_logits.argmax(-1).item()
+        ort_token = ort_logits.argmax(-1).item()
         assert pt_token == ort_token, f"[Qwen2] Token mismatch: PyTorch={pt_token}, ORT={ort_token}"
 
     def test_phi3_ort_prefill_produces_correct_logits(self, tmp_export_dir):
         """ORT Phi3 prefill must produce logits matching QEff PyTorch."""
         pt_logits, ort_logits, _, _, _, _ = self._check_ort_prefill_accuracy(make_tiny_phi3, "Phi3", tmp_export_dir)
-        pt_token = int(pt_logits.argmax(-1))
-        ort_token = int(ort_logits.argmax(-1))
+        pt_token = pt_logits.argmax(-1).item()
+        ort_token = ort_logits.argmax(-1).item()
         assert pt_token == ort_token, f"[Phi3] Token mismatch: PyTorch={pt_token}, ORT={ort_token}"
 
     def test_gpt2_ort_logits_are_finite(self, tmp_export_dir):


### PR DESCRIPTION
Updated numpy version from numpy==1.26.4 -> numpy>=2.2.6,<3, and protobuf==6.31.0 --> protobuf==6.33.6
Also deprecated python 3.8 support as NumPy 2.2.6 requires Python ≥3.10