### PR TITLE
[Fix] removing continues_batching  check for qpc key selection in modeling_auto

### DIFF
--- a/QEfficient/transformers/models/modeling_auto.py
+++ b/QEfficient/transformers/models/modeling_auto.py
@@ -2223,9 +2223,7 @@ class _QEffAutoModelForImageTextToTextDualQPC:
                 else:
                     specializations = lang_specs[:1]
                 qpc_key = "lang_prefill_qpc_path"
-            elif prefill_seq_len == 1 and not (
-                self.continuous_batching and full_batch_size is not None and full_batch_size != batch_size
-            ):
+            elif prefill_seq_len == 1:
                 if self.comp_ctx_lengths_decode is not None:
                     specializations = lang_specs[-len(self.comp_ctx_lengths_decode) :]
                 else:


### PR DESCRIPTION
Issue: Decode Compilation Fails with Missing ONNX External Data File Error, current behavior picks qpc_key = "lang_qpc_path" in place of "lang_decode_qpc_path" under continuous batching, which breaks vllm_qaic