### PR TITLE
Fix profiling type lookup and wire device profiling through generate()

### DIFF
--- a/QEfficient/generation/cloud_infer.py
+++ b/QEfficient/generation/cloud_infer.py
@@ -7,6 +7,7 @@
 
 import platform
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 from warnings import warn
@@ -73,6 +74,9 @@ class QAICInferenceSession:
         stages: Optional[int] = 1,
         cluster_id: Optional[str] = None,
         full_batch_size: int = 1,
+        profiling_type: str | None = None,
+        profiling_output_dir: Path | str | None = None,
+        profiling_file_prefix: str = "aic-profiling-python",
     ):
         """
         Initialise for QAIC inference Session
@@ -93,6 +97,12 @@ class QAICInferenceSession:
             selects which exec-object pool this session allocates. Unused otherwise.
         :full_batch_size: int. Number of decode slots; `batch_index` offsets wrap
             modulo this value at prefill handoff. Only used when `kv_dma_share=True`.
+        :profiling_type: Optional[str]. One of "latency", "trace", "raw_device_stats". Selects the
+            runtime device profiling type (via the `qaicrt.ProfilingHandle` API on this session's `Program`).
+            If None (default), profiling support is disabled.
+        :profiling_output_dir: Optional[Union[Path, str]]. Directory to write the profiling report to. Defaults to
+            a "profiling_output" directory alongside `qpc_path`. Only used when `profiling_type` is set.
+        :profiling_file_prefix: str. Filename prefix for the profiling report. Default="aic-profiling-python".
         """
         if not (is_qaicrt_imported and is_aicapi_imported):
             raise ImportError(
@@ -122,6 +132,16 @@ class QAICInferenceSession:
         self.cluster_id = cluster_id
         self.full_batch_size = full_batch_size
         self._kv_dma: Optional[KvDmaHandoff] = KvDmaHandoff(self) if kv_dma_share else None
+        self.profiling_type_map = {
+            "latency": qaicrt.QAicProfilingTypeEnum.QAIC_PROFILING_INFERENCE_LATENCY_TYPE,
+            "trace": qaicrt.QAicProfilingTypeEnum.QAIC_PROFILING_INFERENCE_TRACE_TYPE,
+            "raw_device_stats": qaicrt.QAicProfilingTypeEnum.QAIC_PROFILING_INFERENCE_RAW_DEVICE_STATS_TYPE,
+            "stats": qaicrt.QAicProfilingTypeEnum.QAIC_PROFILING_INFERENCE_DEV_KPI_TYPE,
+        }
+        if profiling_type is not None and profiling_type not in self.profiling_type_map:
+            raise ValueError(
+                f"Unsupported profiling_type {profiling_type!r}; expected one of {list(self.profiling_type_map)}"
+            )
 
         # Load QPC
         if device_ids is not None:
@@ -160,6 +180,20 @@ class QAICInferenceSession:
         self.program = qaicrt.Program(self.context, dev_id_non_mq, qpc, prog_properties)
         if self.program.load() != qaicrt.QStatus.QS_SUCCESS:
             raise RuntimeError("Failed to load program")
+        self.profiling_handle = None
+        if profiling_type is not None:
+            output_dir = (
+                Path(profiling_output_dir)
+                if profiling_output_dir
+                else (Path(qpc_path) if Path(qpc_path).is_dir() else Path(qpc_path).parent) / "profiling_output"
+            )
+            output_dir.mkdir(parents=True, exist_ok=True)
+            self.profiling_handle = qaicrt.ProfilingHandle(
+                programs=[self.program],
+                type=self.profiling_type_map[profiling_type],
+                fileNamePrefix=profiling_file_prefix,
+                outputDirectory=str(output_dir),
+            )
         self.is_active = False
         if activate:
             self.activate()
@@ -230,6 +264,33 @@ class QAICInferenceSession:
             del self.execObj
             self.program.deactivate()
             self.is_active = False
+
+    def start_profiling(self):
+        """Start capturing a profiling report for this session's program(s)."""
+        if self.profiling_handle is None:
+            raise RuntimeError("Profiling is not enabled for this session; pass `profiling_type` to the constructor.")
+
+        status = self.profiling_handle.start()
+        if status != qaicrt.QStatus.QS_SUCCESS:
+            raise RuntimeError(f"Failed to start profiling. Status {status}")
+
+    def stop_profiling(self):
+        """Stop profiling and flush the report to `profiling_output_dir`."""
+        if self.profiling_handle is None:
+            raise RuntimeError("Profiling is not enabled for this session; pass `profiling_type` to the constructor.")
+        status = self.profiling_handle.stop()
+
+        if status != qaicrt.QStatus.QS_SUCCESS:
+            raise RuntimeError(f"Failed to stop profiling. Status {status}")
+
+    @contextmanager
+    def profile(self):
+        """Context manager that brackets a block of `run()` calls with start/stop profiling."""
+        self.start_profiling()
+        try:
+            yield
+        finally:
+            self.stop_profiling()
 
     def set_buffers(self, buffers: Dict[str, np.ndarray]):
         """

--- a/QEfficient/generation/text_generation_inference.py
+++ b/QEfficient/generation/text_generation_inference.py
@@ -8,7 +8,9 @@
 import json
 import os
 from collections import deque
+from contextlib import nullcontext
 from dataclasses import dataclass
+from pathlib import Path
 from time import perf_counter
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -334,6 +336,8 @@ def cloud_ai_100_exec_kv(
     return_pdfs: bool = False,
     include_guided_decoding: bool = False,
     sampling_params: Optional[Dict[str, Any]] = None,
+    profiling_type: str | None = None,
+    profiling_output_dir: Path | str | None = None,
 ):
     """
     This method generates output until ``eos`` or ``generation_len`` by executing the compiled ``qpc`` on ``Cloud AI 100`` Hardware cards.
@@ -366,6 +370,9 @@ def cloud_ai_100_exec_kv(
         The dictionary should contain the following keys:
         `repetition_penalties`, `presence_penalties`, `temperatures`, `top_ks`, `top_ps`,
         `min_ps`, and `random_numbers`. Each value should be a numpy array of shape (batch_size, 1).
+        :profiling_type (str, default=None): One of "latency", "trace", "raw_device_stats". Enables
+        runtime device profiling capture (via `QAICInferenceSession`'s profiling API) for this call.
+        :profiling_output_dir (Union[Path, str], default=None): Directory to write the profiling report to.
 
     Returns:
         :CloudAI100ExecInfo: Object holding execution output and performance details.
@@ -402,6 +409,8 @@ def cloud_ai_100_exec_kv(
         return_pdfs=return_pdfs,
         include_guided_decoding=include_guided_decoding,
         sampling_params=sampling_params,
+        profiling_type=profiling_type,
+        profiling_output_dir=profiling_output_dir,
     )
 
     for _ in range(0, int(iteration)):
@@ -452,6 +461,8 @@ class QEffTextGenerationBase:
         include_guided_decoding: bool = False,
         sampling_params: Optional[Dict[str, Any]] = None,
         activate: bool = True,
+        profiling_type: str | None = None,
+        profiling_output_dir: Path | str | None = None,
     ) -> None:
         self._ctx_len = ctx_len
         self.comp_ctx_lengths_prefill = comp_ctx_lengths_prefill
@@ -465,7 +476,12 @@ class QEffTextGenerationBase:
 
         # Load QPC
         self._session = QAICInferenceSession(
-            qpc_path, device_id, activate=activate, enable_debug_logs=enable_debug_logs
+            qpc_path,
+            device_id,
+            activate=activate,
+            enable_debug_logs=enable_debug_logs,
+            profiling_type=profiling_type,
+            profiling_output_dir=profiling_output_dir,
         )
 
         # Validate sampler inputs for On-Device Sampling
@@ -502,6 +518,12 @@ class QEffTextGenerationBase:
         self._session.skip_buffers(
             [x for x in self._session.input_names + self._session.output_names if is_retained_state_name(x)]
         )
+
+    def profiling_context(self):
+        """Context manager bracketing a block of `run()` calls with start/stop profiling, or a no-op if profiling is disabled."""
+        if self._session.profiling_handle is not None:
+            return self._session.profile()
+        return nullcontext()
 
     def _set_tokenizer_params(self):
         """
@@ -1086,6 +1108,8 @@ class TextGeneration:
         return_pdfs: bool = False,
         include_guided_decoding: bool = False,
         sampling_params: Optional[Dict[str, Any]] = None,
+        profiling_type: str | None = None,
+        profiling_output_dir: Path | str | None = None,
     ) -> None:
         self._qaic_model = QEffTextGenerationBase(
             tokenizer=tokenizer,
@@ -1102,6 +1126,8 @@ class TextGeneration:
             return_pdfs=return_pdfs,
             include_guided_decoding=include_guided_decoding,
             sampling_params=sampling_params,
+            profiling_type=profiling_type,
+            profiling_output_dir=profiling_output_dir,
         )
         self._full_batch_size = self._qaic_model.full_batch_size
         self._tokenizer = self._qaic_model.tokenizer
@@ -1297,15 +1323,17 @@ class TextGeneration:
 
         if self._full_batch_size is not None:
             logger.warning("Streamer is currently unavailable for continuous batch execution.")
-            perf_metrics, generated_texts = self._continuous_batching_execution(
-                prompt, generation_len, prompt_to_lora_id_mapping
-            )
+            with self._qaic_model.profiling_context():
+                perf_metrics, generated_texts = self._continuous_batching_execution(
+                    prompt, generation_len, prompt_to_lora_id_mapping
+                )
         else:
             if stream:
                 print("\nPrompt : " + prompt[0] + "\nCompletion :", flush=True, end="")
-            perf_metrics, generated_texts = self._regular_model_execution(
-                prompt, generation_len, stream, automation, prompt_to_lora_id_mapping
-            )
+            with self._qaic_model.profiling_context():
+                perf_metrics, generated_texts = self._regular_model_execution(
+                    prompt, generation_len, stream, automation, prompt_to_lora_id_mapping
+                )
 
         if stream:
             stream_start = 0 if self._full_batch_size else 1

--- a/examples/text_generation/basic_inference.py
+++ b/examples/text_generation/basic_inference.py
@@ -6,6 +6,7 @@
 # -----------------------------------------------------------------------------
 
 import argparse
+from pathlib import Path
 
 from transformers import AutoConfig, AutoTokenizer
 
@@ -33,6 +34,22 @@ def main():
         default=None,
         help="Device IDs (comma-separated) e.g. [0,1]",
     )
+    parser.add_argument(
+        "--profiling-type",
+        dest="profiling_type",
+        type=str,
+        default=None,
+        choices=["latency", "trace", "raw_device_stats", "stats"],
+        help="Enable QAIC device profiling via the runtime Program/ExecObj profiling API and capture a "
+        "report for the generate() call. Default: disabled",
+    )
+    parser.add_argument(
+        "--profiling-output-dir",
+        dest="profiling_output_dir",
+        type=str,
+        default=None,
+        help="Directory to write the profiling report to. Default: <qpc dir>/profiling_output",
+    )
     args = parser.parse_args()
 
     # Load tokenizer and model
@@ -47,6 +64,7 @@ def main():
         prefill_seq_len=args.prefill_seq_len,
         ctx_len=args.ctx_len,
         num_cores=args.num_cores,
+        stats_level=100,
         aic_hw_version=args.aic_hw_version,
         num_devices=(1 if args.device_group is None else len(args.device_group)),
         dynamo=args.dynamo,
@@ -55,15 +73,31 @@ def main():
     print(f"Model compiled to: {qpc_path}")
 
     # Generate text
-    exec_info = model.generate(
-        tokenizer=tokenizer,
-        prompts=[args.prompt],
-        device_id=args.device_group,
-        generation_len=args.generation_len,
-    )
+    generate_kwargs = {
+        "tokenizer": tokenizer,
+        "prompts": [args.prompt],
+        "device_id": args.device_group,
+        "generation_len": args.generation_len,
+    }
+    if args.profiling_type is not None:
+        generate_kwargs["profiling_type"] = args.profiling_type
+        if args.profiling_output_dir is not None:
+            generate_kwargs["profiling_output_dir"] = args.profiling_output_dir
+    exec_info = model.generate(**generate_kwargs)
 
     print(f"\nPrompt: {args.prompt}")
     print(f"Generated: {exec_info.generated_texts[0]}")
+
+    if args.profiling_type is not None:
+        output_dir = (
+            Path(args.profiling_output_dir)
+            if args.profiling_output_dir
+            else (Path(qpc_path) if Path(qpc_path).is_dir() else Path(qpc_path).parent) / "profiling_output"
+        )
+        report_files = sorted(p.name for p in output_dir.glob("*") if p.is_file())
+        print(f"\nProfiling type: {args.profiling_type}")
+        print(f"Profiling report directory: {output_dir}")
+        print(f"Profiling report files: {report_files if report_files else '(none found)'}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Threads the runtime `ProfilingHandle` device-profiling support in `QAICInferenceSession` through `cloud_ai_100_exec_kv/TextGeneration/QEffTextGenerationBase`, 

exposing `profiling_type/profiling_output_dir` end-to-end via `model.generate()` and as `--profiling-type`/`--profiling-output-dir` flags in `examples/text_generation/basic_inference.py`. 

profiling_type takes "stats", "latency", "trace", and "raw_device_stats".